### PR TITLE
docs: refactor to use new syntax

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -12,6 +12,9 @@ trim_trailing_whitespace = true
 [*.zig]
 indent_size = 4
 
+[*.mox]
+indent_size = 4
+
 [*.md]
 max_line_length = off
 trim_trailing_whitespace = false

--- a/docs/design/stdlib.md
+++ b/docs/design/stdlib.md
@@ -12,41 +12,43 @@ Core functions and types that are automatically imported.
 
 Optional values:
 ```mox
-type Maybe a = 
+type Maybe(a) = 
     | None 
-    | Some a
+    | Some(a)
 ```
 
 #### Result
 
 Error handling:
 ```mox
-type Result e a = 
-    | Err e 
-    | Ok a
+type Result(e, a) = 
+    | Err(e)
+    | Ok(a)
 ```
 
 #### Validation
 
 Error accumulation:
 ```mox
-type Validation e a
+type Validation(e, a)
 ```
 
 #### List
 
 Immutable linked lists:
 ```mox
-type List a = 
-    | [] 
-    | (::) a (List a)
+type List(a) =
+    | Nil
+    | a :: List(a)
 ```
 
 #### NonEmpty
 
 Non-empty collections:
 ```mox
-type NonEmpty a = a :: List a
+type NonEmpty(a) =
+    | [a]
+    | a :: List(a)
 ```
 
 #### Set
@@ -62,14 +64,14 @@ type Set ...
 
 Synchronous effects handling:
 ```mox
-type Eff e a
+type Eff(e, a)
 ```
 
 #### Aff
 
 Asynchronous effects handling:
 ```mox
-type Aff e a
+type Aff(e, a)
 ```
 
 ### Value Types
@@ -149,22 +151,22 @@ Low-level bitwise operations:
 2. **Effect Handling**
    ```mox
    # Synchronous effects
-   let io : Eff IO a
+   let io() : Eff(IO, a)
 
    # Asynchronous effects
-   let async : Aff Error a
+   let async() : Aff(Error, a)
    ```
 
 3. **Error Handling**
    ```mox
    # Optional values
-   let find : a -> List a -> Maybe a
+   let find(list : List(a), x : a) -> Maybe(a)
 
    # Operations that can fail
-   let parse : String -> Result Error Int
+   let parse(str : String) -> Result(Error, Int)
 
    # Accumulating errors
-   let validate : a -> Validation Error b
+   let validate(value : a) -> Validation(Error, b)
    ```
 
 ### Best Practices

--- a/docs/design/type_system.md
+++ b/docs/design/type_system.md
@@ -26,7 +26,7 @@ Unit    -- Single value type ()
 type Person = 
     { name : String
     , age : Int
-    , email : Maybe String
+    , email : Maybe(String)
     }
 ```
 
@@ -35,11 +35,11 @@ type Person =
 ```
 type Maybe a =
     | None
-    | Some a
+    | Some(a)
 
-type Result e a =
-    | Err e
-    | Ok a
+type Result(e, a) =
+    | Err(e)
+    | Ok(a)
 ```
 
 ### Type Aliases
@@ -60,13 +60,13 @@ Effects are tracked in the type system:
 
 ```
 # Pure function type
-let map : (a -> b) -> List a -> List b
+let map(list : List(a), f : (a -> b)) -> List(b)
 
 # Function with sync effect
-let read_file : String -> Eff (Result Error String)
+let read_file(filename : String) -> Eff(Result(Error, String))
 
 # Function with async effect
-let read_file : String -> Aff (Result Error String)
+let read_file(filename : String) -> Aff(Result(Error, String))
 ```
 
 ## Type Inference
@@ -79,11 +79,14 @@ The type system implements bidirectional type inference:
 Example:
 ```
 # Inferred: a -> a
-let identity = \x => x
+let identity(x : a) -> a =
+    x
 
-# Inferred: Int -> Int -> Int 
-let add = \x y => x + y
+# Inferred: (Int, Int) -> Int 
+let add(x : Int, y : Int) -> Int =
+    x + y
 
 # Annotated
-let repeat : Int -> a -> List a = \n x => ...
+let repeat(n : Int, x : a) -> List(a) =
+    ...
 ```

--- a/docs/spec/features/effects.md
+++ b/docs/spec/features/effects.md
@@ -11,7 +11,7 @@ Mox differentiates between pure and effectful computations at the type level. Th
 ### Type Definition
 
 ```mox
-type Eff e a
+type Eff(e, a)
 ```
 
 Where:
@@ -22,12 +22,18 @@ Where:
 
 ```mox
 # IO operations
-let read_line : Eff IO String
-let print : String -> Eff IO Unit
+let read_line() -> Eff(IO, String) =
+    ...
+
+let print(str : String) -> Eff(IO, Unit) =
+    ...
 
 # State operations
-let get_state : Eff (State s) s
-let set_state : s -> Eff (State s) Unit
+let get_state() -> Eff(State(s), s) =
+    ...
+
+let set_state(state : s) -> Eff(State(s), Unit) =
+    ...
 ```
 
 ## Asynchronous Effects (Aff)
@@ -35,7 +41,7 @@ let set_state : s -> Eff (State s) Unit
 ### Type Definition
 
 ```mox
-type Aff e a
+type Aff(e, a)
 ```
 
 Where:
@@ -45,11 +51,12 @@ Where:
 ### Common Async Operations
 
 ```mox
-# HTTP requests
-let fetch : String -> Aff HttpError Response
+let fetch(url : String) -> Aff(HttpError, Response) =
+    ...
 
 # Database operations
-let query : String -> Aff DbError Result
+let query(sql : String) -> Aff(DbError, Result) =
+    ...
 ```
 
 ## Effect Composition
@@ -58,11 +65,12 @@ Effects can be composed using do-notation or operators:
 
 ```mox
 # Sequential composition
-let program = 
-    Eff.and_then (\name => print ("Hello " <> name <> "!")) read_line
-    
+let program() = 
+    Eff.and_then(read_line, fn(name) => print("Hello " <> name <> "!"))
+
 # Parallel composition (for Aff)
-let parallel = Aff.all [task1, task2, task3]
+let parallel() = 
+    Aff.all([task1, task2, task3])
 ```
 
 ## Pure vs Effectful Code
@@ -71,11 +79,12 @@ The type system enforces separation between pure and effectful code:
 
 ```mox
 # Pure function
-let double : Int -> Int = x => x * 2
+let double(x : Int) -> Int =
+    x * 2
 
 # Effectful function
-let read_and_double : Eff IO Int =
-    Eff.map (\x => double (Int.parse x)) read_line 
+let read_and_double() : Eff(IO, Int) =
+    Eff.map(read_line, fn(x) => double(Int.parse(x)))
 ```
 
 ## Effect Handlers
@@ -87,7 +96,7 @@ let read_and_double : Eff IO Int =
 When using FFI with Zig:
 ```mox
 # FFI function that has effects
-foreign print_line : String -> Eff IO Unit = "zig_print_line"
+foreign print_line(str : String) -> Eff(IO, Unit) = "zig_print_line"
 ```
 
 ## Error Handling in Effects
@@ -96,10 +105,12 @@ Effects integrate with Mox's error handling types:
 
 ```mox
 # Synchronous effect that might fail
-let parse : String -> Eff IO (Result ParseError Int)
+let parse(input : String) -> Eff(IO, Result(ParseError, Int)) =
+    ...
 
 # Asynchronous effect with built-in error type
-let fetch : Url -> Aff HttpError Response
+let fetch(url : Url) -> Aff(HttpError, Response) =
+    ...
 ```
 
 ## Best Practices

--- a/docs/spec/features/error_handling.md
+++ b/docs/spec/features/error_handling.md
@@ -12,18 +12,21 @@ Mox takes a systematic approach to error handling through the type system. There
 Used when a value might or might not be present.
 
 ```mox
-type Maybe a = 
+type Maybe(a) = 
     | None 
-    | Some a
+    | Some(a)
 
 # Examples
-let find_user : String -> Maybe User
-let parse_age : String -> Maybe Int
+let find_user(username : String) -> Maybe(User) =
+    ...
+
+let parse_age(input : String) -> Maybe(Int) =
+    ...
 
 # Pattern matching with Maybe
 match user on
 | None => show_login_prompt
-| Some u => greet_user u
+| Some(u) => greet_user(u)
 ```
 
 ## Result Type
@@ -31,18 +34,24 @@ match user on
 Used when an operation can fail with a specific error.
 
 ```mox
-type Result e a = 
-    | Err e 
-    | Ok a
+type Result(e, a) =
+    | Err(e)
+    | Ok(a)
 
 # Examples
-let divide : Int -> Int -> Result String Int
-let read_file : String -> Result IOError String
+let divide(dividend : Int, divisor : Int) -> Result(String, Int) =
+    if divisor == 0 then
+        Err("Division by zero")
+    else
+        Ok(dividend / divisor)
+
+let read_file(path : String) -> Result(IOError, String) =
+    ...
 
 # Pattern matching with Result
 match result on
-| Err msg => handle_error msg
-| Ok value => process_value value
+| Err(msg) => handle_error(msg)
+| Ok(value) => process_value(value)
 ```
 
 ## Validation Type
@@ -51,12 +60,13 @@ Used when you need to accumulate multiple errors rather than fail fast.
 
 ```mox
 # Example: Form validation
-type ValidationError = 
-    | InvalidEmail String
-    | InvalidAge Int
+type ValidationError =
+    | InvalidEmail(String)
+    | InvalidAge(Int)
     | PasswordTooShort
 
-let validate_form : Form -> Validation ValidationError ValidForm
+let validate_form(form : Form) -> Validation(ValidationError, ValidForm) =
+    ...
 ```
 
 ## Partial Functions
@@ -65,10 +75,12 @@ The language provides explicit ways to handle incomplete functions:
 
 ```mox
 # Explicitly mark incomplete code
-let todo = Partials.todo "Not implemented yet"
+let todo(message : String) -> a =
+    Partials.todo(message)
 
 # Mark impossible cases
-let impossible = Partials.panic "This should never happen"
+let impossible(message : String) -> a =
+    Partials.panic(message)
 ```
 
 ## Error Handling Guidelines
@@ -92,14 +104,14 @@ let impossible = Partials.panic "This should never happen"
 ```mox
 # Combining Maybe values
 match (first_name, last_name) on
-| (Some first, Some last) => full_name first last
+| (Some(first), Some(last)) => full_name(first, last)
 | _ => default_name
 
 # Combining Results
 match (validate_email, validate_age) on
-| (Err e, _) => handle_error e
-| (_, Err e) => handle_error e
-| (Ok email, Ok age) => create_user email age
+| (Err(e), _) => handle_error(e)
+| (_, Err(e)) => handle_error(e)
+| (Ok(email), Ok(age)) => create_user(email, age)
 ```
 
 ## Error Propagation
@@ -108,8 +120,8 @@ match (validate_email, validate_age) on
 # Using pipe operators with error handling
 input
 |> validate_email
-|> Result.map validate_password
-|> Result.map create_user
+|> Result.map(fn(x) => validate_password(x))
+|> Result.map(fn(x) => create_user(x))
 ```
 
 ## FFI Error Handling

--- a/docs/spec/features/modules.md
+++ b/docs/spec/features/modules.md
@@ -52,7 +52,7 @@ open MyModule using (function1, function2)
 #### Rename Imports
 
 ```mox
-open MyModule renaming (oldName to newName)
+open MyModule using (oldName as newName)
 ```
 
 #### Hide Specific Imports

--- a/docs/spec/features/pattern_matching.md
+++ b/docs/spec/features/pattern_matching.md
@@ -26,18 +26,18 @@ match c on
 ```
 match maybe on
 | None => "empty"
-| Some value => "got " <> value
+| Some(value) => "got " <> value
 
 match result on
-| Err msg => "error: " <> msg
-| Ok value => "success: " <> value
+| Err(msg) => "error: " <> msg
+| Ok(value) => "success: " <> value
 ```
 
 ### Record Patterns
 
 ```
 match person on
-| { name, age } => "Alice is " <> Maybe.with_default 0 (String.from_int age)
+| { name, age } => "Alice is " <> Maybe.with_default(String.from_int(age), 0)
 | _ -> "someone else"
 ```
 
@@ -45,9 +45,9 @@ match person on
 
 ```
 match list on
-| [] => "empty"
-| [x] => "singleton: " <> Maybe.with_default 0 (String.from_int x)
-| x :: xs => "cons: " <> Maybe.with_default 0 (String.from_int x)
+| Nil => "empty"
+| [x] => "singleton: " <> Maybe.with_default(String.from_int(x), 0)
+| x :: xs => "cons: " <> Maybe.with_default(String.from_int(x), 0)
 ```
 
 ### Guard Patterns

--- a/docs/spec/semantics.md
+++ b/docs/spec/semantics.md
@@ -7,14 +7,14 @@
 - Pipeline oriented (data transformation focus)
 - Eagerly evaluated (strict evaluation)
 - Immutable data structures
-- All functions are curried
+- All functions are non-curried
 - No null values
 - Tail call optimization
 - Static typing with nominal types
 
 ### Pipeline-Oriented Programming
 
-Pipeline-oriented programming emphasizes data transformation through a series of discrete steps. Functions are designed to be composable and "data-last" to support natural pipeline construction using the pipe operators (`|>` and `<|`).
+Pipeline-oriented programming emphasizes data transformation through a series of discrete steps. Functions are designed to be composable and "data-first" to support natural pipeline construction using the pipe operator (`|>`).
 
 Example:
 ```mox
@@ -34,11 +34,9 @@ some_data
 
 ### Function Evaluation
 
-- Functions are curried by default
+- Functions are non-curried 
 - Arguments are evaluated left-to-right
 - Last expression in a block is the implicit return value
-- Partial application is supported
-- Function composition preserves type safety
 
 ### Pattern Matching
 
@@ -114,23 +112,24 @@ match value on
 
 ```mox
 # These are equivalent:
-add 1 2
-(add 1) 2      # Due to currying
-1 |> add 2     # Right pipe
-add 2 <| 1     # Left pipe
+add(1, 2)
+1 |> add(2)     # Right pipe
 ```
 
 ### Effect Handling
 
 ```mox
 # Pure function
-let pure : Int -> Int
+let pure(n : Int) -> Int =
+    ...
 
 # Function with effects
-let effectful : Int -> Eff () Int
+let effectful(n : Int) -> Eff((), Int) =
+    ...
 
 # Async function with possible errors
-let async : String -> Aff HttpErr Response
+let async(url : String) -> Aff(HttpErr, Response) =
+    ...
 ```
 
 ## Control Flow

--- a/docs/spec/syntax.md
+++ b/docs/spec/syntax.md
@@ -13,19 +13,15 @@ else,
 end,
 exposing,
 foreign,
+fn,
 hiding,
 if,
-in,
 include,
-infixl,
-infixn,
-infixr,
 let,
 match,
 module,
 on,
 open,
-renaming,
 then,
 to,
 type,
@@ -113,9 +109,8 @@ calculate123
 
 #### Function
 
-- Composition: `>>`, `<<`
-- Pipe: `|>`, `<|`
-- Lambda: `\`
+- Pipe: `|>`
+- Lambda: `fn`
 
 #### Other
 
@@ -172,10 +167,9 @@ Operators are listed in descending order of precedence:
 9. Comparison operators (`==`, `/=`, `<`, `<=`, `>`, `>=`)
 10. Logical AND (`&&`)
 11. Logical OR (`||`)
-12. Function composition (`>>`, `<<`)
-13. Pipe operators (`|>`, `<|`)
-14. Pattern match/lambda arrow (`=>`) 
-15. Assignment (`=`) (lowest)
+12. Pipe operators (`|>`)
+13. Pattern match/lambda arrow (`=>`) 
+14. Assignment (`=`) (lowest)
 
 ## Conditional Statements
 

--- a/stdlib/aff.mox
+++ b/stdlib/aff.mox
@@ -1,112 +1,118 @@
 module Aff exposing
-  ( Aff
-  , and_then
-  , fail
-  , from_result
-  , map
-  , map2
-  , map3
-  , map4
-  , run
-  , succeed
-  )
+    ( Aff
+    , and_then
+    , fail
+    , from_result
+    , map
+    , map2
+    , map3
+    , map4
+    , run
+    , succeed
+    )
 
-  ## Model asynchroneous effects.
-  ##
-  ## @since 0.1.0
-  ##
-  ## ```
-  ## ➢
-  ## :
-  ## ```
-  type alias Aff e a =
-    AsyncEffect e a
+    ## Model asynchroneous effects.
+    ##
+    ## @since 0.1.0
+    ##
+    ## ```
+    ## ➢
+    ## :
+    ## ```
+    type alias Aff(e, a) =
+        AsyncEffect(e, a)
 
-  ## Lifts an error into a failed `Aff`.
-  ##
-  ## @since 0.1.0
-  ##
-  ## ```
-  ## ➢ Aff.fail "foobar!" : Aff String String
-  ## : Aff String String
-  ## ```
-  let fail : e -> Aff e Unit =
-    \err =>
-      Scheduler.Async.fail err
+    ## Lifts an error into a failed `Aff`.
+    ##
+    ## @since 0.1.0
+    ##
+    ## ```
+    ## ➢ Aff.fail("foobar!") : Aff(String, String)
+    ## : Aff(String, String)
+    ## ```
+    let fail(err : e) -> Aff(e, Unit) =
+        Scheduler.Async.fail(err)
 
-  ## Lifts a value into a successful `Aff`.
-  ##
-  ## @since 0.1.0
-  ##
-  ## ```
-  ## ➢ Aff.success "foobar" : Aff String String
-  ## : Aff String String
-  ## ```
-  let succeed : a -> Aff Unit a =
-    \value =>
-      Scheduler.Async.succeed value
+    ## Lifts a value into a successful `Aff`.
+    ##
+    ## @since 0.1.0
+    ##
+    ## ```
+    ## ➢ Aff.success("foobar") : Aff(String, String)
+    ## : Aff(String, String)
+    ## ```
+    let succeed(value : a) -> Aff(Unit, a) =
+        Scheduler.Async.succeed(value)
 
-  let map : (a -> b) -> Aff e a -> Aff e b =
-    \f aff =>
-      match run aff_a on
-      | Err ea => fail ea
-      | Ok a => succeed (f a)
+    let map(aff_a : Aff(e, a), f : (a -> b)) =
+        match run(aff_a) on
+        | Err(ea) => fail(ea)
+        | Ok(a) => succeed(f(a))
 
-  let map2 : (a -> b -> value) -> Aff e a -> Aff e b -> Aff e value =
-    \f aff_a aff_b =>
-      match run aff_a on
-      | Err ea => fail ea
-      | Ok a =>
-          match run aff_b on
-          | Err eb => fail eb
-          | Ok b => succeed (f a b)
+    let map2(
+        aff_a: Aff(e, a),
+        aff_b: Aff(e, b),
+        f: ((a, b) -> c)
+    ) -> Aff(e, c) =
+        match run(aff_a) on
+        | Err(ea) => fail(ea)
+        | Ok(a) =>
+            match run(aff_b) on
+            | Err(eb) => fail(eb)
+            | Ok(b) => succeed(f(a, b))
 
-  let map3 : (a -> b -> c -> value) -> Aff e a -> Aff e b -> Aff e c -> Aff e value
-    \f aff_a aff_b aff_c =>
-      match run aff_a on
-      | Err ea => fail ea
-      | Ok a =>
-          match run aff_b on
-          | Err eb => fail eb
-          | Ok b =>
-              match run aff_c on
-              | Err ec => fail ec
-              | Ok c => succeed (f a b c)
+    let map3(
+        aff_a: Aff(e, a),
+        aff_b: Aff(e, b),
+        aff_c: Aff(e, c),
+        f: ((a, b, c) -> d)
+    ) -> Aff(e, d) =
+        match run(aff_a) on
+        | Err(ea) => fail(ea)
+        | Ok(a) =>
+            match run(aff_b) on
+            | Err(eb) => fail(eb)
+            | Ok(b) =>
+                match run(aff_c) on
+                | Err(ec) => fail(ec)
+                | Ok(c) => succeed(f(a, b, c))
 
-  let map4 : (a -> b -> c -> d -> value) -> Aff e a -> Aff e b -> Aff e c -> Aff e d -> Aff e value
-    \f aff_a aff_b aff_c aff_d =>
-      match run aff_a on
-      | Err ea => fail ea
-      | Ok a =>
-          match run aff_b on
-          | Err eb => fail eb
-          | Ok b =>
-              match run aff_c on
-              | Err ec => fail ec
-              | Ok c =>
-                  match run aff_d on
-                  | Err ed => fail ed
-                  | Ok d => succeed (f a b c d)
+    let map4(
+        aff_a: Aff(e, a),
+        aff_b: Aff(e, b),
+        aff_c: Aff(e, c),
+        aff_d: Aff(e, d),
+        f: ((a, b, c, d) -> e)
+    ) -> Aff(e, e) =
+        match run(aff_a) on
+        | Err(ea) => fail(ea)
+        | Ok(a) =>
+            match run(aff_b) on
+            | Err(eb) => fail(eb)
+            | Ok(b) =>
+                match run(aff_c) on
+                | Err(ec) => fail(ec)
+                | Ok(c) =>
+                    match run(aff_d) on
+                    | Err(ed) => fail(ed)
+                    | Ok(d) => succeed(f(a, b, c, d))
 
-  ## Equivalent of `>>=` from the `Monad` typeclass.
-  ##
-  ## @since 0.1.0
-  ##
-  ## ```
-  ## ➢ Aff.and_then ...
-  ## ...
-  ## ```
-  let and_then : (a -> Aff e b) -> Aff e a -> Aff e b =
-    \f aff =>
-      todo "not implemented"
+    ## Equivalent of `>>=` from the `Monad` typeclass.
+    ##
+    ## @since 0.1.0
+    ##
+    ## ```
+    ## ➢ Aff.and_then ...
+    ## ...
+    ## ```
+    let and_then(aff: Aff(e, a), f: (a) -> Aff(e, b)) -> Aff(e, b) =
+        todo("not implemented")
 
-  let run : Aff e a -> Result e a =
-    \aff =>
-      todo "not implemented"
+    let run(aff: Aff(e, a)) -> Result(e, a) =
+        todo("not implemented")
 
-  let from_result : Result e a -> Aff e a =
-    \result =>
-      match result on
-      | Err e => fail e
-      | Ok a => succeed a
+    let from_result(result: Result(e, a)) -> Aff(e, a) =
+        match result on
+        | Err(e) => fail(e)
+        | Ok(a) => succeed(a)
 end

--- a/stdlib/bitwise.mox
+++ b/stdlib/bitwise.mox
@@ -1,154 +1,165 @@
 module Bitwise exposing
-  ( and
-  , distance
-  , hamming_weight
-  , logical_shift_right
-  , not
-  , or
-  , rotate_left
-  , rotate_right
-  , shift_left
-  , shift_right
-  , xor
-  )
+    ( and
+    , distance
+    , hamming_weight
+    , logical_shift_right
+    , not
+    , or
+    , rotate_left
+    , rotate_right
+    , shift_left
+    , shift_right
+    , xor
+    )
 
-  foreign bitwise_and : Int -> Int -> Int = "zig_bitwise_and"
-  foreign bitwise_or : Int -> Int -> Int = "zig_bitwise_or"
-  foreign bitwise_not : Int -> Int = "zig_bitwise_not"
-  foreign bitwise_xor : Int -> Int -> Int = "zig_bitwise_xor"
-  foreign bitwise_shl : Int -> Int -> Int = "zig_bitwise_shl"
-  foreign bitwise_shr : Int -> Int -> Int = "zig_bitwise_shr"
-  foreign bitwise_lshr : Int -> Int -> Int = "zig_bitwise_lshr"
-  foreign bitwise_rotl : Int -> Int -> Int = "zig_bitwise_rotl"
-  foreign bitwise_rotr : Int -> Int -> Int = "zig_bitwise_rotr"
-  foreign bitwise_hw : Int -> Int = "zig_bitwise_hamming_weight"
-  foreign bitwise_dist : Int -> Int -> Int = "zig_bitwise_distance"
+    foreign bitwise_and(x : Int, y : Int) -> Int = "zig_bitwise_and"
+    foreign bitwise_or(x : Int, y : Int) -> Int = "zig_bitwise_or"
+    foreign bitwise_not(x : Int) -> Int = "zig_bitwise_not"
+    foreign bitwise_xor(x : Int, y : Int) -> Int = "zig_bitwise_xor"
+    foreign bitwise_shl(x : Int, y : Int) -> Int = "zig_bitwise_shl"
+    foreign bitwise_shr(x : Int, y : Int) -> Int = "zig_bitwise_shr"
+    foreign bitwise_lshr(x : Int, y : Int) -> Int = "zig_bitwise_lshr"
+    foreign bitwise_rotl(x : Int, y : Int) -> Int = "zig_bitwise_rotl"
+    foreign bitwise_rotr(x : Int, y : Int) -> Int = "zig_bitwise_rotr"
+    foreign bitwise_hw(x : Int) -> Int = "zig_bitwise_hamming_weight"
+    foreign bitwise_dist(x : Int, y : Int) -> Int = "zig_bitwise_distance"
 
-  ## Performs a bitwise AND operation between two integers.
-  ## Each bit in the result is 1 only if the corresponding
-  ## bits in both operands are 1.
-  ##
-  ## @since 0.1.0
-  ##
-  ## ```
-  ## ➢ Bitwise.and 9 3
-  ## 1 : Int
-  ## ```
-  let and : Int -> Int -> Int = bitwise_and
+    ## Performs a bitwise AND operation between two integers.
+    ## Each bit in the result is 1 only if the corresponding
+    ## bits in both operands are 1.
+    ##
+    ## @since 0.1.0
+    ##
+    ## ```
+    ## ➢ Bitwise.and(9, 3)
+    ## 1 : Int
+    ## ```
+    let and(x : Int, y : Int) -> Int =
+        bitwise_and(x, y)
 
-  ## Performs a bitwise OR operation between two integers.
-  ## Each bit in the result is 1 if at least one of the corresponding
-  ## bits in either operand is 1.
-  ##
-  ## @since 0.1.0
-  ##
-  ## ```
-  ## ➢ Bitwise.or 9 3
-  ## 11 : Int
-  ## ```
-  let or : Int -> Int -> Int = bitwise_or
+    ## Performs a bitwise OR operation between two integers.
+    ## Each bit in the result is 1 if at least one of the corresponding
+    ## bits in either operand is 1.
+    ##
+    ## @since 0.1.0
+    ##
+    ## ```
+    ## ➢ Bitwise.or(9, 3)
+    ## 11 : Int
+    ## ```
+    let or(x : Int, y : Int) -> Int =
+        bitwise_or(x, y)
 
-  ## Performs a bitwise NOT operation on an integer, inverting all bits.
-  ## Each 0 becomes 1 and each 1 becomes 0 in the binary representation.
-  ##
-  ## @since 0.1.0
-  ##
-  ## ```
-  ## ➢ Bitwise.not 2
-  ## -3 : Int
-  ## ```
-  let not : Int -> Int = bitwise_not
+    ## Performs a bitwise NOT operation on an integer, inverting all bits.
+    ## Each 0 becomes 1 and each 1 becomes 0 in the binary representation.
+    ##
+    ## @since 0.1.0
+    ##
+    ## ```
+    ## ➢ Bitwise.not(2)
+    ## -3 : Int
+    ## ```
+    let not(x : Int) -> Int =
+        bitwise_not(x)
 
-  ## Performs a bitwise XOR (exclusive OR) operation between two integers.
-  ## Each bit in the result is 1 only if the corresponding bits in the
-  ## operands are different.
-  ##
-  ## @since 0.1.0
-  ##
-  ## ```
-  ## ➢ Bitwise.xor 9 3
-  ## 10 : Int
-  ## ```
-  let xor : Int -> Int -> Int = bitwise_xor
+    ## Performs a bitwise XOR (exclusive OR) operation between two integers.
+    ## Each bit in the result is 1 only if the corresponding bits in the
+    ## operands are different.
+    ##
+    ## @since 0.1.0
+    ##
+    ## ```
+    ## ➢ Bitwise.xor(9, 3)
+    ## 10 : Int
+    ## ```
+    let xor(x : Int, y : Int) -> Int =
+        bitwise_xor(x, y)
 
-  ## Shifts all bits in the first integer to the left by the number of
-  ## positions specified by the second integer. New bits are filled with zeros.
-  ##
-  ## @since 0.1.0
-  ##
-  ## ```
-  ## ➢ Bitwise.shift_left 1 2
-  ## 4 : Int
-  ## ```
-  let shift_left : Int -> Int -> Int = bitwise_shl
+    ## Shifts all bits in the first integer to the left by the number of
+    ## positions specified by the second integer. New bits are filled with zeros.
+    ##
+    ## @since 0.1.0
+    ##
+    ## ```
+    ## ➢ Bitwise.shift_left(1, 2)
+    ## 4 : Int
+    ## ```
+    let shift_left(x : Int, y : Int) -> Int =
+        bitwise_shl(x, y)
 
-  ## Performs an arithmetic right shift, preserving the sign bit. All
-  ## bits are shifted right by the specified number of positions, with
-  ## the sign bit being copied into the newly vacated bit positions.
-  ##
-  ## @since 0.1.0
-  ##
-  ## ```
-  ## ➢ Bitwise.shift_right 1 2
-  ## 0 : Int
-  ## ```
-  let shift_right : Int -> Int -> Int = bitwise_shr
+    ## Performs an arithmetic right shift, preserving the sign bit. All
+    ## bits are shifted right by the specified number of positions, with
+    ## the sign bit being copied into the newly vacated bit positions.
+    ##
+    ## @since 0.1.0
+    ##
+    ## ```
+    ## ➢ Bitwise.shift_right(1, 2)
+    ## 0 : Int
+    ## ```
+    let shift_right(x : Int, y : Int) -> Int =
+        bitwise_shr(x, y)
 
-  ## Performs a logical right shift, filling new bits with zeros
-  ## regardless of the sign bit. This differs from `shift_right` in how
-  ## it handles negative numbers.
-  ##
-  ## @since 0.1.0
-  ##
-  ## ```
-  ## ➢ Bitwise.logical_shift_right 1 32
-  ## 16 : Int
-  ## ```
-  let logical_shift_right : Int -> Int -> Int = bitwise_lshr
+    ## Performs a logical right shift, filling new bits with zeros
+    ## regardless of the sign bit. This differs from `shift_right` in how
+    ## it handles negative numbers.
+    ##
+    ## @since 0.1.0
+    ##
+    ## ```
+    ## ➢ Bitwise.logical_shift_right(1, 32)
+    ## 16 : Int
+    ## ```
+    let logical_shift_right(x : Int, y : Int) -> Int =
+        bitwise_lshr(x, y)
 
-  ## Rotates all bits to the left by the specified number of positions.
-  ## Unlike shifting, bits that would be shifted out are wrapped around
-  ## to the rightmost positions.
-  ##
-  ## @since 0.1.0
-  ##
-  ## ```
-  ## ➢ Bitwise.rotate_left 11 2
-  ## 14 : Int
-  ## ```
-  let rotate_left : Int -> Int -> Int = bitwise_rotl
+    ## Rotates all bits to the left by the specified number of positions.
+    ## Unlike shifting, bits that would be shifted out are wrapped around
+    ## to the rightmost positions.
+    ##
+    ## @since 0.1.0
+    ##
+    ## ```
+    ## ➢ Bitwise.rotate_left(11, 2)
+    ## 14 : Int
+    ## ```
+    let rotate_left(x : Int, y : Int) -> Int =
+        bitwise_rotl(x, y)
 
-  ## Rotates all bits to the right by the specified number of positions.
-  ## Unlike shifting, bits that would be shifted out are wrapped around
-  ## to the leftmost positions.
-  ##
-  ## @since 0.1.0
-  ##
-  ## ```
-  ## ➢ Bitwise.rotate_right 11 2
-  ## 14 : Int
-  ## ```
-  let rotate_right : Int -> Int -> Int = bitwise_rotr
+    ## Rotates all bits to the right by the specified number of positions.
+    ## Unlike shifting, bits that would be shifted out are wrapped around
+    ## to the leftmost positions.
+    ##
+    ## @since 0.1.0
+    ##
+    ## ```
+    ## ➢ Bitwise.rotate_right(11, 2)
+    ## 14 : Int
+    ## ```
+    let rotate_right(x : Int, y : Int) -> Int =
+        bitwise_rotr(x, y)
 
-  ## Returns the Hamming weight (population count) of an integer - the
-  ## number of 1s in its binary representation.
-  ##
-  ## @since 0.1.0
-  ##
-  ## ```
-  ## ➢ Bitwise.hamming_weight 29
-  ## 4 : Int
-  ## ```
-  let hamming_weight : Int -> Int = bitwise_hw
+    ## Returns the Hamming weight (population count) of an integer - the
+    ## number of 1s in its binary representation.
+    ##
+    ## @since 0.1.0
+    ##
+    ## ```
+    ## ➢ Bitwise.hamming_weight(29)
+    ## 4 : Int
+    ## ```
+    let hamming_weight(x : Int) -> Int =
+        bitwise_hw(x)
 
-  ## Calculates the Hamming distance between two integers - the number of
-  ## positions at which their binary representations differ.
-  ##
-  ## @since 0.1.0
-  ##
-  ## ```
-  ## ➢ Bitwise.distance 29 21
-  ## 1 : Int
-  ## ```
-  let distance : Int -> Int -> Int = bitwise_dist
+    ## Calculates the Hamming distance between two integers - the number of
+    ## positions at which their binary representations differ.
+    ##
+    ## @since 0.1.0
+    ##
+    ## ```
+    ## ➢ Bitwise.distance(29, 21)
+    ## 1 : Int
+    ## ```
+    let distance(x : Int, y : Int) -> Int =
+        bitwise_dist(x, y)
 end

--- a/stdlib/boolean.mox
+++ b/stdlib/boolean.mox
@@ -1,117 +1,111 @@
 module Boolean exposing
-  ( Bool(..)
-  , and
-  , nand
-  , nor
-  , not
-  , or
-  , xor
-  )
+    ( Bool(..)
+    , and
+    , nand
+    , nor
+    , not
+    , or
+    , xor
+    )
 
-  ## The `Bool` type represents binary true/false values used for logical operations.
-  type Bool =
-    | True
-    | False
+    ## The `Bool` type represents binary true/false values used for logical operations.
+    type Bool =
+        | False
+        | True
 
-  ## Negates a boolean value.
-  ## Returns `True` for `False` input and `False` for `True` input.
-  ##
-  ## @since 0.1.0
-  ##
-  ## ```
-  ## ➢ not True
-  ## False : Bool
-  ## ```
-  let not : Bool -> Bool =
-    \x =>
-      match x on
-      | True => False
-      | False => True
+    ## Negates a boolean value.
+    ## Returns `True` for `False` input and `False` for `True` input.
+    ##
+    ## @since 0.1.0
+    ##
+    ## ```
+    ## ➢ Boolean.not(True)
+    ## False : Bool
+    ## ```
+    let not(x : Bool) -> Bool =
+        match x on
+        | False => True
+        | True => False
 
-  ## Returns `True` only if both inputs are `True`.
-  ## Classic logical AND operation from boolean algebra.
-  ##
-  ## @since 0.1.0
-  ##
-  ## ```
-  ## ➢ and True False
-  ## False : Bool
-  ##
-  ## ➢ and True True
-  ## True : Bool
-  ## ```
-  let and : Bool -> Bool -> Bool =
-    \x y =>
-      match (x, y) on
-      | (True, True) => True
-      | _ => False
+    ## Returns `True` only if both inputs are `True`.
+    ## Classic logical AND operation from boolean algebra.
+    ##
+    ## @since 0.1.0
+    ##
+    ## ```
+    ## ➢ Boolean.and(True, False)
+    ## False : Bool
+    ##
+    ## ➢ Boolean.and(True, True)
+    ## True : Bool
+    ## ```
+    let and(x : Bool, y : Bool) -> Bool =
+        match (x, y) on
+        | (True, True) => True
+        | _ => False
 
-  ## Returns `False` only if both inputs are `True`.
-  ## Equivalent to negating the AND of both inputs.
-  ##
-  ## @since 0.1.0
-  ##
-  ## ```
-  ## ➢ nand True False
-  ## True : Bool
-  ##
-  ## ➢ nand True True
-  ## False : Bool
-  ## ```
-  let nand : Bool -> Bool -> Bool =
-    \x y =>
-      not (and x y)
+    ## Returns `False` only if both inputs are `True`.
+    ## Equivalent to negating the AND of both inputs.
+    ##
+    ## @since 0.1.0
+    ##
+    ## ```
+    ## ➢ Boolean.nand(True, False)
+    ## True : Bool
+    ##
+    ## ➢ Boolean.nand(True, True)
+    ## False : Bool
+    ## ```
+    let nand(x : Bool, y : Bool) -> Bool =
+        not(and(x, y))
 
-  ## Returns `True` if either input is `True`.
-  ## Classic logical OR operation from boolean algebra.
-  ##
-  ## @since 0.1.0
-  ##
-  ## ```
-  ## ➢ or True False
-  ## True : Bool
-  ##
-  ## ➢ or False False
-  ## False : Bool
-  ## ```
-  let or : Bool -> Bool -> Bool =
-    \x y =>
-      match (x, y) on
-      | (False, False) => False
-      | _ => True
+    ## Returns `True` if either input is `True`.
+    ## Classic logical OR operation from boolean algebra.
+    ##
+    ## @since 0.1.0
+    ##
+    ## ```
+    ## ➢ Boolean.or(True, False)
+    ## True : Bool
+    ##
+    ## ➢ Boolean.or(False, False)
+    ## False : Bool
+    ## ```
+    let or(x : Bool, y : Bool) -> Bool =
+        match (x, y) on
+        | (False, False) => False
+        | _ => True
 
-  ## Returns `True` only if both inputs are `False`.
-  ## Equivalent to negating the OR of both inputs.
-  ##
-  ## @since 0.1.0
-  ##
-  ## ```
-  ## ➢ nor False False
-  ## True : Bool
-  ##
-  ## ➢ nor True False
-  ## False : Bool
-  ## ```
-  let nor : Bool -> Bool -> Bool =
-    \x y =>
-      not (or x y)
+    ## Returns `True` only if both inputs are `False`.
+    ## Equivalent to negating the OR of both inputs.
+    ##
+    ## @since 0.1.0
+    ##
+    ## ```
+    ## ➢ Boolean.nor(False, False)
+    ## True : Bool
+    ##
+    ## ➢ Boolean.nor(True, False)
+    ## False : Bool
+    ## ```
+    let nor(x : Bool, y : Bool) -> Bool =
+        not(or(x, y))
 
-  ## Returns `True` if exactly one input is `True`.
-  ## Also known as "exclusive or" - `True` when inputs differ.
-  ##
-  ## @since 0.1.0
-  ##
-  ## ```
-  ## ➢ xor True False
-  ## True : Bool
-  ##
-  ## ➢ xor True True
-  ## False : Bool
-  ## ```
-  let xor : Bool -> Bool -> Bool =
-    \x y =>
-      match (x, y) on
-      | (False, False) => False
-      | (True, True) => False
-      | _ => True
+    ## Returns `True` if exactly one input is `True`.
+    ## Also known as "exclusive or" - `True` when inputs differ.
+    ##
+    ## @since 0.1.0
+    ##
+    ## ```
+    ## ➢ Boolean.xor(True, False)
+    ## True : Bool
+    ##
+    ## ➢ Boolean.xor(True, True)
+    ## False : Bool
+    ## ```
+    let xor(x : Bool, y : Bool) -> Bool =
+        match (x, y) on
+        | (False, False) => False
+        | (True, True) => False
+        | _ => True
 end

--- a/stdlib/comparable.mox
+++ b/stdlib/comparable.mox
@@ -1,68 +1,59 @@
 module Comparable exposing
-  ( Ordering(..)
-  , compare
-  , eq
-  , gt,
-  , gte
-  , lt
-  , lte
-  , max
-  , min
-  , neq
-  )
+    ( Ordering(..)
+    , compare
+    , eq
+    , gt,
+    , gte
+    , lt
+    , lte
+    , max
+    , min
+    , neq
+    )
 
-  type Ordering =
-    | EQ
-    | LT
-    | GT
+    type Ordering =
+        | EQ
+        | LT
+        | GT
 
-  let eq : Bool -> Bool -> Bool =
-    \x y =>
-      if (x == True) and (y == True) then
-        True
-      else
-        False
+    let eq(x : Bool, y : Bool) -> Bool =
+        if (x == True) and (y == True) then
+            True
+        else
+            False
 
-  let neq : Bool -> Bool -> Bool =
-    \x y =>
-      not (eq x y)
+    let neq(x : Bool, y : Bool) -> Bool =
+        not(eq(x, y))
 
-  let lt : comparable -> comparable -> Bool =
-    \x y =>
-      todo "not implemented"
+    let lt(x : comparable, y : comparable) -> Bool =
+        todo("not implemented")
 
-  let gt : comparable -> comparable -> Bool =
-    \x y =>
-      todo "not implemented"
+    let gt(x : comparable, y : comparable) -> Bool =
+        todo("not implemented")
 
-  let lte : comparable -> comparable -> Bool =
-    \x y =>
-      todo "not implemented"
+    let lte(x : comparable, y : comparable) -> Bool =
+        todo("not implemented")
 
-  let gte : comparable -> comparable -> Bool =
-    \x y =>
-      todo "not implemented"
+    let gte(x : comparable, y : comparable) -> Bool =
+        todo("not implemented")
 
-  let compare : comparable -> comparable -> Ordering =
-    \x y =>
-      if x == y then
-        EQ
-      else if x < y then
-        LT
-      else
-        GT
+    let compare(x : comparable, y : comparable) -> Ordering =
+        if x == y then
+            EQ
+        else if x < y then
+            LT
+        else
+            GT
 
-  let min : comparable -> comparable -> comparable =
-    \x y =>
-      if lt x y then
-        x
-      else
-        y
+    let min(x : comparable, y : comparable) -> comparable =
+        if lt(x, y) then
+            x
+        else
+            y
 
-  let max : comparable -> comparable -> comparable =
-    \x y =>
-      if gt x y then
-        x
-      else
-        y
+    let max(x : comparable, y : comparable) -> comparable =
+        if gt(x, y) then
+            x
+        else
+            y
 end

--- a/stdlib/date.mox
+++ b/stdlib/date.mox
@@ -1,44 +1,41 @@
 module Date exposing
-  ( Date
-  , Month(..)
-  , and_then
-  , map
-  , mk_date
-  , today
-  )
+    ( Date
+    , Month(..)
+    , and_then
+    , map
+    , mk_date
+    , today
+    )
 
-  type Date = Date
-    { month : Month
-    , day : Int
-    , year : Int
-    }
+    type Date = Date
+        { month : Month
+        , day : Int
+        , year : Int
+        }
 
-  type Month =
-    | January
-    | February
-    | March
-    | April
-    | May
-    | June
-    | July
-    | August
-    | September
-    | October
-    | November
-    | December
+    type Month =
+        | January
+        | February
+        | March
+        | April
+        | May
+        | June
+        | July
+        | August
+        | September
+        | October
+        | November
+        | December
 
-  let mk_date : Month -> Int -> Int -> Date =
-    \month day year =>
-      Date { month, day, year }
+    let mk_date(month : Month, day : Int, year : Int) -> Date =
+        Date({ month, day, year })
 
-  let today : Eff () Date =
-    todo "not implemented"
+    let today() -> Eff () Date =
+        todo("not implemented")
 
-  let map : (Date -> Date) -> Date -> Date =
-    \f date =>
-      f date
+    let map(f : (Date -> Date), date : Date) -> Date =
+        f(date)
 
-  let and_then : (Date -> Maybe Date) -> Maybe Date -> Maybe Date
-    \f mdate =>
-      Maybe.map f mdate
+    let and_then(mdate : Maybe(Date), f : (Date -> Maybe(Date))) -> Maybe(Date)
+        Maybe.map(mdate, f)
 end

--- a/stdlib/eff.mox
+++ b/stdlib/eff.mox
@@ -1,112 +1,118 @@
 module Eff exposing
-  ( Eff
-  , and_then
-  , fail
-  , from_result
-  , map
-  , map2
-  , map3
-  , map4
-  , run
-  , succeed
-  )
+    ( Eff
+    , and_then
+    , fail
+    , from_result
+    , map
+    , map2
+    , map3
+    , map4
+    , run
+    , succeed
+    )
 
-  ## Model synchroneous effects.
-  ##
-  ## @since 0.1.0
-  ##
-  ## ```
-  ## ➢
-  ## :
-  ## ```
-  type alias Eff e a =
-    SyncEffect e a
+    ## Model synchroneous effects.
+    ##
+    ## @since 0.1.0
+    ##
+    ## ```
+    ## ➢
+    ## :
+    ## ```
+    type alias Eff(e, a) =
+        SyncEffect(e, a)
 
-  ## Lifts an error into a failed `Eff`.
-  ##
-  ## @since 0.1.0
-  ##
-  ## ```
-  ## ➢ Eff.fail "foobar!" : Eff String String
-  ## :
-  ## ```
-  let fail : e -> Eff e Unit =
-    \e =>
-      Scheduler.Sync.fail e
+    ## Lifts an error into a failed `Eff`.
+    ##
+    ## @since 0.1.0
+    ##
+    ## ```
+    ## ➢ Eff.fail("foobar!") : Eff(String, String)
+    ## :
+    ## ```
+    let fail(err : e) -> Eff(e, Unit) =
+        Scheduler.Sync.fail(err)
 
-  ## Lifts a value into a successful `#ff`.
-  ##
-  ## @since 0.1.0
-  ##
-  ## ```
-  ## ➢ Eff.success "foobar" : Eff String String
-  ## :
-  ## ```
-  let succeed : a -> Eff Unit a =
-    \value =>
-      Scheduler.Sync.succeed value
+    ## Lifts a value into a successful `#ff`.
+    ##
+    ## @since 0.1.0
+    ##
+    ## ```
+    ## ➢ Eff.success("foobar") : Eff(String, String)
+    ## :
+    ## ```
+    let succeed(value : a) -> Eff(Unit, a) =
+        Scheduler.Sync.succeed(value)
 
-  let map : (a -> value) -> Eff e a -> Eff e value =
-    \f eff_a =>
-      match run eff_a on
-      | Err ea => fail ea
-      | Ok a => succeed (f a)
+    let map(eff_a : Eff(e, a), f : (a -> value)) -> Eff(e, value) =
+        match run(eff_a) on
+        | Err ea => fail(ea)
+        | Ok a => succeed(f(a))
 
-  let map2 : (a -> b -> value) -> Eff e a -> Eff e b -> Eff e value =
-    \f eff_a eff_b =>
-      match run eff_a on
-      | Err ea => fail ea
-      | Ok a =>
-          match run eff_b on
-          | Err eb => fail eb
-          | Ok b => succeed (f a b)
+    let map2(
+        eff_a : Eff(e, a),
+        eff_b : Eff(e, b),
+        f : ((a, b) -> value)
+    ) -> Eff(e, value) =
+        match run(eff_a) on
+        | Err(ea) => fail(ea)
+        | Ok(a) =>
+            match run(eff_b) on
+            | Err(eb) => fail(eb)
+            | Ok(b) => succeed(f(a, b))
 
-  let map3 : (a -> b -> c -> value) -> Eff e a -> Eff e b -> Eff e c -> Eff e value
-    \f eff_a eff_b eff_c =>
-      match run eff_a on
-      | Err ea => fail ea
-      | Ok a =>
-          match run eff_b on
-          | Err eb => fail eb
-          | Ok b =>
-              match run eff_c on
-              | Err ec => fail ec
-              | Ok c => succeed (f a b c)
+    let map3(
+        eff_a : Eff(e, a),
+        eff_b : Eff(e, b),
+        eff_c : Eff(e, c),
+        f : ((a, b, c) -> value)
+    ) -> Eff(e, value) =
+        match run(eff_a) on
+        | Err(ea) => fail(ea)
+        | Ok(a) =>
+            match run(eff_b) on
+            | Err(eb) => fail(eb)
+            | Ok(b) =>
+                match run(eff_c) on
+                | Err(ec) => fail(ec)
+                | Ok(c) => succeed(f(a, b, c))
 
-  let map4 : (a -> b -> c -> d -> value) -> Eff e a -> Eff e b -> Eff e c -> Eff e d -> Eff e value
-    \f eff_a eff_b eff_c eff_d =>
-      match run eff_a on
-      | Err ea => fail ea
-      | Ok a =>
-          match run eff_b on
-          | Err eb => fail eb
-          | Ok b =>
-              match run eff_c on
-              | Err ec => fail ec
-              | Ok c =>
-                  match run eff_d on
-                  | Err ed => fail ed
-                  | Ok d => succeed (f a b c d)
+    let map4(
+        eff_a : Eff(e, a),
+        eff_b : Eff(e, b),
+        eff_c : Eff(e, c),
+        eff_d : Eff(e, d),
+        f : ((a, b, c, d) -> value)
+    ) -> Eff(e, value) =
+        match run(eff_a) on
+        | Err(ea) => fail(ea)
+        | Ok(a) =>
+            match run(eff_b) on
+            | Err(eb) => fail(eb)
+            | Ok(b) =>
+                match run(eff_c) on
+                | Err(ec) => fail(ec)
+                | Ok(c) =>
+                    match run(eff_d) on
+                    | Err(ed) => fail(ed)
+                    | Ok(d) => succeed(f(a, b, c, d))
 
-  ## Equivalent of `>>=` from the `Monad` typeclass.
-  ##
-  ## @since 0.1.0
-  ##
-  ## ```
-  ## ➢ Eff.and_then ...
-  ## ...
-  ## ```
-  let and_then : (a -> Eff e value) -> Eff e a -> Eff e value =
-    \f eff =>
-      todo "not implemented"
+    ## Equivalent of `>>=` from the `Monad` typeclass.
+    ##
+    ## @since 0.1.0
+    ##
+    ## ```
+    ## ➢ Eff.and_then ...
+    ## ...
+    ## ```
+    let and_then(eff : Eff(e, a), f : (a -> Eff(e, value))) -> Eff(e, value) =
+        todo("not implemented")
 
-  let run : Eff e a -> Result e a =
-    \eff =>
-      todo "not implemented"
+    let run(eff : Eff(e, a)) -> Result(e, a) =
+        todo("not implemented")
 
-  let from_result : Result e a -> Eff e a =
-    \result =>
-      match result on
-      | Err e => fail e
-      | Ok a => succeed a
+    let from_result(result : Result(e, a)) -> Eff(e, a) =
+        match result on
+        | Err(e) => fail(e)
+        | Ok(a) => succeed(a)
 end

--- a/stdlib/float.mox
+++ b/stdlib/float.mox
@@ -1,384 +1,412 @@
 module Float exposing
-  ( Degrees
-  , Radians
-  , abs
-  , acos
-  , acosech
-  , acosh
-  , acoth
-  , asech
-  , asin
-  , asinh
-  , atan
-  , atan2
-  , atanh
-  , ceil
-  , clamp
-  , cos
-  , cosech
-  , cosh
-  , e
-  , floor
-  , from_int
-  , log
-  , log10
-  , log2
-  , max
-  , min
-  , mod
-  , negate
-  , pi
-  , pow
-  , round
-  , sech
-  , sin
-  , sinh
-  , sqrt
-  , tan
-  , tanh
-  , to_degress
-  , to_radians
-  , trunc
-  )
+    ( Degrees
+    , Radians
+    , abs
+    , acos
+    , acosech
+    , acosh
+    , acoth
+    , asech
+    , asin
+    , asinh
+    , atan
+    , atan2
+    , atanh
+    , ceil
+    , clamp
+    , cos
+    , cosech
+    , cosh
+    , e
+    , floor
+    , from_int
+    , log
+    , log10
+    , log2
+    , max
+    , min
+    , mod
+    , negate
+    , pi
+    , pow
+    , round
+    , sech
+    , sin
+    , sinh
+    , sqrt
+    , tan
+    , tanh
+    , to_degress
+    , to_radians
+    , trunc
+    )
 
-  type alias Radians = Float
-  type alias Degrees = Float
+    type alias Radians =
+        Float
 
-  foreign float_sqrt : Float -> Float = "zig_float_sqrt"
-  foreign float_log : Float -> Float -> Float = "zig_float_log"
-  foreign float_e : Float = "zig_float_e"
-  foreign float_pi : Float = "zig_float_pi"
-  foreign float_cos : Float -> Float = "zig_float_cos"
-  foreign float_sin : Float -> Float = "zig_float_sin"
-  foreign float_tan : Float -> Float = "zig_float_tan"
-  foreign float_acos : Float -> Float = "zig_float_acos"
-  foreign float_asin : Float -> Float = "zig_float_asin"
-  foreign float_atan : Float -> Float = "zig_float_atan"
-  foreign float_atan2 : Float -> Float -> Float = "zig_float_atan2"
-  foreign float_trunc : Float -> Int = "zig_float_trunc"
-  foreign float_ceil : Float -> Int = "zig_float_ceil"
-  foreign float_floor : Float -> Int = "zig_float_floor"
-  foreign float_round : Float -> Int = "zig_float_round"
-  foreign float_cosh : Float -> Float = "zig_float_cosh"
-  foreign float_sinh : Float -> Float = "zig_float_sinh"
-  foreign float_tanh : Float -> Float = "zig_float_tanh"
-  foreign float_sech : Float -> Float = "zig_float_sech"
-  foreign float_cosech : Float -> Float = "zig_float_cosech"
-  foreign float_acosh : Float -> Float = "zig_float_acosh"
-  foreign float_asinh : Float -> Float = "zig_float_asinh"
-  foreign float_atanh : Float -> Float = "zig_float_atanh"
-  foreign float_acoth : Float -> Float = "zig_float_acoth"
-  foreign float_asech : Float -> Float = "zig_float_asech"
-  foreign float_acosech : Float -> Float = "zig_float_acosech"
-  foreign float_min : Float = "zig_float_min"
-  foreign float_max : Float = "zig_float_max"
-  foreign float_from_int : Float = "zig_float_from_int"
+    type alias Degrees =
+        Float
 
-  ## Get the absolute value of a number.
-  ##
-  ## @since 0.1.0
-  ##
-  ## ```
-  ## ➢ Float.abs -42.0
-  ## 42.0 : Float
-  ## ```
-  let abs : Float -> Float =
-    \x =>
-      if x < 0 then
+    foreign float_sqrt(x : Float) -> Float = "zig_float_sqrt"
+    foreign float_log(x : Float, y : Float) -> Float = "zig_float_log"
+    foreign float_e() -> Float = "zig_float_e"
+    foreign float_pi() -> Float = "zig_float_pi"
+    foreign float_cos(x : Float) -> Float = "zig_float_cos"
+    foreign float_sin(x : Float) -> Float = "zig_float_sin"
+    foreign float_tan(x : Float) -> Float = "zig_float_tan"
+    foreign float_acos(x : Float) -> Float = "zig_float_acos"
+    foreign float_asin(x : Float) -> Float = "zig_float_asin"
+    foreign float_atan(x : Float) -> Float = "zig_float_atan"
+    foreign float_atan2(x : Float, y : Float) -> Float = "zig_float_atan2"
+    foreign float_trunc(x : Float) -> Int = "zig_float_trunc"
+    foreign float_ceil(x : Float) -> Int = "zig_float_ceil"
+    foreign float_floor(x : Float) -> Int = "zig_float_floor"
+    foreign float_round(x : Float) -> Int = "zig_float_round"
+    foreign float_cosh(x : Float) -> Float = "zig_float_cosh"
+    foreign float_sinh(x : Float) -> Float = "zig_float_sinh"
+    foreign float_tanh(x : Float) -> Float = "zig_float_tanh"
+    foreign float_sech(x : Float) -> Float = "zig_float_sech"
+    foreign float_cosech(x : Float) -> Float = "zig_float_cosech"
+    foreign float_acosh(x : Float) -> Float = "zig_float_acosh"
+    foreign float_asinh(x : Float) -> Float = "zig_float_asinh"
+    foreign float_atanh(x : Float) -> Float = "zig_float_atanh"
+    foreign float_acoth(x : Float) -> Float = "zig_float_acoth"
+    foreign float_asech(x : Float) -> Float = "zig_float_asech"
+    foreign float_acosech(x : Float) -> Float = "zig_float_acosech"
+    foreign float_min() -> Float = "zig_float_min"
+    foreign float_max() -> Float = "zig_float_max"
+    foreign float_from_int(x : Int) -> Float = "zig_float_from_int"
+
+    ## Get the absolute value of a number.
+    ##
+    ## @since 0.1.0
+    ##
+    ## ```
+    ## ➢ Float.abs(-42.0)
+    ## 42.0 : Float
+    ## ```
+    let abs(x : Float) -> Float =
+        if x < 0 then
+            -x
+        else
+            x
+
+    ## Calculates the value of *x* to the power of *y*.
+    ##
+    ## @since 0.1.0
+    ##
+    ## ```
+    ## ➢ Float.pow(9.0, 3.0)
+    ## 729.0 : Float
+    ## ```
+    let pow(x : Float, y : Float) -> Float =
+        todo("not implemented")
+
+    ## Integer remainder.
+    ##
+    ## @since 0.1.0
+    ##
+    ## ```
+    ## ➢ Float.mod(42, 8)
+    ## 2 : Int
+    ## ```
+    let mod(x : Float, y : Float) -> Float =
+        todo("not implemented")
+
+    ## Clamps a number within a given range.
+    ##
+    ## @since 0.1.0
+    ##
+    ## ```
+    ## ➢ Float.clamp(100.0, 200.0, 99.0)
+    ## 100.0 : Float
+    ## ```
+    let clamp(low : Float, hight : Float, n : Float) -> Float =
+        if n < low then
+            low
+        else if n > high then
+            high
+        else
+            n
+
+    ## Negate a number.
+    ##
+    ## @since 0.1.0
+    ##
+    ## ```
+    ## ➢ Float.negate(42.0)
+    ## -42.0 : Float
+    ## ```
+    let negate(x : Float) -> Float =
         -x
-      else
-        x
 
-  ## Calculates the value of *x* to the power of *y*.
-  ##
-  ## @since 0.1.0
-  ##
-  ## ```
-  ## ➢ Float.pow 9.0 3.0
-  ## 729.0 : Float
-  ## ```
-  let pow : Float -> Float -> Float =
-    \x y =>
-      todo "not implemented"
+    ## Calculate the square root of a number.
+    ##
+    ## @since 0.1.0
+    ##
+    ## ```
+    ## ➢ Float.sqrt(16.0)
+    ## 4.0 : Float
+    ## ```
+    let sqrt(x : Float, y : Float) -> Float =
+        float_sqrt(x, y)
+        # Unsafe for: Negative inputs (x < 0)
+        # Reason: The square root of a negative number is undefined for real numbers. It typically results in NaN (Not-a-Number) or an error.
 
-  ## Integer remainder.
-  ##
-  ## @since 0.1.0
-  ##
-  ## ```
-  ## ➢ Float.mod 42 8
-  ## 2 : Int
-  ## ```
-  let mod : Float -> Float -> Float =
-    \x y =>
-      todo "not implemented"
+    ## Calculate the logarithm of a number with a given base.
+    ##
+    ## @since 0.1.0
+    ##
+    ## ```
+    ## ➢ Float.log(2.0, 256.0)
+    ## 8.0 : Float
+    ## ```
+    let log(x : Float, y : Float) -> Float =
+        float_log(x, y)
+        # x <= 0 for log x (undefined for non-positive inputs).
+        # log base x where base <= 0 or base == 1 (invalid base).
+        # log(0) approaches negative infinity, and log(x) for x < 0 is undefined.
+        # The logarithm base must be greater than 0 and not equal to 1.
 
-  ## Clamps a number within a given range.
-  ##
-  ## @since 0.1.0
-  ##
-  ## ```
-  ## ➢ Float.clamp 100.0 200.0 99.0
-  ## 100.0 : Float
-  ## ```
-  let clamp : Float -> Float -> Float -> Float =
-    \low high n =>
-      if n < low then
-        low
-      else if n > high then
-        high
-      else
-        n
+    ##
+    let log2(x : Float) -> Float =
+        log(2, x)
 
-  ## Negate a number.
-  ##
-  ## @since 0.1.0
-  ##
-  ## ```
-  ## ➢ Float.negate 42.0
-  ## -42.0 : Float
-  ## ```
-  let negate : Float -> Float =
-    \x =>
-      -x
+    ##
+    let log10(x : Float) -> Float =
+        log(10, x)
 
-  ## Calculate the square root of a number.
-  ##
-  ## @since 0.1.0
-  ##
-  ## ```
-  ## ➢ Float.sqrt 16.0
-  ## 4.0 : Float
-  ## ```
-  let sqrt : Float -> Float = float_sqrt
-    # Unsafe for: Negative inputs (x < 0)
-    # Reason: The square root of a negative number is undefined for real numbers. It typically results in NaN (Not-a-Number) or an error.
+    ## An approximation of *e*.
+    ##
+    ## @since 0.1.0
+    ##
+    ## ```
+    ## ➢ Float.e()
+    ## 3.141592653589793 : Float
+    ## ```
+    let e() -> Float =
+        float_e()
 
-  ## Calculate the logarithm of a number with a given base.
-  ##
-  ## @since 0.1.0
-  ##
-  ## ```
-  ## ➢ Float.log 2.0 256.0
-  ## 8.0 : Float
-  ## ```
-  let log : Float -> Float -> Float = float_log
-    # x <= 0 for log x (undefined for non-positive inputs).
-    # log base x where base <= 0 or base == 1 (invalid base).
-    # log(0) approaches negative infinity, and log(x) for x < 0 is undefined.
-    # The logarithm base must be greater than 0 and not equal to 1.
+    ## An approximation of pie.
+    ##
+    ## @since 0.1.0
+    ##
+    ## ```
+    ## ➢ Float.pi()
+    ## 3.141592653589793 : Float
+    ## ```
+    let pi() -> Float =
+        float_pi()
 
-  ##
-  let log2 : Float -> Float = log 2
+    ## Calculate the cosine given an angle in radians.
+    ##
+    ## @since 0.1.0
+    ##
+    ## ```
+    ## ➢ Float.cos(3.141592653589793)
+    ## -1.0 : Float
+    ## ```
+    let cos(x : Float) -> Float =
+        float_cos(x)
 
-  ##
-  let log10 : Float -> Float = log 10
+    ## Calculate the sine given an angle in radians.
+    ##
+    ## @since 0.1.0
+    ##
+    ## ```
+    ## ➢ Float.sin(90.0)
+    ## 0.8939966636005579 : Float
+    ## ```
+    let sin(x : Float) -> Float =
+        float_sin(x)
 
-  ## An approximation of *e*.
-  ##
-  ## @since 0.1.0
-  ##
-  ## ```
-  ## ➢ Float.e
-  ## 3.141592653589793 : Float
-  ## ```
-  let e : Float = float_e
+    ## Calculate the tangent given an angle in radians.
+    ##
+    ## @since 0.1.0
+    ##
+    ## ```
+    ## ➢ Float.tan(90.0)
+    ## -1.995200412208242 : Float
+    ## ```
+    let tan(x : Float) -> Float =
+        float_tan(x)
+        # Unsafe for: Inputs near (pi/2 + n*pi) where n is an integer.
+        # Reason: Tangent is undefined at odd multiples of pi/2 and results in NaN or large values.
 
-  ## An approximation of pie.
-  ##
-  ## @since 0.1.0
-  ##
-  ## ```
-  ## ➢ Float.pi
-  ## 3.141592653589793 : Float
-  ## ```
-  let pi : Float = float_pi
+    ## ??
+    ##
+    ## @since 0.1.0
+    ##
+    ## ```
+    ## ➢
+    ## :
+    ## ```
+    let acos(x : Float) -> Float =
+        float_acos(x)
+        # Unsafe for: Inputs outside the range [-1, 1]
+        # Reason: The inverse cosine is only defined for values between -1 and 1. Outside this range, it results in NaN.
 
-  ## Calculate the cosine given an angle in radians.
-  ##
-  ## @since 0.1.0
-  ##
-  ## ```
-  ## ➢ Float.cos 3.141592653589793
-  ## -1.0 : Float
-  ## ```
-  let cos : Float -> Float = float_cos
+    ## ??
+    ##
+    ## @since 0.1.0
+    ##
+    ## ```
+    ## ➢
+    ## :
+    ## ```
+    let asin(x : Float) -> Float =
+        float_asin(x)
+        # Unsafe for: Inputs outside the range [-1, 1].
+        # Reason: Similar to acos, asin is only defined for inputs between -1 and 1.
 
-  ## Calculate the sine given an angle in radians.
-  ##
-  ## @since 0.1.0
-  ##
-  ## ```
-  ## ➢ Float.sin 90.0
-  ## 0.8939966636005579 : Float
-  ## ```
-  let sin : Float -> Float = float_sin
+    ## ??
+    ##
+    ## @since 0.1.0
+    ##
+    ## ```
+    ## ➢
+    ## :
+    ## ```
+    let atan(x : Float) -> Float =
+        float_atan(x)
 
-  ## Calculate the tangent given an angle in radians.
-  ##
-  ## @since 0.1.0
-  ##
-  ## ```
-  ## ➢ Float.tan 90.0
-  ## -1.995200412208242 : Float
-  ## ```
-  let tan : Float -> Float = float_tan
-    # Unsafe for: Inputs near (pi/2 + n*pi) where n is an integer.
-    # Reason: Tangent is undefined at odd multiples of pi/2 and results in NaN or large values.
+    ## ??
+    ##
+    ## @since 0.1.0
+    ##
+    ## ```
+    ## ➢
+    ## :
+    ## ```
+    let atan2(x : Float, y : Float) -> Float =
+        float_atan2(x, y)
 
-  ## ??
-  ##
-  ## @since 0.1.0
-  ##
-  ## ```
-  ## ➢
-  ## :
-  ## ```
-  let acos : Float -> Float = float_acos
-    # Unsafe for: Inputs outside the range [-1, 1]
-    # Reason: The inverse cosine is only defined for values between -1 and 1. Outside this range, it results in NaN.
+    ## Converts a degree value into radians.
+    ##
+    ## @since 0.1.0
+    ##
+    ## ```
+    ## ➢ Float.radians(Float.pi)
+    ## 3.141592653589793 : Float
+    ## ```
+    let to_radians(deg : Degrees) -> Radians =
+        deg *. (pi /. 180.0)
 
-  ## ??
-  ##
-  ## @since 0.1.0
-  ##
-  ## ```
-  ## ➢
-  ## :
-  ## ```
-  let asin : Float -> Float = float_asin
-    # Unsafe for: Inputs outside the range [-1, 1].
-    # Reason: Similar to acos, asin is only defined for inputs between -1 and 1.
+    ## Converts an angle from radians to degrees.
+    ##
+    ## @since 0.1.0
+    ##
+    ## ```
+    ## ➢ Float.degrees(180.0)
+    ## 3.141592653589793 : Float
+    ## ```
+    let to_degrees(rad : Radians) -> Degrees =
+        rad *. (180.0 /. pi)
 
-  ## ??
-  ##
-  ## @since 0.1.0
-  ##
-  ## ```
-  ## ➢
-  ## :
-  ## ```
-  let atan : Float -> Float = float_atan
+    ## Truncate a number, rounding towards zero.
+    ##
+    ## @since 0.1.0
+    ##
+    ## ```
+    ## ➢ Float.trunc(-99.29)
+    ## -99 : Int
+    ## ```
+    let trunc(x : Float) -> Int =
+        float_trunc(x)
 
-  ## ??
-  ##
-  ## @since 0.1.0
-  ##
-  ## ```
-  ## ➢
-  ## :
-  ## ```
-  let atan2 : Float -> Float -> Float = float_atan2
+    ## Rounds a number up to the nearest integer.
+    ##
+    ## @since 0.1.0
+    ##
+    ## ```
+    ## ➢ Float.ceil(1.4)
+    ## 2 : Int
+    ## ```
+    let ceil(x : Float) -> Int =
+        float_ceil(x)
 
-  ## Converts a degree value into radians.
-  ##
-  ## @since 0.1.0
-  ##
-  ## ```
-  ## ➢ Float.radians Float.pi
-  ## 3.141592653589793 : Float
-  ## ```
-  let to_radians : Degrees -> Radians =
-    \deg =>
-      deg *. (pi /. 180.0)
+    ## Rounds a number down to the nearest integer.
+    ##
+    ## @since 0.1.0
+    ##
+    ## ```
+    ## ➢ Float.floor(1.2)
+    ## 1 : Int
+    ## ```
+    let floor(x : Float) -> Int =
+        float_floor(x)
 
-  ## Converts an angle from radians to degrees.
-  ##
-  ## @since 0.1.0
-  ##
-  ## ```
-  ## ➢ Float.degrees 180.0
-  ## 3.141592653589793 : Float
-  ## ```
-  let to_degrees : Radians -> Degrees =
-    \rad =>
-      rad *. (180.0 /. pi)
+    ## Round a number to the nearest integer.
+    ##
+    ## @since 0.1.0
+    ##
+    ## ```
+    ## ➢ Float.round(1.2)
+    ## 1 : Int
+    ##
+    ## ➢ Float.round(1.5)
+    ## 2 : Int
+    ## ```
+    let round(x : Float) -> Int =
+        float_round(x)
 
-  ## Truncate a number, rounding towards zero.
-  ##
-  ## @since 0.1.0
-  ##
-  ## ```
-  ## ➢ Float.trunc -99.29
-  ## -99 : Int
-  ## ```
-  let trunc : Float -> Int = float_trunc
+    ## Hyperbolic cosine. Argument is in radians.
+    let cosh(x : Radians) -> Float =
+        float_cosh(x)
 
-  ## Rounds a number up to the nearest integer.
-  ##
-  ## @since 0.1.0
-  ##
-  ## ```
-  ## ➢ Float.ceil 1.4
-  ## 2 : Int
-  ## ```
-  let ceil : Float -> Int = float_ceil
+    ## Hyperbolic sine. Argument is in radians.
+    let sinh(x : Radians) -> Float =
+        float_sinh(x)
 
-  ## Rounds a number down to the nearest integer.
-  ##
-  ## @since 0.1.0
-  ##
-  ## ```
-  ## ➢ Float.floor 1.2
-  ## 1 : Int
-  ## ```
-  let floor : Float -> Int = float_floor
+    ## Hyperbolic tangent. Argument is in radians.
+    let tanh(x : Radians) -> Float =
+        float_tanh(x)
 
-  ## Round a number to the nearest integer.
-  ##
-  ## @since 0.1.0
-  ##
-  ## ```
-  ## ➢ Float.round 1.2
-  ## 1 : Int
-  ##
-  ## ➢ Float.round 1.5
-  ## 2 : Int
-  ## ```
-  let round : Float -> Int = float_round
+    ## Hyperbolic cotangent. Argument is in radians.
+    let coth(x : Radians) -> Float =
+        float_coth(x)
 
-  ## Hyperbolic cosine. Argument is in radians.
-  let cosh : Radians -> Float = float_cosh
+    ## Hyperbolic secant. Argument is in radians.
+    let sech(x : Radians) -> Float =
+        float_sech(x)
 
-  ## Hyperbolic sine. Argument is in radians.
-  let sinh : Radians -> Float = float_sinh
+    ## Hyperbolic cosecant. Argument is in radians.
+    let cosech(x : Radians) -> Float =
+        float_cosech(x)
 
-  ## Hyperbolic tangent. Argument is in radians.
-  let tanh : Radians -> Float = float_tanh
+    ## Hyperbolic arc cosine.
+    let acosh(x : Float) -> Float =
+        float_acosh(x)
 
-  ## Hyperbolic cotangent. Argument is in radians.
-  let coth : Radians -> Float = float_coth
+    ## Hyperbolic arc sine.
+    let asinh(x : Float) -> Float =
+        float_asinh(x)
 
-  ## Hyperbolic secant. Argument is in radians.
-  let sech : Radians -> Float = float_sech
+    ## Hyperbolic arc cotangent.
+    let acoth(x : Float) -> Float =
+        float_acoth(x)
 
-  ## Hyperbolic cosecant. Argument is in radians.
-  let cosech : Radians -> Float = float_cosech
+    ## Hyperbolic arc tangent.
+    let atanh(x : Float) -> Float =
+        float_atanh(x)
 
-  ## Hyperbolic arc cosine.
-  let acosh : Float -> Float = float_acosh
+    ## Hyperbolic arc secant.
+    let asech(x : Float) -> Float =
+        float_asech(x)
 
-  ## Hyperbolic arc sine.
-  let asinh : Float -> Float = float_asinh
+    ## Hyperbolic arc cosecant.
+    let acosech(x : Float) -> Float =
+        float_acosech(x)
 
-  ## Hyperbolic arc cotangent.
-  let acoth : Float -> Float = float_acoth
+    ##
+    let from_int(x : Int) -> Float =
+        float_from_int(x)
 
-  ## Hyperbolic arc tangent.
-  let atanh : Float -> Float = float_atanh
+    ##
+    let max() -> Float =
+        float_max()
 
-  ## Hyperbolic arc secant.
-  let asech : Float -> Float = float_asech
-
-  ## Hyperbolic arc cosecant.
-  let acosech : Float -> Float = float_acosech
-
-  ##
-  let from_int : Float = float_from_int
-
-  ##
-  let max : Float = float_max
-
-  ##
-  let min : Float = float_min
+    ##
+    let min() -> Float =
+        float_min()
 end

--- a/stdlib/list.mox
+++ b/stdlib/list.mox
@@ -1,355 +1,340 @@
 module List exposing
-  ( List(..)
-  , all?
-  , alter_at
-  , any?
-  , collect_map
-  , cons
-  , delete_at
-  , empty?
-  , flatten
-  , fold_left
-  , fold_right
-  , head
-  , insert_at
-  , keep
-  , last
-  , map
-  , maximum
-  , member?
-  , minimum
-  , modify_at
-  , product
-  , range
-  , reject
-  , reverse
-  , singleton
-  , size
-  , sum
-  , tail
-  )
+    ( List(..)
+    , all?
+    , alter_at
+    , any?
+    , collect_map
+    , cons
+    , delete_at
+    , empty?
+    , flatten
+    , fold_left
+    , fold_right
+    , head
+    , insert_at
+    , keep
+    , last
+    , map
+    , maximum
+    , member?
+    , minimum
+    , modify_at
+    , product
+    , range
+    , reject
+    , reverse
+    , singleton
+    , size
+    , sum
+    , tail
+    )
 
-  type List a =
-    | []
-    | a :: List a
+    type List(a) =
+        | Nil
+        | a :: List(a)
 
-  let cons : a -> List a -> List a =
-    \x xs =>
-      todo "not implemented"
+    let cons(xs : List(a), x : a) -> List(a) =
+        x :: xs
 
-  ## Create a list with only one element.
-  ##
-  ## @since 0.1.0
-  ##
-  ## ```
-  ## ➢ List.singleton 42
-  ## [42] : List Int
-  ## ```
-  let singleton : a -> List a =
-    \x =>
-      [x]
+    ## Create a list with only one element.
+    ##
+    ## @since 0.1.0
+    ##
+    ## ```
+    ## ➢ List.singleton(42)
+    ## [42] : List(Int)
+    ## ```
+    let singleton(x : a) -> List(a) =
+        x :: Nil
 
-  ## Test whether a list is empty.
-  ##
-  ## @since 0.1.0
-  ##
-  ## ```
-  ## ➢ List.empty? [42]
-  ## False : Bool
-  ##
-  ## ➢ List.empty? []
-  ## True : Bool
-  ## ```
-  let empty? : List a -> Bool =
-    \list =>
-      match list on
-      | [] => True
-      | _ => False
+    ## Test whether a list is empty.
+    ##
+    ## @since 0.1.0
+    ##
+    ## ```
+    ## ➢ List.empty?([42])
+    ## False : Bool
+    ##
+    ## ➢ List.empty?(Nil)
+    ## True : Bool
+    ## ```
+    let empty?(list : List(a)) -> Bool =
+        match list on
+        | Nil => True
+        | _ => False
 
-  ## Get the size of a list.
-  ##
-  ## @since 0.1.0
-  ##
-  ## ```
-  ## ➢ List.size [42]
-  ## 1 : Int
-  ##
-  ## ➢ List.size []
-  ## 0 : Int
-  ## ```
-  let size : List a -> Int =
-    \list =>
-      fold_left (\acc _ => acc + 1) 0 list
-
-  ## Determine if a list contains a value.
-  ##
-  ## @since 0.1.0
-  ##
-  ## ```
-  ## ➢ List.member? 42 [42]
-  ## True : Bool
-  ##
-  ## ➢ List.member? 0 []
-  ## False : Bool
-  ## ```
-  let member? : a -> List a -> Bool =
-    \elem list =>
-      any (\x => x == elem) list
-
-  ## Determine if all elements satisfy some test.
-  ##
-  ## @since 0.1.0
-  ##
-  ## ```
-  ## ➢ List.all? Math.even? [2, 4, 6]
-  ## True : Bool
-  ## ```
-  let all? : (a -> Bool) -> List a -> Bool =
-    \predicate list =>
-      not (any (not << predicate) list)
-
-  ## Determine if any elements satisfy some test.
-  ##
-  ## @since 0.1.0
-  ##
-  ## ```
-  ## ➢ List.any? (== 4) [2, 4, 6]
-  ## True : Bool
-  ## ```
-  let any? : (a -> Bool) -> List a -> Bool =
-    \predicate list =>
-      match list on
-      | [] => False
-      | x :: xs =>
-          if predicate x then
-            True
-          else
-            any predicate xs
-
-  ## Reduce a list from the left.
-  let fold_left : (a -> b -> b) -> b -> List a -> b =
-    \f acc list =>
-      match list on
-      | [] => acc
-      | x :: xs => fold_left f (f x acc) xs
-
-  ## Reduce a list from the right.
-  let fold_right : (a -> b -> b) -> b -> List a -> b =
-    \f acc list =>
-      todo "not implemented"
-
-  ## Get the first element in a list, or `None` if the list is empty.
-  ##
-  ## @since 0.1.0
-  ##
-  ## ```
-  ## ➢ List.head [1, 2, 3]
-  ## Some 1 : Maybe Int
-  ##
-  ## ➢ List.head ([] : List Int)
-  ## None : Maybe Int
-  ## ```
-  let head : List a -> Maybe a =
-    \list =>
-      match list on
-      | [] => None
-      | x :: _ => Some x
-
-  ## Get all but the first element of a list, or `None` if the list is empty.
-  ##
-  ## @since 0.1.0
-  ##
-  ## ```
-  ## ➢ List.tail [1, 2, 3]
-  ## Some [2, 3] : Maybe (List Int)
-  ##
-  ## ➢ List.tail ([] : List Int)
-  ## None : Maybe (List Int)
-  ## ```
-  let tail : List a -> Maybe (List a) =
-    \list =>
-      match list on
-      | [] => None
-      | _ :: xs => Some xs
-
-  ## Get the last element in a list, or `None` if the list is empty.
-  ##
-  ## @since 0.1.0
-  ##
-  ## ```
-  ## ➢ List.last [1, 2, 3]
-  ## Some 3 : Maybe Int
-  ##
-  ## ➢ List.last ([] : List Int)
-  ## None : Maybe Int
-  ## ```
-  let last : List a -> Maybe a =
-    \list =>
-      match list on
-      | x :: [] => Some x
-      | _ :: xs => last xs
-      | _ => None
-
-  ## Reverse a list.
-  ##
-  ## @since 0.1.0
-  ##
-  ## ```
-  ## ➢ List.reverse [1, 2, 3]
-  ## [3, 2, 1] : List Int
-  ## ```
-  let reverse : List a -> List a =
-    \list =>
-      fold_left cons [] list
-
-  ## Apply a function to every element in a list.
-  ##
-  ## @since 0.1.0
-  ##
-  ## ```
-  ## ➢ List.map (* 2) [1, 2, 3]
-  ## [2, 4, 6] : List Int
-  ## ```
-  let map : (a -> b) -> List a -> List b =
-    \f list =>
-      fold_right (\x acc => cons (f x) acc) [] list
-
-  ## Keep elements that satisfy the given predicate.
-  let keep : (a -> Bool) -> List a -> List a =
-    \predicate list =>
-      fold_right (\x xs =>
-        if predicate x then
-          cons x xs
-        else
-          xs
-      ) [] list
-
-  ## Exclude elements that satisfy the given predicate.
-  let reject : (a -> Bool) -> List a -> List a =
-    \predicate list =>
-      fold_right (\x xs =>
-        if predicate x then
-          xs
-        else
-          cons x xs
-      ) [] list
-
-  ## Applies filter and map simultaneously.
-  let collect_map : (a -> Maybe b) -> List a -> List b =
-    \f list =>
-      fold_right (\mx xs =>
-        match f mx on
-        | None => xs
-        | Some x => cons x xs
-      ) [] list
-
-  ## Create a list of numbers, every element increasing by one.
-  let range : Int -> Int -> List Int =
-    \start end =>
-      range_helper start end []
-
-  let range_helper : Int -> Int -> List Int -> List Int =
-    \start end list =>
-      if start <= end then
-        range_helper start (end - 1) (cons end list)
-      else
+    ## Get the size of a list.
+    ##
+    ## @since 0.1.0
+    ##
+    ## ```
+    ## ➢ List.size([42])
+    ## 1 : Int
+    ##
+    ## ➢ List.size(Nil)
+    ## 0 : Int
+    ## ```
+    let size(list : List(a)) -> Int =
         list
+        |> fold_left(0, fn(acc, _) => acc + 1)
 
-  let insert_at : Int -> a -> List a -> Maybe (List a) =
-    \index elem list =>
-      match list on
-      | x :: xs when index == 0 => Some (elem :: list)
-      | x :: xs =>
-        insert_at (index - 1) elem xs
-        |> Maybe.map (\rest => x :: rest)
-      | _ => None
+    ## Determine if a list contains a value.
+    ##
+    ## @since 0.1.0
+    ##
+    ## ```
+    ## ➢ List.member?([42], 42)
+    ## True : Bool
+    ##
+    ## ➢ List.member?(Nil, 0)
+    ## False : Bool
+    ## ```
+    let member?(list : List(a), elem : a) -> Bool =
+        any?(list, fn(x) => x == elem)
 
-  let delete_at : Int -> List a -> Maybe (List a) =
-    \index list =>
-      match list on
-      | x :: xs when index == 0 => Some xs
-      | x :: xs =>
-        delete_at (index - 1) xs
-        |> Maybe.map (\rest => x :: rest)
-      | _ => None
+    ## Determine if all elements satisfy some test.
+    ##
+    ## @since 0.1.0
+    ##
+    ## ```
+    ## ➢ List.all?([2, 4, 6], fn(x) => Math.even?(x))
+    ## True : Bool
+    ## ```
+    let all?(list : List(a), predicate : (a -> Bool)) -> Bool =
+        not(any?(list, fn(x) => not(predicate(x))))
 
-  let modify_at : Int -> (a -> a) -> List a -> Maybe (List a) =
-    \index f list =>
-      alter_at index (Some << f)
+    ## Determine if any elements satisfy some test.
+    ##
+    ## @since 0.1.0
+    ##
+    ## ```
+    ## ➢ List.any?([2, 4, 6] fn(x) => x == 4)
+    ## True : Bool
+    ## ```
+    let any?(list : List(a), predicate : (a -> Bool)) -> Bool =
+        match list on
+        | Nil => False
+        | x :: xs =>
+            if predicate(x) then
+                True
+            else
+                any?(xs, predicate)
 
-  let alter_at : Int -> (a -> Maybe a) -> List a -> Maybe (List a) =
-    \index f list =>
-      todo "not implemented"
+    ## Reduce a list from the left.
+    let fold_left(list : List(a), acc : b, f : (b, a) -> b) -> b =
+        match list on
+        | Nil => acc
+        | x :: xs => fold_left(xs, f(acc, x), f)
 
-  let flatten : List (List a) -> List a =
-    \lol =>
-      List.and_then identity lol
+    ## Reduce a list from the right.
+    let fold_right(list : List(a), acc : b, f : (a, b) -> b) -> b =
+        match list on
+        | Nil => acc
+        | x :: xs => f(x, fold_right(xs, acc, f))
 
-  ## Find the maximum element in a list.
-  ##
-  ## @since 0.1.0
-  ##
-  ## ```
-  ## ➢ List.maximum [1, 4, 2]
-  ## Some 4 : Maybe Int
-  ##
-  ## ➢ List.maximum [] : Maybe Int
-  ## None : Maybe Int
-  ## ```
-  let maximum : List comparable -> Maybe comparable =
-    \list =>
-      match list on
-      | x :: xs => Some (fold_left max x xs)
-      | _ -> None
+    ## Get the first element in a list, or `None` if the list is empty.
+    ##
+    ## @since 0.1.0
+    ##
+    ## ```
+    ## ➢ List.head([1, 2, 3])
+    ## Some(1) : Maybe(Int)
+    ##
+    ## ➢ List.head(Nil : List(Int))
+    ## None : Maybe(Int)
+    ## ```
+    let head(list : List(a)) -> Maybe(a) =
+        match list on
+        | Nil => None
+        | x :: _ => Some(x)
 
-  ## Find the minimum element in a non-empty list.
-  ##
-  ## @since 0.1.0
-  ##
-  ## ```
-  ## ➢ List.minimum [3, 2, 1]
-  ## Some 1 : Maybe Int
-  ##
-  ## ➢ List.minimum [] : Maybe Int
-  ## None : Maybe Int
-  ## ```
-  let minimum : List comparable -> Maybe comparable =
-    \list =>
-      match list on
-      | x :: xs => Some (fold_left min x xs)
-      | _ => None
+    ## Get all but the first element of a list, or `None` if the list is empty.
+    ##
+    ## @since 0.1.0
+    ##
+    ## ```
+    ## ➢ List.tail([1, 2, 3])
+    ## Some([2, 3]) : Maybe(List(Int))
+    ##
+    ## ➢ List.tail(Nil : List(Int))
+    ## None : Maybe(List(Int))
+    ## ```
+    let tail(list : List(a)) -> Maybe(List(a)) =
+        match list on
+        | Nil => None
+        | _ :: xs => Some(xs)
 
-  ## Get the sum of the list elements.
-  ##
-  ## @since 0.1.0
-  ##
-  ## ```
-  ## ➢ List.sum [3, 2, 1]
-  ## 6.0 : Double
-  ##
-  ## ➢ List.sum []
-  ## 0.0 : Double
-  ## ```
-  let sum : List Number -> Number =
-    \numbers =>
-      fold_left (\num acc =>
-        match num on
-        | Int x => acc +. double_from_int x
-        | Double x => acc +. x
-      ) 0.0 numbers
+    ## Get the last element in a list, or `None` if the list is empty.
+    ##
+    ## @since 0.1.0
+    ##
+    ## ```
+    ## ➢ List.last([1, 2, 3])
+    ## Some(3) : Maybe(Int)
+    ##
+    ## ➢ List.last(Nil : List(Int))
+    ## None : Maybe(Int)
+    ## ```
+    let last(list : List(a)) -> Maybe(a) =
+        match list on
+        | x :: Nil => Some(x)
+        | _ :: xs => last(xs)
+        | _ => None
 
-  ## Get the product of the list elements.
-  ##
-  ## @since 0.1.0
-  ##
-  ## ```
-  ## ➢ List.product [2, 4, 6]
-  ## 48 : Int
-  ##
-  ## ➢ List.product [] : Int
-  ## 1 : Int
-  ## ```
-  let product : List Number -> Number =
-    \numbers =>
-      fold_left (*) 1 numbers
+    ## Reverse a list.
+    ##
+    ## @since 0.1.0
+    ##
+    ## ```
+    ## ➢ List.reverse([1, 2, 3])
+    ## [3, 2, 1] : List(Int)
+    ## ```
+    let reverse(list : List(a)) -> List(a) =
+        fold_left(list, Nil, fn(xs, x) => cons(xs, x))
+
+    ## Apply a function to every element in a list.
+    ##
+    ## @since 0.1.0
+    ##
+    ## ```
+    ## ➢ List.map([1, 2, 3], fn(x) => x * 2)
+    ## [2, 4, 6] : List(Int)
+    ## ```
+    let map(list : List(a), f : (a -> b)) -> List(b) =
+        fold_right(list, Nil, fn(x, acc) => cons(acc, f(x)))
+
+    ## Keep elements that satisfy the given predicate.
+    let keep(list : List(a), predicate : (a -> Bool)) -> List(a) =
+        list
+        |> fold_right(
+            Nil,
+            fn(x, xs) =>
+                if predicate(x) then
+                    cons(xs, x)
+                else
+                    xs
+        )
+
+    ## Exclude elements that satisfy the given predicate.
+    let reject(list : List(a), predicate : (a -> Bool)) -> List(a) =
+        keep(list, fn(x) => not(predicate(x)))
+
+    ## Applies filter and map simultaneously.
+    let collect_map(list : List(a), f : (a -> Maybe(b))) -> List(b) =
+        list
+        |> fold_right(
+            Nil,
+            fn(x, xs) =>
+                match f(x) on
+                | None => xs
+                | Some(y) => cons(xs, y)
+        )
+
+    ## Create a list of numbers, every element increasing by one.
+    let range(start : Int, end : Int) -> List(Int) =
+        if start > end then
+            Nil
+        else
+            cons(range(start + 1, end), start)
+
+    let insert_at(list : List(a), index : Int, elem : a) -> Maybe(List(a)) =
+        match list on
+        | _ when index == 0 => Some(cons(list, elem))
+        | x :: xs =>
+            insert_at(xs, index - 1, elem)
+            |> Maybe.map(fn(rest) => cons(rest, x))
+        | _ => None
+
+    let delete_at(list : List(a), index : Int) -> Maybe(List(a)) =
+        match list on
+        | _ when index == 0 =>
+            match list on
+            | _ :: xs => Some(xs)
+            | _ => None
+        | x :: xs =>
+            delete_at(xs, index - 1)
+            |> Maybe.map(fn(rest) => cons(rest, x))
+        | _ => None
+
+    let modify_at(list : List(a), index : Int, f : (a -> a)) -> Maybe(List(a)) =
+        alter_at(list, index, fn(x) => Some(f(x)))
+
+    let alter_at(list : List(a), index : Int, f : (a -> Maybe(a))) -> Maybe(List(a)) =
+        match list on
+        | _ when index == 0 =>
+            match list on
+            | x :: xs =>
+                f(x)
+                |> Maybe.map(fn(y) => cons(xs, y))
+            | _ => None
+        | x :: xs =>
+            alter_at(xs, index - 1, f)
+            |> Maybe.map(fn(rest) => cons(rest, x))
+        | _ => None
+
+    let flatten(list : List(List(a))) -> List(a) =
+        list
+        |> fold_right(Nil, fn(xs, acc) => fold_right(xs, acc, cons))
+
+    ## Find the maximum element in a list.
+    ##
+    ## @since 0.1.0
+    ##
+    ## ```
+    ## ➢ List.maximum([1, 4, 2])
+    ## Some(4) : Maybe(Int)
+    ##
+    ## ➢ List.maximum(Nil : Maybe(Int))
+    ## None : Maybe(Int)
+    ## ```
+    let maximum(list : List(Comparable)) -> Maybe(Comparable) =
+        match list on
+        | x :: xs => Some(fold_left(xs, x, max))
+        | _ => None
+
+    ## Find the minimum element in a non-empty list.
+    ##
+    ## @since 0.1.0
+    ##
+    ## ```
+    ## ➢ List.minimum([3, 2, 1])
+    ## Some(1) : Maybe(Int)
+    ##
+    ## ➢ List.minimum(Nil : Maybe(Int))
+    ## None : Maybe(Int)
+    ## ```
+    let minimum(list : List(Comparable)) -> Maybe(Comparable) =
+        match list on
+        | x :: xs => Some(fold_left(xs, x, min))
+        | _ => None
+
+    ## Get the sum of the list elements.
+    ##
+    ## @since 0.1.0
+    ##
+    ## ```
+    ## ➢ List.sum([3, 2, 1])
+    ## 6.0 : Double
+    ##
+    ## ➢ List.sum Nil
+    ## 0.0 : Double
+    ## ```
+    let sum(list : List(Number)) -> Number =
+        list
+        |> fold_left(0, fn(acc, x) => acc + x)
+
+    ## Get the product of the list elements.
+    ##
+    ## @since 0.1.0
+    ##
+    ## ```
+    ## ➢ List.product [2, 4, 6]
+    ## 48 : Int
+    ##
+    ## ➢ List.product Nil : Int
+    ## 1 : Int
+    ## ```
+    let product(list : List(Number)) -> Number =
+        list
+        |> fold_left(1, fn(acc, x) => acc * x)
 end

--- a/stdlib/maybe.mox
+++ b/stdlib/maybe.mox
@@ -1,373 +1,387 @@
 module Maybe exposing
-  ( Maybe(..)
-  , and_then
-  , and_then2
-  , and_then3
-  , and_then4
-  , compact
-  , flatten
-  , from_predicate
-  , from_result
-  , map
-  , map2
-  , map3
-  , map4
-  , next
-  , none?
-  , one_of
-  , or
-  , prev
-  , satisfy?
-  , some?
-  , with_default
-  , zip
-  )
+    ( Maybe(..)
+    , and_then
+    , and_then2
+    , and_then3
+    , and_then4
+    , compact
+    , flatten
+    , from_predicate
+    , from_result
+    , map
+    , map2
+    , map3
+    , map4
+    , next
+    , none?
+    , one_of
+    , or
+    , prev
+    , satisfy?
+    , some?
+    , with_default
+    , zip
+    )
 
-  ## Represent values that may or may not exist.
-  ##
-  ## @since 0.1.0
-  ##
-  ## ```
-  ## ➢ Some 42
-  ## Some 42 : Maybe Int
-  ## ```
-  type Maybe a =
-    | None
-    | Some a
+    ## Represent values that may or may not exist.
+    ##
+    ## @since 0.1.0
+    ##
+    ## ```
+    ## ➢ Some(42)
+    ## Some(42) : Maybe(Int)
+    ## ```
+    type Maybe(a) =
+        | None
+        | Some(a)
 
-  ## Returns `True` when the `Maybe` value was constructed with `Some`.
-  ##
-  ## @since 0.1.0
-  ##
-  ## ```
-  ## ➢ Maybe.some? (Some 42)
-  ## True : Bool
-  ## ```
-  let some? : Maybe a -> Bool =
-    \ma =>
-      match ma on
-      | None => False
-      | Some _ => True
+    ## Returns `True` when the `Maybe` value was constructed with `Some`.
+    ##
+    ## @since 0.1.0
+    ##
+    ## ```
+    ## ➢ Maybe.some?(Some(42))
+    ## True : Bool
+    ## ```
+    let some?(ma : Maybe(a)) -> Bool =
+        match ma on
+        | None => False
+        | Some(_) => True
 
-  ## Returns `True` when the `Maybe` value is `None`.
-  ##
-  ## @since 0.1.0
-  ##
-  ## ```
-  ## ➢ Maybe.none? (Some 42)
-  ## False : Bool
-  ## ```
-  let none? : Maybe a -> Bool =
-    \ma =>
-      match ma on
-      | None => True
-      | Some _ => False
+    ## Returns `True` when the `Maybe` value is `None`.
+    ##
+    ## @since 0.1.0
+    ##
+    ## ```
+    ## ➢ Maybe.none?(Some(42))
+    ## False : Bool
+    ## ```
+    let none?(ma : Maybe(a)) -> Bool =
+        match ma on
+        | None => True
+        | Some(_) => False
 
-  ## Unwrap a value while providing a default value.
-  ## Useful for pipelines, otherwise use a `match` expr instead.
-  ## Default value is lazy and will only be computed if the `Maybe` is `None`.
-  ##
-  ## @since 0.1.0
-  ##
-  ## ```
-  ## ➢ Maybe.with_default 100 (Some 42)
-  ## 42 : Int
-  ##
-  ## ➢ Maybe.with_default 100 None
-  ## 100 : Int
-  ## ```
-  let with_default : a -> Maybe a -> a =
-    \default ma =>
-      match ma on
-      | None => default
-      | Some a => a
+    ## Unwrap a value while providing a default value.
+    ## Useful for pipelines, otherwise use a `match` expr instead.
+    ## Default value is lazy and will only be computed if the `Maybe` is `None`.
+    ##
+    ## @since 0.1.0
+    ##
+    ## ```
+    ## ➢ Maybe.with_default(Some(42), 100)
+    ## 42 : Int
+    ##
+    ## ➢ Maybe.with_default(None, 100)
+    ## 100 : Int
+    ## ```
+    let with_default(ma : Maybe(a), default : a) -> a =
+        match ma on
+        | None => default
+        | Some(a) => a
 
-  ## Applies the predicate to a value and lifts the result into a `Maybe`.
-  ##
-  ## @since 0.1.0
-  ##
-  ## ```
-  ## ➢ Maybe.from_predicate ((==) 42) 42
-  ## Some 42 : Maybe Int
-  ## ```
-  let from_predicate : (a -> Bool) -> a -> Maybe a =
-    \predicate x =>
-      if predicate x then
-        Some x
-      else
-        None
+    ## Applies the predicate to a value and lifts the result into a `Maybe`.
+    ##
+    ## @since 0.1.0
+    ##
+    ## ```
+    ## ➢ Maybe.from_predicate(42, fn(x) => x == 42)
+    ## Some(42) : Maybe(Int)
+    ## ```
+    let from_predicate(x : a, predicate : (a -> Bool)) -> Maybe(a) =
+        if predicate(x) then
+            Some(x)
+        else
+            None
 
-  ## Determines if the wrapped value satisfies a predicate.
-  ##
-  ## @since 0.1.0
-  ##
-  ## ```
-  ## ➢ Maybe.satisfy? (\x => x > 10) (Some 15)
-  ## True : Bool
-  ## ```
-  let satisfy? : (a -> Bool) -> Maybe a -> Bool =
-    \predicate ma =>
-      match ma on
-      | None => False
-      | Some a => predicate a
+    ## Determines if the wrapped value satisfies a predicate.
+    ##
+    ## @since 0.1.0
+    ##
+    ## ```
+    ## ➢ Maybe.satisfy?(Some(15), fn(x) => x > 10)
+    ## True : Bool
+    ## ```
+    let satisfy?(ma : Maybe(a), predicate : (a -> Bool)) -> Bool =
+        match ma on
+        | None => False
+        | Some(a) => predicate(a)
 
-  ## Apply a function to value wrapped by a `Maybe`.
-  ## Equivalent of `<$>` from the `Functor` typeclass.
-  ##
-  ## @since 0.1.0
-  ##
-  ## ```
-  ## ➢ Maybe.map ((*) 2) (Some 21)
-  ## Some 42 : Maybe Int
-  ## ```
-  let map : (a -> value) -> Maybe a -> Maybe value =
-    \f ma =>
-      match ma on
-      | None => None
-      | Some a => Some (f a)
+    ## Apply a function to value wrapped by a `Maybe`.
+    ## Equivalent of `<$>` from the `Functor` typeclass.
+    ##
+    ## @since 0.1.0
+    ##
+    ## ```
+    ## ➢ Maybe.map(Some(21), fn(x) => x * 2)
+    ## Some(42) : Maybe(Int)
+    ## ```
+    let map(Maybe(a), (a -> value)) -> Maybe(value) =
+        match ma on
+        | None => None
+        | Some(a) => Some(f(a))
 
-  ## Apply a function if all the arguments are `Some`'s.
-  ##
-  ## @since 0.1.0
-  ##
-  ## ```
-  ## ➢ Maybe.map2 (+) (Some 21) (Some 21)
-  ## Some 42 : Maybe Int
-  ## ```
-  let map2 : (a -> b -> value) -> Maybe a -> Maybe b -> Maybe value =
-    \f ma mb =>
-      match ma on
-      | None => None
-      | Some a =>
-          match mb on
-          | None => None
-          | Some b => Some (f a b)
+    ## Apply a function if all the arguments are `Some`'s.
+    ##
+    ## @since 0.1.0
+    ##
+    ## ```
+    ## ➢ Maybe.map2(Some(21), Some(21), fn(x, y) => x + y)
+    ## Some(42) : Maybe(Int)
+    ## ```
+    let map2(
+        ma : Maybe(a),
+        mb : Maybe(b)
+        f : ((a, b) -> value),
+    ) -> Maybe(value) =
+        match ma on
+        | None => None
+        | Some(a) =>
+            match mb on
+            | None => None
+            | Some(b) => Some(f(a, b))
 
-  ## Apply a function if all the arguments are `Some`'s.
-  ##
-  ## @since 0.1.0
-  ##
-  ## ```
-  ## ➢ Maybe.map3 (+) (Some 14) (Some 14) (Some 14)
-  ## Some 42 : Maybe Int
-  ## ```
-  let map3 : (a -> b -> c -> value) -> Maybe a -> Maybe b -> Maybe c -> Maybe value =
-    \f ma mb mc =>
-      match ma on
-      | None => None
-      | Some a =>
-          match mb on
-          | None => None
-          | Some b =>
-              match mc on
-              | None => None
-              | Some c => Some (f a b c)
+    ## Apply a function if all the arguments are `Some`'s.
+    ##
+    ## @since 0.1.0
+    ##
+    ## ```
+    ## ➢ Some(14) |> Maybe.map3(Some(14), Some(14), fn(x, y, z) => x + y + z)
+    ## Some(42) : Maybe(Int)
+    ## ```
+    let map3(
+        ma : Maybe(a),
+        mb : Maybe(b),
+        mc : Maybe(c),
+        f : ((a, b, c) -> value)
+    ) -> Maybe(value) =
+        match ma on
+        | None => None
+        | Some(a) =>
+            match mb on
+            | None => None
+            | Some(b) =>
+                match mc on
+                | None => None
+                | Some(c) => Some(f(a, b, c))
 
-  ## Apply a function if all the arguments are `Some`'s.
-  ##
-  ## @since 0.1.0
-  let map4 : (a -> b -> c -> d -> value) -> Maybe a -> Maybe b -> Maybe c -> Maybe d -> Maybe value =
-    \f ma mb mc md =>
-      match ma on
-      | None => None
-      | Some a =>
-          match mb on
-          | None => None
-          | Some b =>
-              match mc on
-              | None => None
-              | Some c =>
-                  match md on
-                  | None => None
-                  | Some d => Some (f a b c d)
+    ## Apply a function if all the arguments are `Some`s.
+    ##
+    ## @since 0.1.0
+    ##
+    ## ```
+    ## ➢ Some(10) |> Maybe.map4(Some(11), Some(12), Some(13), fn(w, x, y, z) => w + x + y + z)
+    ## Some(46) : Maybe(Int)
+    ## ```
+    let map4(
+        ma : Maybe(a),
+        mb : Maybe(b),
+        mc : Maybe(c),
+        md : Maybe(d),
+        f : ((a, b, c, d) -> value)
+    ) -> Maybe(value) =
+        match ma on
+        | None => None
+        | Some(a) =>
+            match mb on
+            | None => None
+            | Some(b) =>
+                match mc on
+                | None => None
+                | Some(c) =>
+                    match md on
+                    | None => None
+                    | Some(d) => Some(f(a, b, c, d))
 
-  ## Removes one level of nesting.
-  ##
-  ## @since 0.1.0
-  ##
-  ## ```
-  ## ➢ Maybe.flatten (Some (Some 42))
-  ## Some 42 : Maybe Int
-  ## ```
-  let flatten : Maybe (Maybe a) -> Maybe a =
-    \mma =>
-      match mma on
-      | None => None
-      | Some ma => ma
+    ## Removes one level of nesting.
+    ##
+    ## @since 0.1.0
+    ##
+    ## ```
+    ## ➢ Maybe.flatten(Some(Some(42)))
+    ## Some(42) : Maybe(Int)
+    ## ```
+    let flatten(mma : Maybe(Maybe(a)) -> Maybe(a) =
+        match mma on
+        | None => None
+        | Some(ma) => ma
 
-  ## Combines two `Maybe` values into a tuple, if both are `Some`.
-  ##
-  ## @since 0.1.0
-  ##
-  ## ```
-  ## ➢ Maybe.zip (Some "hello word") (Some 42)
-  ## Some ("hello world", 42) : Maybe (String, Int)
-  ## ```
-  let zip : Maybe a -> Maybe b -> Maybe (a, b) =
-    \ma mb =>
-      match (ma, mb) on
-      | Some (a, b) => Some (a, b)
-      | _ => None
+    ## Combines two `Maybe` values into a tuple, if both are `Some`.
+    ##
+    ## @since 0.1.0
+    ##
+    ## ```
+    ## ➢ Maybe.zip(Some("hello world"), Some(42))
+    ## Some("hello world", 42) : Maybe(String, Int)
+    ## ```
+    let zip(ma : Maybe(a), mb : Maybe(b)) -> Maybe((a, b)) =
+        match (ma, mb) on
+        | (Some(a), Some(b)) => Some((a, b))
+        | _ => None
 
-  ## Equivalent of `<|>` from the `Alternative` typeclass.
-  ##
-  ## @since 0.1.0
-  ##
-  ## ```
-  ## ➢ Maybe.or None (Some 42)
-  ## Some 42 : Maybe Int
-  ## ```
-  let or : Maybe a -> Maybe a -> Maybe a =
-    \ma mb =>
-      match ma on
-      | None => mb
-      | Some _ => ma
+    ## Equivalent of `<|>` from the `Alternative` typeclass.
+    ##
+    ## @since 0.1.0
+    ##
+    ## ```
+    ## ➢ Maybe.or(None, Some(42))
+    ## Some(42) : Maybe(Int)
+    ## ```
+    let or(ma : Maybe(a), mb : Maybe(a)) -> Maybe(a) =
+        match ma on
+        | None => mb
+        | Some(_) => ma
 
-  ## Equivalent of `>>=` from the `Monad` typeclass.
-  ##
-  ## @since 0.1.0
-  ##
-  ## ```
-  ## ➢ Maybe.and_then (\x -> Some (x * 2)) (Some 21)
-  ## Some 42 : Maybe Int
-  ## ```
-  let and_then : (a -> Maybe value) -> Maybe a -> Maybe value =
-    \f ma =>
-      match ma on
-      | None => None
-      | Some a => f a
+    ## Equivalent of `>>=` from the `Monad` typeclass.
+    ##
+    ## @since 0.1.0
+    ##
+    ## ```
+    ## ➢ Maybe.and_then(Some(21), fn(x) => Some(x * 2))
+    ## Some(42) : Maybe(Int)
+    ## ```
+    let and_then(ma : Maybe(a), f : (a -> Maybe(value))) -> Maybe(value) =
+        match ma on
+        | None => None
+        | Some(a) => f(a)
 
-  ## Equivalent of `>>=` from the `Monad` typeclass.
-  ##
-  ## @since 0.1.0
-  let and_then2 : (a -> b -> Maybe value) -> Maybe a -> Maybe b -> Maybe value =
-    \f ma mb =>
-      match ma on
-      | None => None
-      | Some a =>
-          match mb on
-          | None => None
-          | Some b => f a b
+    ## Equivalent of `>>=` from the `Monad` typeclass.
+    ##
+    ## @since 0.1.0
+    let and_then2(
+        ma : Maybe(a),
+        mb : Maybe(b),
+        f : ((a, b) -> Maybe(value))
+    ) -> Maybe(value) =
+        match ma on
+        | None => None
+        | Some(a) =>
+            match mb on
+            | None => None
+            | Some(b) => f(a, b)
 
-  ## Equivalent of `>>=` from the `Monad` typeclass.
-  ##
-  ## @since 0.1.0
-  let and_then3 : (a -> b -> c -> Maybe value) -> Maybe a -> Maybe b -> Maybe c -> Maybe value =
-    \f ma mb mc =>
-      match ma on
-      | None => None
-      | Some a =>
-          match mb on
-          | None => None
-          | Some b =>
-              match mc on
-              | None => None
-              | Some c => f a b c
+    ## Equivalent of `>>=` from the `Monad` typeclass.
+    ##
+    ## @since 0.1.0
+    let and_then3(
+        ma : Maybe(a),
+        mb : Maybe(b),
+        mc : Maybe(c),
+        f : ((a, b, c) -> Maybe(value))
+    ) -> Maybe(value) =
+        match ma on
+        | None => None
+        | Some(a) =>
+            match mb on
+            | None => None
+            | Some(b) =>
+                match mc on
+                | None => None
+                | Some(c) => f(a, b, c)
 
-  ## Equivalent of `>>=` from the `Monad` typeclass.
-  ##
-  ## @since 0.1.0
-  let and_then4 : (a -> b -> c -> d -> Maybe value) -> Maybe a -> Maybe b -> Maybe c -> Maybe d -> Maybe value =
-    \f ma mb mc md =>
-      match ma on
-      | None => None
-      | Some a =>
-          match mb on
-          | None => None
-          | Some b =>
-              match mc on
-              | None => None
-              | Some c =>
-                  match md on
-                  | None => None
-                  | Some d => f a b c d
+    ## Equivalent of `>>=` from the `Monad` typeclass.
+    ##
+    ## @since 0.1.0
+    let and_then4(
+        ma : Maybe(a),
+        mb : Maybe(b),
+        mc : Maybe(c),
+        md : Maybe(d),
+        f : ((a, b, c, d) -> Maybe(value))
+    ) -> Maybe(value) =
+        match ma on
+        | None => None
+        | Some(a) =>
+            match mb on
+            | None => None
+            | Some(b) =>
+                match mc on
+                | None => None
+                | Some(c) =>
+                    match md on
+                    | None => None
+                    | Some(d) => f(a, b, c, d)
 
-  ## Try a list of functions against a value. Return the value of the first call that succeeds (returns `Some`).
-  ##
-  ## @since 0.1.0
-  ##
-  ## ```
-  ## ➢ "42.0" |> Maybe.one_of [String.to_int, String.to_float]
-  ## Some 42.0 : Maybe Float
-  ## ```
-  let one_of : List (a -> Maybe b) -> a -> Maybe b =
-    \fmbs default =>
-      match fmbs on
-      | [] => None
-      | fmb :: rest =>
-          match fmb default on
-          | None => one_of rest default
-          | Some b => Some b
+    ## Try a list of functions against a value. Return the value of the first call that succeeds (returns `Some`).
+    ##
+    ## @since 0.1.0
+    ##
+    ## ```
+    ## ➢ Maybe.one_of("42.0", [String.to_int, String.to_float])
+    ## Some(42.0) : Maybe(Float)
+    ## ```
+    let one_of(default : a, fmbs : List((a -> Maybe(b)))) -> Maybe(b) =
+        match fmbs on
+        | Nil => None
+        | fmb :: rest =>
+            match fmb(default) on
+            | None => one_of(default, rest)
+            | Some(b) => Some(b)
 
-  ## Removes `None` values from a collection while unwrapping all present values.
-  ##
-  ## @since 0.1.0
-  ##
-  ## ```
-  ## ➢ Maybe.compact [Some 1, None, Some 2]
-  ## [1, 2] : List Int
-  ## ```
-  let compact : List (Maybe a) -> List a =
-    \maybes =>
-      List.collect_map identity maybes
+    ## Removes `None` values from a collection while unwrapping all present values.
+    ##
+    ## @since 0.1.0
+    ##
+    ## ```
+    ## ➢ Maybe.compact([Some(1), None, Some(2)])
+    ## [1, 2] : List(Int)
+    ## ```
+    let compact(maybes : List(Maybe(a))) -> List(a) =
+        List.collect_map(identity, maybes)
 
-  ## Take two `Maybe` values. If the first one equals `None`, return `None`. Otherwise return the second value.
-  ## Allows for chaining `Maybe` computations, with a possible "early return" in case of `None`.
-  ## Equivalent of `*>` from the `Applicative` typeclass.
-  ##
-  ## @since 0.1.0
-  ##
-  ## ```
-  ## ➢ Maybe.next (Some 1) (Some 2)
-  ## Some 2 : Maybe Int
-  ##
-  ## ➢ Maybe.next None (Some 2)
-  ## None : Maybe Int
-  ##
-  ## ➢ Maybe.next (Some 1) None
-  ## None : Maybe Int
-  ## ```
-  let next : Maybe a -> Maybe b -> Maybe b =
-    \ma mb =>
-      match ma on
-      | None => None
-      | Some _ => mb
+    ## Take two `Maybe` values. If the first one equals `None`, return `None`. Otherwise return the second value.
+    ## Allows for chaining `Maybe` computations, with a possible "early return" in case of `None`.
+    ## Equivalent of `*>` from the `Applicative` typeclass.
+    ##
+    ## @since 0.1.0
+    ##
+    ## ```
+    ## ➢ Maybe.next(Some(1), Some(2))
+    ## Some(2) : Maybe(Int)
+    ##
+    ## ➢ Maybe.next(None, Some(2))
+    ## None : Maybe(Int)
+    ##
+    ## ➢ Maybe.next(Some(1), None)
+    ## None : Maybe(Int)
+    ## ```
+    let next(ma : Maybe(a), mb : Maybe(b)) -> Maybe(b) =
+        match ma on
+        | None => None
+        | Some(_) => mb
 
-  ## Take two `Maybe` values. If the second one equals `None`, return `None`. Otherwise return the first value.
-  ## Equivalent of `<*` from the `Applicative` typeclass.
-  ##
-  ## @since 0.1.0
-  ##
-  ## ```
-  ## ➢ Maybe.prev (Some 1) (Some 2)
-  ## Some 1 : Maybe Int
-  ##
-  ## ➢ Maybe.prev None (Some 2)
-  ## None : Maybe Int
-  ##
-  ## ➢ Maybe.prev (Some 1) None
-  ## None : Maybe Int
-  ## ```
-  let prev : Maybe a -> Maybe b -> Maybe a =
-    \ma mb =>
-      match mb on
-      | None => None
-      | Some _ => ma
+    ## Take two `Maybe` values. If the second one equals `None`, return `None`. Otherwise return the first value.
+    ## Equivalent of `<*` from the `Applicative` typeclass.
+    ##
+    ## @since 0.1.0
+    ##
+    ## ```
+    ## ➢ Maybe.prev(Some(1), Some(2))
+    ## Some(1) : Maybe(Int)
+    ##
+    ## ➢ Maybe.prev(None, Some(2))
+    ## None : Maybe(Int)
+    ##
+    ## ➢ Maybe.prev(Some(1), None)
+    ## None : Maybe(Int)
+    ## ```
+    let prev(ma : Maybe(a), mb : Maybe(b)) -> Maybe(a) =
+        match mb on
+        | None => None
+        | Some(_) => ma
 
-  ## Converts a `Result` to `Maybe`, dropping the error.
-  ##
-  ## @since 0.1.0
-  ##
-  ## ```
-  ## ➢ Maybe.from_result (Ok 42) : Result String Int
-  ## Some 42 : Maybe Int
-  ##
-  ## ➢ Maybe.from_result (Err "uh oh!") : Result String Int
-  ## None : Maybe Int
-  ## ```
-  let from_result : Result e a -> Maybe a =
-    \result =>
-      match result on
-      | Err _ => None
-      | Ok a => Some a
+    ## Converts a `Result` to `Maybe`, dropping the error.
+    ##
+    ## @since 0.1.0
+    ##
+    ## ```
+    ## ➢ Maybe.from_result(Ok(42))
+    ## Some(42) : Maybe(Int)
+    ##
+    ## ➢ Maybe.from_result(Err("uh oh!"))
+    ## None : Maybe(Int)
+    ## ```
+    let from_result(result : Result(e, a)) -> Maybe(a) =
+        match result on
+        | Err(_) => None
+        | Ok(a) => Some(a)
 end

--- a/stdlib/non_empty.mox
+++ b/stdlib/non_empty.mox
@@ -1,83 +1,68 @@
 module NonEmpty where
-  ( NonEmpty
-  , drop_left
-  , drop_while
-  , from_list
-  , head
-  , intersperse
-  , map
-  , repeate
-  , reverse
-  , singleton
-  , size
-  , sort
-  , tail
-  , take_left
-  , take_while
-  , to_list
-  )
+    ( NonEmpty
+    , drop_left
+    , drop_while
+    , from_list
+    , head
+    , intersperse
+    , map
+    , repeate
+    , reverse
+    , singleton
+    , size
+    , sort
+    , tail
+    , take_left
+    , take_while
+    , to_list
+    )
 
-  type NonEmpty a =
-    | [a]
-    | a :: List a
+    type NonEmpty(a) =
+        | [a]
+        | a :: List(a)
 
-  let singleton : a -> NonEmpty a =
-    \x =>
-      todo "not implemented"
+    let singleton(x : a) -> NonEmpty(a) =
+        todo("not implemented")
 
-  let head : NonEmpty a -> a =
-    \list =>
-      todo "not implemented"
+    let head(list : NonEmpty(a)) -> a =
+        todo("not implemented")
 
-  let tail : NonEmpty a -> a =
-    \list =>
-      todo "not implemented"
+    let tail(list : NonEmpty(a)) -> a =
+        todo("not implemented")
 
-  let map : (a -> b) -> NonEmpty a -> NonEmpty b =
-    \f list =>
-      todo "not implemented"
+    let map(f : (a -> b), list : NonEmpty(a)) -> NonEmpty(b) =
+        todo("not implemented")
 
-  let intersperse : a -> NonEmpty a -> NonEmpty a =
-    \x list =>
-      todo "not implemented"
+    let intersperse(x : a, list : NonEmpty(a)) -> NonEmpty(a) =
+        todo("not implemented")
 
-  let size : NonEmpty a -> Int =
-    \list =>
-      todo "not implemented"
+    let size(list : NonEmpty(a)) -> Int =
+        todo("not implemented")
 
-  let sort : NonEmpty comparable -> NonEmpty comparable =
-    \list =>
-      todo "not implemented"
+    let sort(list : NonEmpty(comparable)) -> NonEmpty(comparable) =
+        todo("not implemented")
 
-  let reverse : NonEmpty a -> NonEmpty a =
-    \list =>
-      todo "not implemented"
+    let reverse(list : NonEmpty(a)) -> NonEmpty(a) =
+        todo("not implemented")
 
-  let repeat : a -> NonEmpty a =
-    \x =>
-      todo "not implemented"
+    let repeat(x : a) -> NonEmpty(a) =
+        todo("not implemented")
 
-  let take_left : Int -> NonEmpty a -> [a] =
-    \n list =>
-      todo "not implemented"
+    let take_left(n : Int, list : NonEmpty(a)) -> List(a) =
+        todo("not implemented")
 
-  let drop_left : Int -> NonEmpty a -> [a] =
-    \n list =>
-      todo "not implemented"
+    let drop_left(n : Int, list : NonEmpty(a)) -> List(a) =
+        todo("not implemented")
 
-  let take_while : (a -> Bool) -> NonEmpty a -> [a] =
-    \predicate list =>
-      todo "not implemented"
+    let take_while(predicate : (a -> Bool), list : NonEmpty(a)) -> List(a) =
+        todo("not implemented")
 
-  let drop_while : (a -> Bool) -> NonEmpty a -> [a] =
-    \predicate list =>
-      todo "not implemented"
+    let drop_while(predicate : (a -> Bool), list : NonEmpty(a)) -> List(a) =
+        todo("not implemented")
 
-  let from_list : [a] -> Maybe (NonEmpty a) =
-    \list =>
-      todo "not implemented"
+    let from_list(list : List(a)) -> Maybe(NonEmpty(a)) =
+        todo("not implemented")
 
-  let to_list : NonEmpty a -> [a] =
-    \list =>
-      todo "not implemented"
+    let to_list(list : NonEmpty(a)) -> List(a) =
+        todo("not implemented")
 end

--- a/stdlib/prelude.mox
+++ b/stdlib/prelude.mox
@@ -1,292 +1,273 @@
 module Prelude exposing
-  ( abs
-  , always
-  , even?
-  , gcd
-  , identity
-  , lcm
-  , max
-  , min
-  , negate
-  , odd?
-  , pow
-  , (|>)
-  , (<|)
-  , (||)
-  , (&&)
-  , (^)
-  , (==)
-  , (/=)
-  , (<)
-  , (>)
-  , (<=)
-  , (>=)
-  , (..)
-  , (<>)
-  , (::)
-  , (+)
-  , (-)
-  , (+.)
-  , (-.)
-  , (.|.)
-  , (.^.)
-  , (*)
-  , (/)
-  , (*.)
-  , (/.)
-  , (.&.)
-  , (.>>.)
-  , (.<<.)
-  , (^^)
-  , (**)
-  , (.~.)
-  , (<<)
-  , (>>)
-  )
+    ( abs
+    , always
+    , even?
+    , gcd
+    , identity
+    , lcm
+    , max
+    , min
+    , negate
+    , odd?
+    , pow
+    , (|>)
+    , (||)
+    , (&&)
+    , (^)
+    , (==)
+    , (/=)
+    , (<)
+    , (>)
+    , (<=)
+    , (>=)
+    , (..)
+    , (<>)
+    , (+)
+    , (-)
+    , (+.)
+    , (-.)
+    , (.|.)
+    , (.^.)
+    , (*)
+    , (/)
+    , (*.)
+    , (/.)
+    , (.&.)
+    , (.>>.)
+    , (.<<.)
+    , (^^)
+    , (**)
+    , (.~.)
+    )
 
-  include Boolean
-  include Compareable
+    include Boolean
+    include Compareable
 
-  foreign int_add : Int -> Int -> Int = "zig_int_add"
-  foreign int_sub : Int -> Int -> Int = "zig_int_sub"
-  foreign int_mul : Int -> Int -> Int = "zig_int_mul"
-  foreign int_div : Int -> Int -> Int = "zig_int_div"
-  foreign int_pow : Int -> Int -> Int = "zig_int_pow"
-  foreign int_min : Int -> Int -> Int = "zig_int_min"
-  foreign int_max : Int -> Int -> Int = "zig_int_max"
+    foreign int_add(x : Int, y : Int) -> Int = "zig_int_add"
+    foreign int_sub(x : Int, y : Int) -> Int = "zig_int_sub"
+    foreign int_mul(x : Int, y : Int) -> Int = "zig_int_mul"
+    foreign int_div(x : Int, y : Int) -> Int = "zig_int_div"
+    foreign int_pow(x : Int, y : Int) -> Int = "zig_int_pow"
+    foreign int_min(x : Int, y : Int) -> Int = "zig_int_min"
+    foreign int_max(x : Int, y : Int) -> Int = "zig_int_max"
 
-  # HELPFUL FUNCTIONS
+    # =============================
+    #      HELPFUL FUNCTIONS
+    # =============================
 
-  ## ??
-  ##
-  ## @since 0.1.0
-  ##
-  ## ```
-  ## ➢ identity 42
-  ## 42
-  ## ```
-  let identity : a -> a =
-    \a =>
-      a
+    ## ??
+    ##
+    ## @since 0.1.0
+    ##
+    ## ```
+    ## ➢ identity(42)
+    ## 42 : Int
+    ## ```
+    let identity(x : a) -> a =
+        x
 
-  ## ??
-  ##
-  ## @since 0.1.0
-  ##
-  ## ```
-  ## ➢ always 42 0
-  ## 42 : Int
-  ## ```
-  let always : a -> b -> a =
-    \a _ =>
-      a
+    ## ??
+    ##
+    ## @since 0.1.0
+    ##
+    ## ```
+    ## ➢ always(42, 0)
+    ## 42 : Int
+    ## ```
+    let always(x : a, _ : b) -> a =
+        x
 
-  ## Reverse-application operator: `x |> f |> g` is exactly equivalent to `g (f (x))`
-  let ap_right : a -> (a -> b) -> b =
-    \x f =>
-      f x
+    ## Reverse-application operator: `x |> f |> g` is exactly equivalent to `g(f(x))`
+    let ap_right(x : a, f : (a -> b)) -> b =
+        f(x)
 
-  ## Application operator: `g <| f <| x` is exactly equivalent to `g (f (x))`
-  let ap_left : (a -> b) -> a -> b =
-    \f x =>
-      f x
+    # =============================
+    #      INTEGER ARITHMETIC
+    # =============================
 
-  let compose_left : (b -> c) -> (a -> b) -> (a -> c) =
-    \g f x =>
-      g (f x)
+    ## Calculates the addition of two integers.
+    ##
+    ## @since 0.1.0
+    ##
+    ## ```
+    ## ➢ add(40, 2)
+    ## 42 : Int
+    ## ```
+    let add(x : Int, y : Int) -> Int =
+        int_add(x, y)
 
-  let compose_right : (a -> b) -> (b -> c) -> (a -> c) =
-    \f g x =>
-      g (f x)
+    ## Calculates the subtraction of two integers.
+    ##
+    ## @since 0.1.0
+    ##
+    ## ```
+    ## ➢ sub(44, 2)
+    ## 42 : Int
+    ## ```
+    let sub(x : Int, y : Int) -> Int =
+        int_sub(x, y)
 
-  # INTEGER ARITHMETIC
+    ## Calculates the multiplication of two integers.
+    ##
+    ## @since 0.1.0
+    ##
+    ## ```
+    ## ➢ mul(2, 21)
+    ## 42 : Int
+    ## ```
+    let mul(x : Int, y : Int) -> Int =
+        int_mul(x, y)
 
-  ## Calculates the addition of two integers.
-  ##
-  ## @since 0.1.0
-  ##
-  ## ```
-  ## ➢ add 40 2
-  ## 42 : Int
-  ## ```
-  let add : Int -> Int -> Int = int_add
+    ## Calculates the division of two integers.
+    ##
+    ## @since 0.1.0
+    ##
+    ## ```
+    ## ➢ div(2, 84)
+    ## 42 : Int
+    ## ```
+    let div(x : Int, y : Int) -> Int =
+        int_div(x, y)
 
-  ## Calculates the subtraction of two integers.
-  ##
-  ## @since 0.1.0
-  ##
-  ## ```
-  ## ➢ sub 44 2
-  ## 42 : Int
-  ## ```
-  let sub : Int -> Int -> Int = int_sub
+    ## Determines if a number is even.
+    ##
+    ## @since 0.1.0
+    ##
+    ## ```
+    ## ➢ even?(4)
+    ## True : Bool
+    ## ```
+    let even?(n : Int) -> Bool =
+        mod(n, 2) == 0
 
-  ## Calculates the multiplication of two integers.
-  ##
-  ## @since 0.1.0
-  ##
-  ## ```
-  ## ➢ mul 2 21
-  ## 42 : Int
-  ## ```
-  let mul : Int -> Int -> Int = int_mul
+    ## Determines if a number is odd.
+    ##
+    ## @since 0.1.0
+    ##
+    ## ```
+    ## ➢ odd?(3)
+    ## True : Bool
+    ## ```
+    let odd?(n : Int) -> Bool =
+        mod(n, 2) /= 0
 
-  ## Calculates the division of two integers.
-  ##
-  ## @since 0.1.0
-  ##
-  ## ```
-  ## ➢ div 2 84
-  ## 42 : Int
-  ## ```
-  let div : Int -> Int -> Int = int_div
+    ## Returns the greatest common divisor of the two integers.
+    ##
+    ## @since 0.1.0
+    ##
+    ## ```
+    ## ➢ gcd(8, 12)
+    ## 4 : Int
+    ## ```
+    let gcd(a : Int, b : Int) -> Int =
+        if b == 0 then
+            a
+        else
+            gcd(b, mod(a, b))
 
-  ## Determines if a number is even.
-  ##
-  ## @since 0.1.0
-  ##
-  ## ```
-  ## ➢ even? 4
-  ## True : Bool
-  ## ```
-  let even? : Int -> Bool =
-    \n =>
-      mod n 2 == 0
+    ## Determines the smallest positive integer that is divisible by both *a* and *b*
+    ##
+    ## @since 0.1.0
+    ##
+    ## ```
+    ## ➢ lcm(21, 6)
+    ## 42 : Int
+    ## ```
+    let lcm(a : Int, b : Int) -> Int =
+        abs(a * b) / gcd(a, b)
 
-  ## Determines if a number is odd.
-  ##
-  ## @since 0.1.0
-  ##
-  ## ```
-  ## ➢ odd? 3
-  ## True : Bool
-  ## ```
-  let odd? : Int -> Bool =
-    \n =>
-      mod n 2 /= 0
+    ## Calculates the value of *a* to the power of *b*.
+    ##
+    ## @since 0.1.0
+    ##
+    ## ```
+    ## ➢ pow(9, 3)
+    ## 729 : Int
+    ## ```
+    let pow(x : Int, y : Int) -> Int =
+        int_pow(x, y)
 
-  ## Returns the greatest common divisor of the two integers.
-  ##
-  ## @since 0.1.0
-  ##
-  ## ```
-  ## ➢ gcd 8 12
-  ## 4 : Int
-  ## ```
-  let gcd : Int -> Int -> Int =
-    \a b =>
-      if b == 0 then
-        a
-      else
-        gcd b (mod a b)
+    ## Integer remainder.
+    ##
+    ## @since 0.1.0
+    ##
+    ## ```
+    ## ➢ mod(42, 8)
+    ## 2 : Int
+    ## ```
+    let mod(a : Int, b : Int) -> Int =
+        a - b * (a / b)
 
-  ## Determines the smallest positive integer that is divisible by both *a* and *b*
-  ##
-  ## @since 0.1.0
-  ##
-  ## ```
-  ## ➢ lcm 21 6
-  ## 42 : Int
-  ## ```
-  let lcm : Int -> Int -> Int =
-    \a b =>
-      abs (a * b) / gcd a b
-
-  ## Calculates the value of *a* to the power of *b*.
-  ##
-  ## @since 0.1.0
-  ##
-  ## ```
-  ## ➢ pow 9 3
-  ## 729 : Int
-  ## ```
-  let pow : Int -> Int -> Int = int_pow
-
-  ## Integer remainder.
-  ##
-  ## @since 0.1.0
-  ##
-  ## ```
-  ## ➢ mod 42 8
-  ## 2 : Int
-  ## ```
-  let mod : Int -> Int -> Int =
-    \a b =>
-      a - b * (a / b)
-
-  ## Negate a number.
-  ##
-  ## @since 0.1.0
-  ##
-  ## ```
-  ## ➢ negate 42
-  ## -42 : Int
-  ## ```
-  let negate : Int -> Int =
-    \n =>
-      -n
-
-  ## Get the absolute value of a number.
-  ##
-  ## @since 0.1.0
-  ##
-  ## ```
-  ## ➢ abs -42
-  ## 42 : Int
-  ## ```
-  let abs : Int -> Int =
-    \n =>
-      if x < 0 then
+    ## Negate a number.
+    ##
+    ## @since 0.1.0
+    ##
+    ## ```
+    ## ➢ negate(42)
+    ## -42 : Int
+    ## ```
+    let negate(n : Int) -> Int =
         -n
-      else
-        n
 
-  ## Clamps a number within a given range.
-  ##
-  ## @since 0.1.0
-  ##
-  ## ```
-  ## ➢ clamp 100 200 99
-  ## 100 : Int
-  ## ```
-  let clamp : Int -> Int -> Int -> Int =
-    \low high n =>
-      if n < low then
-        low
-      else if n > high then
-        high
-      else
-        n
+    ## Get the absolute value of a number.
+    ##
+    ## @since 0.1.0
+    ##
+    ## ```
+    ## ➢ abs(-42)
+    ## 42 : Int
+    ## ```
+    let abs(n : Int) -> Int =
+        if x < 0 then
+            -n
+        else
+            n
 
-  let max : Int = int_max
+    ## Clamps a number within a given range.
+    ##
+    ## @since 0.1.0
+    ##
+    ## ```
+    ## ➢ clamp(100, 200, 99)
+    ## 100 : Int
+    ## ```
+    let clamp(low : Int, high : Int, n : Int) -> Int =
+        if n < low then
+            low
+        else if n > high then
+            high
+        else
+            n
 
-  let min : Int = int_min
+    let max() -> Int =
+        int_max()
 
-  # INFIX OPERATORS
+    let min() -> Int =
+        int_min()
 
-  infixr 2  (<|)  = pipe_left
-  infixl 2  (|>)  = pipe_right
-  infixr 3  (||)  = logical_or
-  infixr 4  (&&)  = logical_and
-  infixn 5  (==)  = eq
-  infixn 5  (/=)  = neq
-  infixn 5  (<)   = lt
-  infixn 5  (>)   = gt
-  infixn 5  (<=)  = lte
-  infixn 5  (>=)  = gte
-  infixr 6  (++)  = List.concat
-  infixr 7  (<>)  = Str.concat
-  infixr 8  (..)  = range
-  infixr 9  (::)  = cons
-  infixl 10 (<<)  = compose_left
-  infixr 10 (>>)  = compose_right
-  infixl 11 (+)   = add
-  infixl 11 (-)   = sub
-  infixl 11 (+.)  = Float.add
-  infixl 11 (-.)  = Float.sub
-  infixl 12 (*)   = mul
-  infixl 12 (/)   = div
-  infixl 12 (*.)  = Float.mul
-  infixl 12 (/.)  = Float.div
-  infixl 13 (**)  = Float.pow
+    # =============================
+    #        INFIX OPERATORS
+    # =============================
+
+    infixl 2  (|>)  = pipe_right
+    infixr 3  (||)  = logical_or
+    infixr 4  (&&)  = logical_and
+    infixn 5  (==)  = eq
+    infixn 5  (/=)  = neq
+    infixn 5  (<)   = lt
+    infixn 5  (>)   = gt
+    infixn 5  (<=)  = lte
+    infixn 5  (>=)  = gte
+    infixr 6  (++)  = List.concat
+    infixr 7  (<>)  = Str.concat
+    infixr 8  (..)  = range
+    infixl 9  (+)   = add
+    infixl 9  (-)   = sub
+    infixl 9  (+.)  = Float.add
+    infixl 9  (-.)  = Float.sub
+    infixl 10 (*)   = mul
+    infixl 10 (/)   = div
+    infixl 10 (*.)  = Float.mul
+    infixl 10 (/.)  = Float.div
+    infixl 11 (**)  = Float.pow
 end

--- a/stdlib/result.mox
+++ b/stdlib/result.mox
@@ -1,161 +1,167 @@
 module Result exposing
-  ( Result(..)
-  , and_then
-  , combine
-  , compact
-  , err?
-  , from_maybe
-  , map
-  , map2
-  , map3
-  , map4
-  , map_error
-  , ok?
-  , or
-  , parition
-  , with_default
-  )
+    ( Result(..)
+    , and_then
+    , combine
+    , compact
+    , err?
+    , from_maybe
+    , map
+    , map2
+    , map3
+    , map4
+    , map_error
+    , ok?
+    , or
+    , parition
+    , with_default
+    )
 
-  ## A `Result` is either `Ok` meaning the computation succeeded,
-  ## or it is an `Err` meaning that there was some failure.
-  ##
-  ## @since 0.1.0
-  ##
-  ## ```
-  ## ➢ Ok 42 : Result String Int
-  ## Ok 42 : Result String Int
-  ## ```
-  type Result e a =
-    | Err e
-    | Ok a
+    ## A `Result` is either `Ok` meaning the computation succeeded,
+    ## or it is an `Err` meaning that there was some failure.
+    ##
+    ## @since 0.1.0
+    ##
+    ## ```
+    ## ➢ Ok(42) : Result(String, Int)
+    ## Ok(42) : Result(String, Int)
+    ## ```
+    type Result(e, a) =
+        | Err(e)
+        | Ok(a)
 
-  ## Check whether the result is `Ok` without unwrapping it.
-  let ok? : Result e a -> Bool =
-    \ra =>
-      match ra on
-      | Err _ => False
-      | Ok _ => True
+    ## Check whether the result is `Ok` without unwrapping it.
+    let ok?(ra : Result(e, a)) -> Bool =
+        match ra on
+        | Err(_) => False
+        | Ok(_) => True
 
-  ## Check whether the result is `Err` without unwrapping it.
-  let err? : Result e a -> Bool =
-    \ra =>
-      match ra on
-      | Err _  => True
-      | Ok _  => False
+    ## Check whether the result is `Err` without unwrapping it.
+    let err?(ra : Result(e, a)) -> Bool =
+        match ra on
+        | Err(_)  => True
+        | Ok(_)  => False
 
-  let with_default : a -> Result e a -> a =
-    \default ra =>
-      match ra on
-      | Err _ => default
-      | Ok a => a
+    let with_default(ra : Result(e, a), default : a) -> a =
+        match ra on
+        | Err(_) => default
+        | Ok(a) => a
 
-  let map : (a -> value) -> Result e a -> Result e value =
-    \f ra =>
-      match ra on
-      | Err e => Err e
-      | Ok a => Ok (f a)
+    let map(ra : Result(e, a), f : (a -> value)) -> Result(e, value) =
+        match ra on
+        | Err(e) => Err(e)
+        | Ok(a) => Ok(f(a))
 
-  let map2 : (a -> b -> value) -> Result e a -> Result e b -> Result e value =
-    \f ra rb =>
-      match ra on
-      | Err e => Err e
-      | Ok a =>
-          match rb on
-          | Err e => Err e
-          | Ok b => Ok (f a b)
+    let map2(
+        ra : Result(e, a),
+        rb : Result(e, b),
+        f : ((a, b) -> value)
+    ) -> Result(e, value) =
+        match ra on
+        | Err(e) => Err(e)
+        | Ok(a) =>
+            match rb on
+            | Err(e) => Err(e)
+            | Ok(b) => Ok(f(a, b))
 
-  let map3 : (a -> b -> c -> value) -> Result e a -> Result e b -> Result e c -> Result e value =
-    \f ra rb rc =>
-      match ra on
-      | Err e => Err e
-      | Ok a =>
-          match rb on
-          | Err e => Err e
-          | Ok b =>
-              match rc on
-              | Err e => Err e
-              | Ok c => Ok (f a b c)
+    let map3(
+        ra : Result(e, a),
+        rb : Result(e, b),
+        rc : Result(e, c),
+        f : ((a, b, c) -> value)
+    ) -> Result(e, value) =
+        match ra on
+        | Err(e) => Err(e)
+        | Ok(a) =>
+            match rb on
+            | Err(e) => Err(e)
+            | Ok(b) =>
+                match rc on
+                | Err(e) => Err(e)
+                | Ok(c) => Ok(f(a, b, c))
 
-  let map4 : (a -> b -> c -> d -> value) -> Result e a -> Result e b -> Result e c -> Result e d -> Result e value =
-    \f ra rb rc rd =>
-      match ra on
-      | Err e => Err e
-      | Ok a =>
-          match rb on
-          | Err e => Err e
-          | Ok b =>
-              match rc on
-              | Err e => Err e
-              | Ok c =>
-                  match rd on
-                  | Err e => Err e
-                  | Ok d => Ok (f a b c d)
 
-  let and_then : (a -> Result e b) -> Result e a -> Result e b =
-    \f ra =>
-      match ra on
-      | Err e => Err e
-      | Ok a => f a
+    let map4(
+        ra : Result(e, a),
+        rb : Result(e, b),
+        rc : Result(e, c),
+        rd : Result(e, d),
+        f : ((a, b, c, d) -> value)
+    ) -> Result(e, value) =
+        match ra on
+        | Err(e) => Err(e)
+        | Ok(a) =>
+            match rb on
+            | Err(e) => Err(e)
+            | Ok(b) =>
+                match rc on
+                | Err(e) => Err(e)
+                | Ok(c) =>
+                    match rd on
+                    | Err(e) => Err(e)
+                    | Ok(d) => Ok(f(a, b, c, d))
 
-  let or : Result e a -> Result e a -> Result e a =
-    \ra rb =>
-      match ra on
-      | Err _ => rb
-      | Ok _ => ra
+    let and_then(ra : Result(e, a), f : (a -> Result(e, b))) -> Result(e, b) =
+        match ra on
+        | Err(e) => Err(e)
+        | Ok(a) => f(a)
 
-  let map_error : (x -> y) -> Result x a -> Result y a =
-    \f ra =>
-      match ra on
-      | Err e => Err (f e)
-      | Ok a => Ok a
+    let or(ra : Result(e, a), rb : Result(e, a)) -> Result(e, a) =
+        match ra on
+        | Err(_) => rb
+        | Ok(_) => ra
 
-  let from_maybe : e -> Maybe a -> Result e a =
-    \e ma =>
-      match ma on
-      | None => Err e
-      | Some a => Ok a
+    let map_error(ra : Result(x, a), f : (x -> y)) -> Result(y, a) =
+        match ra on
+        | Err(e) => Err(f(e))
+        | Ok(a) => Ok(a)
 
-  ## Combine a list of results into a single result (holding a list).
-  ##
-  ## @since 0.1.0
-  ##
-  ## ```
-  ## ➢ Result.compact [Ok 1, Ok 2]
-  ## [1, 2] : List Int
-  ## ```
-  let compact : List (Result e a) -> List a =
-    \results =>
-      List.collect_map identity results
+    let from_maybe(ma : Maybe(a), err : e) -> Result(e, a) =
+        match ma on
+        | None => Err(err)
+        | Some(a) => Ok(a)
 
-  ## Combine a list of results into a single result (holding a list).
-  ## Also known as `sequence` on lists.
-  ##
-  ## @since 0.1.0
-  ##
-  ## ```
-  ## ➢ Result.combine [Ok 1, Ok 2]
-  ## Ok [1, 2] : List Int
-  ## ```
-  let combine : List (Result e a) -> Result e (List a) =
-    \results =>
-      List.fold_right (map2 (::)) (Ok []) results
+    ## Combine a list of results into a single result (holding a list).
+    ##
+    ## @since 0.1.0
+    ##
+    ## ```
+    ## ➢ Result.compact([Ok(1), Ok(2)])
+    ## [1, 2] : List(Int)
+    ## ```
+    let compact(results : List(Result(e, a)) -> List(a) =
+        List.collect_map(results, identity)
 
-  ## Partition a list of Results into two lists of values (successes and failures).
-  ##
-  ## @since 0.1.0
-  ##
-  ## ```
-  ## ➢ Result.paritition [Ok 1, Err "uh no!", Ok 2]
-  ## (["uh oh!"], [1, 2]) : (List String, List Int)
-  ## ```
-  let partition : List (Result e a) -> (List e, List a) =
-    \results =>
-      List.fold_right
-        (\r (err, succ) =>
-          match r on
-          | Err v => (v :: err, succ)
-          | Ok v => (err, v :: succ)
-        )
-        ([], [])
+    ## Combine a list of results into a single result (holding a list).
+    ## Also known as `sequence` on lists.
+    ##
+    ## @since 0.1.0
+    ##
+    ## ```
+    ## ➢ Result.combine([Ok(1), Ok(2)])
+    ## Ok([1, 2]) : List(Int)
+    ## ```
+    let combine(results : List(Result(e, a))) -> Result(e, List(a)) =
         results
+        |> List.fold_right(
+            fn(r, acc) => map2(r, acc, fn(x, xs) => x :: xs),
+            Ok(Nil)
+        )
+
+    ## Partition a list of Results into two lists of values (successes and failures).
+    ##
+    ## @since 0.1.0
+    ##
+    ## ```
+    ## ➢ Result.paritition([Ok(1), Err("uh no!"), Ok(2)]
+    ## (["uh oh!"], [1, 2]) : (List(String), List(Int))
+    ## ```
+    let partition(results : List(Result(e, a))) -> (List(e), List(a)) =
+        results
+        |> List.fold_right(
+            fn(r, (err, succ)) =>
+                match r on
+                | Err(v) => (v :: err, succ)
+                | Ok(v) => (err, v :: succ),
+            (Nil, Nil)
+        )
 end

--- a/stdlib/set.mox
+++ b/stdlib/set.mox
@@ -1,101 +1,100 @@
 module Set exposing
-  ( Set
-  , diff
-  , empty
-  , empty?
-  , fold_left
-  , fold_right
-  , from_list
-  , insert
-  , intersect
-  , keep
-  , map
-  , member
-  , parition
-  , reject
-  , remove
-  , singleton
-  , size
-  , to_list
-  , union
-  )
+    ( Set
+    , diff
+    , empty
+    , empty?
+    , fold_left
+    , fold_right
+    , from_list
+    , insert
+    , intersect
+    , keep
+    , map
+    , member
+    , parition
+    , reject
+    , remove
+    , singleton
+    , size
+    , to_list
+    , union
+    )
 
-  ## A collection of unique values without any particular order.
-  type Set a =
-    ...
+    ## A collection of unique values without any particular order.
+    type Set(a) =
+        ...
 
-  ## Create an empty set.
-  let empty : Set a =
-    todo "not implemented"
+    ## Create an empty set.
+    let empty() -> Set(a) =
+        todo("not implemented")
 
-  ## Determine if a set is empty.
-  let empty? : Set a => Bool =
-    \set =>
-      todo "not implemented"
+    ## Determine if a set is empty.
+    let empty?(set : Set(a)) -> Bool =
+        todo("not implemented")
 
-  ## Create a set with one value.
-  let singleton : comparable -> Set comparable =
-    todo "not implemented"
+    ## Create a set with one value.
+    let singleton(value : comparable) -> Set(comparable) =
+        todo("not implemented")
 
-  ## Insert a value into a set.
-  let insert : comparable -> Set comparable -> Set comparable =
-    todo "not implemented"
+    ## Insert a value into a set.
+    let insert(set : Set(comparable), value : comparable) -> Set(comparable) =
+        todo("not implemented")
 
-  ## Remove a value from a set. If the value is not found, no changes are made.
-  let remove : comparable -> Set comparable -> Set comparable =
-    todo "not implemented"
+    ## Remove a value from a set. If the value is not found, no changes are made.
+    let remove(set : Set(comparable), value : comparable) -> Set(comparable) =
+        todo("not implemented")
 
-  ## Determine if a value is in a set.
-  let member? : comparable -> Set comparable -> Bool =
-    todo "not implemented"
+    ## Determine if a value is in a set.
+    let member?(set : Set(comparable), value : comparable) -> Bool =
+        todo("not implemented")
 
-  ## Determine the number of elements in a set.
-  let size : Set a -> Int =
-    todo "not implemented"
+    ## Determine the number of elements in a set.
+    let size(set : Set(a)) -> Int =
+        todo("not implemented")
 
-  ## Get the union of two sets. Keep all values.
-  let union : Set comparable -> Set comparable -> Set comparable =
-    todo "not implemented"
+    ## Get the union of two sets. Keep all values.
+    let union(set1 : Set(comparable), set2 : Set(comparable)) -> Set(comparable) =
+        todo("not implemented")
 
-  ## Get the intersection of two sets. Keeps values that appear in both sets.
-  let intersect : Set comparable -> Set comparable -> Set comparable =
-    todo "not implemented"
+    ## Get the intersection of two sets. Keeps values that appear in both sets.
+    let intersect(set1 : Set(comparable), set2 : Set(comparable)) -> Set(comparable) =
+        todo("not implemented")
 
-  ## Get the difference between the first set and the second. Keeps values
-  that do not appear in the second set.
-  let diff : Set comparable -> Set comparable -> Set comparable =
-    todo "not implemented"
+    ## Get the difference between the first set and the second. Keeps values
+    that do not appear in the second set.
+    let diff(set1 : Set(comparable), set2 : Set(comparable)) -> Set(comparable) =
+        todo("not implemented")
 
-  ## Convert a set into a list, sorted from lowest to highest.
-  let to_list : Set a -> List a =
-    todo "not implemented"
+    ## Convert a set into a list, sorted from lowest to highest.
+    let to_list(set : Set(a)) -> List(a) =
+        todo("not implemented")
 
-  ## Convert a list into a set, removing any duplicates.
-  let from_list : List comparable -> Set comparable =
-    todo "not implemented"
+    ## Convert a list into a set, removing any duplicates.
+    let from_list(list : List(comparable)) -> Set(comparable) =
+        todo("not implemented")
 
-  ## Fold over the values in a set, in order from lowest to highest.
-  let fold_left : (a -> b -> b) -> b -> Set a -> b =
-    todo "not implemented"
+    ## Fold over the values in a set, in order from lowest to highest.
+    let fold_left(set : Set(a), f : (a, b -> b), init : b) -> b =
+        todo("not implemented")
 
-  ## Fold over the values in a set, in order from highest to lowest.
-  let fold_right : (a -> b -> b) -> b -> Set a -> b =
-    todo "not implemented"
+    ## Fold over the values in a set, in order from highest to lowest.
+    let fold_right(set : Set(a), f : (a, b -> b), init : b) -> b =
+        todo("not implemented")
 
-  ## Map a function onto a set, creating a new set with no duplicates.
-  let map : (comparable -> comparable2) -> Set comparable -> Set comparable2 =
-    todo "not implemented"
+    ## Map a function onto a set, creating a new set with no duplicates.
+    let map(set : Set(comparable), f : (comparable -> comparable2)) -> Set(comparable2) =
+        todo("not implemented")
 
-  ## Only keep elements that satisfy the given predicate
-  let keep : (comparable -> Bool) -> Set comparable -> Set comparable =
-    todo "not implemented"
+    ## Only keep elements that satisfy the given predicate
+    let keep(set : Set(comparable), pred : (comparable -> Bool)) -> Set(comparable) =
+        todo("not implemented")
 
-  # Returns a set by excluding the elements which satisfy the given predicate
-  let reject : (comparable -> Bool) -> Set comparable -> Set comparable =
-    todo "not implemented"
+    # Returns a set by excluding the elements which satisfy the given predicate
+    let reject(set : Set(comparable), pred : (comparable -> Bool)) -> Set(comparable) =
+        todo("not implemented")
 
-  ## Create two new sets. The first contains all the elements that passed the
-  ## given test, and the second contains all the elements that did not.
-  let partition : (comparable -> Bool) -> Set comparable -> (Set comparable, Set comparable) =
-    todo "not implemented"
+    ## Create two new sets. The first contains all the elements that passed the
+    ## given test, and the second contains all the elements that did not.
+    let partition(set : Set(comparable), pred : (comparable -> Bool)) -> (Set(comparable), Set(comparable)) =
+        todo("not implemented")
 end

--- a/stdlib/string.mox
+++ b/stdlib/string.mox
@@ -1,502 +1,462 @@
 module String exposing
-  ( Pattern(..)
-  , all?
-  , any?
-  , append
-  , at
-  , concat
-  , contains?
-  , drop_right
-  , drop_while
-  , empty?
-  , ends_with?
-  , fold_left
-  , fold_right
-  , from_char
-  , index_of
-  , indexes_of
-  , join
-  , keep
-  , last_index_of
-  , lines
-  , map
-  , match?
-  , pad
-  , pad_left
-  , pad_right
-  , reject
-  , repeat
-  , replace
-  , reverse
-  , size
-  , slice
-  , split_at
-  , split_on
-  , starts_with?
-  , take_left
-  , take_right
-  , take_while
-  , to_float
-  , to_int
-  , to_lower
-  , to_upper
-  , trim
-  , trim_left
-  , trim_right
-  , words
-  )
+    ( Pattern(..)
+    , all?
+    , any?
+    , append
+    , at
+    , concat
+    , contains?
+    , drop_right
+    , drop_while
+    , empty?
+    , ends_with?
+    , fold_left
+    , fold_right
+    , from_char
+    , index_of
+    , indexes_of
+    , join
+    , keep
+    , last_index_of
+    , lines
+    , map
+    , match?
+    , pad
+    , pad_left
+    , pad_right
+    , reject
+    , repeat
+    , replace
+    , reverse
+    , size
+    , slice
+    , split_at
+    , split_on
+    , starts_with?
+    , take_left
+    , take_right
+    , take_while
+    , to_float
+    , to_int
+    , to_lower
+    , to_upper
+    , trim
+    , trim_left
+    , trim_right
+    , words
+    )
 
-  type Pattern =
-    Pattern String
+    type Pattern =
+        Pattern(String)
 
-  ## Calculate the number of characters in a string.
-  ##
-  ## @since 0.1.0
-  ##
-  ## ```
-  ## ➢ String.size "foobar"
-  ## 6 : Int
-  ## ```
-  let size : String -> Int =
-    \str =>
-      todo "not implemented"
+    ## Calculate the number of characters in a string.
+    ##
+    ## @since 0.1.0
+    ##
+    ## ```
+    ## ➢ String.size("foobar")
+    ## 6 : Int
+    ## ```
+    let size(str : String) -> Int =
+        todo("not implemented")
 
-  ## Append two strings.
-  ##
-  ## @since 0.1.0
-  ##
-  ## ```
-  ## ➢ String.append "foo" "bar"
-  ## "foobar" : String
-  ## ```
-  let append : String -> String -> String =
-    \str1 str2 =>
-      todo "not implemented"
+    ## Append two strings.
+    ##
+    ## @since 0.1.0
+    ##
+    ## ```
+    ## ➢ String.append("foo", "bar")
+    ## "foobar" : String
+    ## ```
+    let append(str1 : String, str2 : String) -> String =
+        todo("not implemented")
 
-  ## Concatenate many strings into one.
-  ##
-  ## @since 0.1.0
-  ##
-  ## ```
-  ## ➢ String.concat ["foo", "bar"]
-  ## "foobar" : String
-  ## ```
-  let concat : List String -> String =
-    \list =>
-      todo "not implemented"
+    ## Concatenate many strings into one.
+    ##
+    ## @since 0.1.0
+    ##
+    ## ```
+    ## ➢ String.concat(["foo", "bar"])
+    ## "foobar" : String
+    ## ```
+    let concat(list : List(String)) -> String =
+        todo("not implemented")
 
-  ## Put many strings together with a given pattern.
-  ##
-  ## @since 0.1.0
-  ##
-  ## ```
-  ## ➢ String.concat (Pattern "/") ["foo", "bar", "baz"]
-  ## "foo/bar/baz" : String
-  ## ```
-  let join : Pattern -> List String -> String =
-    \pattern list =>
-      todo "not implemented"
+    ## Put many strings together with a given pattern.
+    ##
+    ## @since 0.1.0
+    ##
+    ## ```
+    ## ➢ String.concat(Pattern("/"), (["foo", "bar", "baz"])
+    ## "foo/bar/baz" : String
+    ## ```
+    let join(pattern : Pattern, list : List(String)) -> String =
+        todo("not implemented")
 
-  ## Take *n* characters from the left side of a string.
-  ##
-  ## @since 0.1.0
-  ##
-  ## ```
-  ## ➢ String.take_left 3 "foobar"
-  ## "foo" : String
-  ## ```
-  let take_left : Int -> String -> String =
-    \n str =>
-      if n < 1 then
-        ""
-      else
-        slice 0 n str
+    ## Take *n* characters from the left side of a string.
+    ##
+    ## @since 0.1.0
+    ##
+    ## ```
+    ## ➢ String.take_left("foobar", 3)
+    ## "foo" : String
+    ## ```
+    let take_left(str : String, n : Int) -> String =
+        if n < 1 then
+            ""
+        else
+            slice(str, 0, n)
 
-  ## Take *n* characters from the right side of a string.
-  ##
-  ## @since 0.1.0
-  ##
-  ## ```
-  ## ➢ String.take_right 3 "foobar"
-  ## "bar" : String
-  ## ```
-  let take_right : Int -> String -> String =
-    \n str =>
-      todo "not implemented"
+    ## Take *n* characters from the right side of a string.
+    ##
+    ## @since 0.1.0
+    ##
+    ## ```
+    ## ➢ String.take_right("foobar", 3)
+    ## "bar" : String
+    ## ```
+    let take_right(str : String, n : Int) -> String =
+        todo("not implemented")
 
-  ## ???
-  ##
-  ## @since 0.1.0
-  ##
-  ## ```
-  ## ➢ String.take_while vowel? "foobar"
-  ## : String
-  ## ```
-  let take_while : (Char -> Bool) -> String -> String =
-    \predicate str =>
-      todo "not implemented"
+    ## ???
+    ##
+    ## @since 0.1.0
+    ##
+    ## ```
+    ## ➢ String.take_while("foobar", vowel?)
+    ## : String
+    ## ```
+    let take_while(str : String, predicate : (Char -> Bool)) -> String =
+        todo("not implemented")
 
-  ## Drop *n* characters from the right side of a string.
-  ##
-  ## @since 0.1.0
-  ##
-  ## ```
-  ## ➢ String.drop_left 3 "foobar"
-  ## "bar" : String
-  ## ```
-  let drop_left : Int -> String -> String =
-    \n str =>
-      todo "not implemented"
+    ## Drop *n* characters from the right side of a string.
+    ##
+    ## @since 0.1.0
+    ##
+    ## ```
+    ## ➢ String.drop_left("foobar", 3)
+    ## "bar" : String
+    ## ```
+    let drop_left(str : String, n : Int) -> String =
+        todo("not implemented")
 
-  ## Drop *n* characters from the right side of a string.
-  ##
-  ## @since 0.1.0
-  ##
-  ## ```
-  ## ➢ String.drop_right 3 "foobar"
-  ## "foo" : String
-  ## ```
-  let drop_right : Int -> String -> String =
-    \n str =>
-      todo "not implemented"
+    ## Drop *n* characters from the right side of a string.
+    ##
+    ## @since 0.1.0
+    ##
+    ## ```
+    ## ➢ String.drop_right("foobar", 3)
+    ## "foo" : String
+    ## ```
+    let drop_right(str : String, n : Int) -> String =
+        todo("not implemented")
 
-  ## ???
-  ##
-  ## @since 0.1.0
-  ##
-  ## ```
-  ## ➢
-  ## : String
-  ## ```
-  let drop_while : (Char -> Bool) -> String -> String =
-    \predicate str =>
-      todo "not implemented"
+    ## ???
+    ##
+    ## @since 0.1.0
+    ##
+    ## ```
+    ## ➢
+    ## : String
+    ## ```
+    let drop_while(str : String, predicate : (Char -> Bool)) -> String =
+        todo("not implemented")
 
-  ## Determin if the second string contains the first one.
-  ##
-  ## @since 0.1.0
-  ##
-  ## ```
-  ## ➢
-  ## : String
-  ## ```
-  let contains? : Pattern -> String -> Bool =
-    \pattern str =>
-      todo "not implemented"
+    ## Determin if the second string contains the first one.
+    ##
+    ## @since 0.1.0
+    ##
+    ## ```
+    ## ➢
+    ## : String
+    ## ```
+    let contains?(str : String, pattern : Pattern) -> Bool =
+        todo("not implemented")
 
-  ## Break a string into words, splitting on chunks of whitespace.
-  ##
-  ## @since 0.1.0
-  ##
-  ## ```
-  ## ➢ String.words "..."
-  ## [] : List String
-  ## ```
-  let words : String -> List String =
-    \str =>
-      todo "not implemented"
+    ## Break a string into words, splitting on chunks of whitespace.
+    ##
+    ## @since 0.1.0
+    ##
+    ## ```
+    ## ➢ String.words "..."
+    ## [] : List String
+    ## ```
+    let words(str : String) -> List(String) =
+        todo("not implemented")
 
-  ## Break a string into lines, splitting on newlines.
-  ##
-  ## @since 0.1.0
-  ##
-  ## ```
-  ## ➢ String.lines "..."
-  ## [] : List String
-  ## ```
-  let lines : String -> List String =
-    \str =>
-      todo "not implemented"
+    ## Break a string into lines, splitting on newlines.
+    ##
+    ## @since 0.1.0
+    ##
+    ## ```
+    ## ➢ String.lines "..."
+    ## [] : List String
+    ## ```
+    let lines(str : String) -> List(String) =
+        todo("not implemented")
 
-  ## ???
-  ##
-  ## @since 0.1.0
-  ##
-  ## ```
-  ## ➢
-  ## : String
-  ## ```
-  let index_of : Pattern -> String -> Maybe Int =
-    \pattern str =>
-      todo "not implemented"
+    ## ???
+    ##
+    ## @since 0.1.0
+    ##
+    ## ```
+    ## ➢
+    ## : String
+    ## ```
+    let index_of(str : String, pattern : Pattern) -> Maybe(Int) =
+        todo("not implemented")
 
-  ## ???
-  ##
-  ## @since 0.1.0
-  ##
-  ## ```
-  ## ➢
-  ## : String
-  ## ```
-  let last_index_of : Pattern -> String -> Maybe Int =
-    \pattern str =>
-      todo "not implemented"
+    ## ???
+    ##
+    ## @since 0.1.0
+    ##
+    ## ```
+    ## ➢
+    ## : String
+    ## ```
+    let last_index_of(str : String, pattern : Pattern) -> Maybe(Int) =
+        todo("not implemented")
 
-  ## Split a string using a given pattern.
-  ##
-  ## @since 0.1.0
-  ##
-  ## ```
-  ## ➢ String.split_on (Pattern ",") "foo,bar"
-  ## ["foo", "bar"] : List String
-  ## ```
-  let split_on : Pattern -> String -> List String =
-    \pattern str =>
-      todo "not implemented"
+    ## Split a string using a given pattern.
+    ##
+    ## @since 0.1.0
+    ##
+    ## ```
+    ## ➢ String.split_on("foo,bar", Pattern(","))
+    ## ["foo", "bar"] : List(String)
+    ## ```
+    let split_on(str : String, pattern : Pattern) -> List(String) =
+        todo("not implemented")
 
-  ## Split a string using a given pattern.
-  ##
-  ## @since 0.1.0
-  ##
-  ## ```
-  ## ➢ String.split_at 3 "foobar"
-  ## ("foo", "bar") : (String, String)
-  ## ```
-  let split_at : Int -> String -> (String, String) =
-    \pattern str =>
-      todo "not implemented"
+    ## Split a string using a given pattern.
+    ##
+    ## @since 0.1.0
+    ##
+    ## ```
+    ## ➢ String.split_at("foobar", 3)
+    ## ("foo", "bar") : (String, String)
+    ## ```
+    let split_at(str : String, n : Int) -> (String, String) =
+        todo("not implemented")
 
-  ## Take a substring given a start and end index.
-  ##
-  ## @since 0.1.0
-  ##
-  ## ```
-  ## ➢ String.slice 1 3 "abcd"
-  ## "bc" : String
-  ## ```
-  let slice : Int -> Int -> String =
-    \start end str =>
-      todo "not implemented"
+    ## Take a substring given a start and end index.
+    ##
+    ## @since 0.1.0
+    ##
+    ## ```
+    ## ➢ String.slice("abcd", 1, 3)
+    ## "bc" : String
+    ## ```
+    let slice(str : String, start : Int, end : Int) -> String =
+        todo("not implemented")
 
-  ## Convert a string to all lower case.
-  ##
-  ## @since 0.1.0
-  ##
-  ## ```
-  ## ➢ String.to_lower "FOOBAR"
-  ## "foobar" : String
-  ## ```
-  let to_lower : String -> String =
-    \str =>
-      todo "not implemented"
+    ## Convert a string to all lower case.
+    ##
+    ## @since 0.1.0
+    ##
+    ## ```
+    ## ➢ String.to_lower("FOOBAR")
+    ## "foobar" : String
+    ## ```
+    let to_lower(str : String) -> String =
+        todo("not implemented")
 
-  ## Convert a string to all upper case.
-  ##
-  ## @since 0.1.0
-  ##
-  ## ```
-  ## ➢ String.to_upper "foobar"
-  ## "FOOBAR" : String
-  ## ```
-  let to_upper : String -> String =
-    \str =>
-      todo "not implemented"
+    ## Convert a string to all upper case.
+    ##
+    ## @since 0.1.0
+    ##
+    ## ```
+    ## ➢ String.to_upper("foobar")
+    ## "FOOBAR" : String
+    ## ```
+    let to_upper(str : String) -> String =
+        todo("not implemented")
 
-  ## Reverse a string.
-  ##
-  ## @since 0.1.0
-  ##
-  ## ```
-  ## ➢ String.reverse "foobar"
-  ## "raboof" : String
-  ## ```
-  let reverse : String -> String =
-    \str =>
-      todo "not implemented"
+    ## Reverse a string.
+    ##
+    ## @since 0.1.0
+    ##
+    ## ```
+    ## ➢ String.reverse("foobar")
+    ## "raboof" : String
+    ## ```
+    let reverse(str : String) -> String =
+        todo("not implemented")
 
-  ## Repeat a string *n* times.
-  ##
-  ## @since 0.1.0
-  ##
-  ## ```
-  ## ➢ String.repeat 3 "ha"
-  ## "hahaha" : String
-  ## ```
-  let repeat : Int -> String -> String =
-    \count str =>
-      todo "not implemented"
+    ## Repeat a string *n* times.
+    ##
+    ## @since 0.1.0
+    ##
+    ## ```
+    ## ➢ String.repeat("ha", 3)
+    ## "hahaha" : String
+    ## ```
+    let repeat(str : String, count : Int) -> String =
+        todo("not implemented")
 
-  ## ???
-  ##
-  ## @since 0.1.0
-  ##
-  ## ```
-  ## ➢
-  ## : string
-  ## ```
-  let empty? : String -> Bool =
-    \str =>
-      todo "not implemented"
+    ## ???
+    ##
+    ## @since 0.1.0
+    ##
+    ## ```
+    ## ➢
+    ## : string
+    ## ```
+    let empty?(str : String) -> Bool =
+        todo("not implemented")
 
-  ## Returns `True` if string ends with the given pattern.
-  ##
-  ## @since 0.1.0
-  ##
-  ## ```
-  ## ➢ String.ends_with? "c" "abc"
-  ## True : Bool
-  ## ```
-  let ends_with? : Pattern -> String =
-    \str =>
-      todo "not implemented"
+    ## Returns `True` if string ends with the given pattern.
+    ##
+    ## @since 0.1.0
+    ##
+    ## ```
+    ## ➢ String.ends_with?("abc", "c")
+    ## True : Bool
+    ## ```
+    let ends_with?(str : String, pattern : Pattern) =
+        todo("not implemented")
 
-  ## Returns `True` if string starts with the given pattern.
-  ##
-  ## @since 0.1.0
-  ##
-  ## ```
-  ## ➢ String.starts_with? "a" "abc"
-  ## True : Bool
-  ## ```
-  let starts_with? : Pattern -> String -> Bool
-    \pattern str =>
-      todo "not implemented"
+    ## Returns `True` if string starts with the given pattern.
+    ##
+    ## @since 0.1.0
+    ##
+    ## ```
+    ## ➢ String.starts_with?("abc", "a")
+    ## True : Bool
+    ## ```
+    let starts_with?(str : String, pattern : Pattern) -> Bool
+        todo("not implemented")
 
-  ## Replace all occurrences of some pattern.
-  ##
-  ## @since 0.1.0
-  ##
-  ## ```
-  ## ➢ String.replace (Pattern "-") (Pattern "_") "foo-bar-baz"
-  ## "foo_bar_baz" : String
-  ## ```
-  let replace : Pattern -> Pattern -> String =
-    \pattern1 pattern2 str =>
-      todo "not implemented"
+    ## Replace all occurrences of some pattern.
+    ##
+    ## @since 0.1.0
+    ##
+    ## ```
+    ## ➢ String.replace "foo-bar-baz" (Pattern "-") (Pattern "_")
+    ## "foo_bar_baz" : String
+    ## ```
+    let replace(str: String, pattern1 : String, pattern2 : String) -> String =
+        todo("not implemented")
 
-  ## Remove whitespace from both sides of a string.
-  ##
-  ## @since 0.1.0
-  ##
-  ## ```
-  ## ➢ String.trim "  foo  "
-  ## "foo" : String
-  ## ```
-  let trim : String -> String =
-    \str =>
-      todo "not implemented"
+    ## Remove whitespace from both sides of a string.
+    ##
+    ## @since 0.1.0
+    ##
+    ## ```
+    ## ➢ String.trim("  foo  ")
+    ## "foo" : String
+    ## ```
+    let trim(str : String) -> String =
+        todo("not implemented")
 
-  ## Remove whitespace from the left of a string.
-  ##
-  ## @since 0.1.0
-  ##
-  ## ```
-  ## ➢ String.trim_left "  foo"
-  ## "foo" : String
-  ## ```
-  let trim_left : String -> String =
-    \str =>
-      todo "not implemented"
+    ## Remove whitespace from the left of a string.
+    ##
+    ## @since 0.1.0
+    ##
+    ## ```
+    ## ➢ String.trim_left("  foo")
+    ## "foo" : String
+    ## ```
+    let trim_left(str : String) -> String =
+        todo("not implemented")
 
-  ## Remove whitespace from the right of a string.
-  ##
-  ## @since 0.1.0
-  ##
-  ## ```
-  ## ➢ String.trim_right "foo  "
-  ## "foo" : String
-  ## ```
-  let trim_right : String -> String =
-    \str =>
-      todo "not implemented"
+    ## Remove whitespace from the right of a string.
+    ##
+    ## @since 0.1.0
+    ##
+    ## ```
+    ## ➢ String.trim_right("foo  ")
+    ## "foo" : String
+    ## ```
+    let trim_right(str : String) -> String =
+        todo("not implemented")
 
-  ## Pad a string on both sides until it has a given length.
-  ##
-  ## @since 0.1.0
-  ##
-  ## ```
-  ## ➢ String.pad 10 _ "foobar"
-  ## "__foobar__" : String
-  ## ```
-  let pad : Int -> Char -> String -> String =
-    \n char str =>
-      todo "not implemented"
+    ## Pad a string on both sides until it has a given length.
+    ##
+    ## @since 0.1.0
+    ##
+    ## ```
+    ## ➢ String.pad("foobar", 10, '_')
+    ## "__foobar__" : String
+    ## ```
+    let pad : Int -> Char -> String -> String =
+    let pad(str : String, n : Int, char : Char) -> String =
+        todo("not implemented")
 
-  ## Pad a string from the left until it has a given length.
-  ##
-  ## @since 0.1.0
-  ##
-  ## ```
-  ## ➢ String.pad_left 6 (Pattern " ") "foo"
-  ## "   foo" : String
-  ## ```
-  let pad_left : Int -> Pattern -> String -> String =
-    \count pattern str =>
-      todo "not implemented"
+    ## Pad a string from the left until it has a given length.
+    ##
+    ## @since 0.1.0
+    ##
+    ## ```
+    ## ➢ String.pad_left("foo", 6, Pattern(" "))
+    ## "   foo" : String
+    ## ```
+    let pad_left(str : String, count : Int, pattern : Pattern) -> String =
+        todo("not implemented")
 
-  ## Pad a string from the right until it has a given length.
-  ##
-  ## @since 0.1.0
-  ##
-  ## ```
-  ## ➢ String.pad_right 6 (Pattern " ") "foo"
-  ## "foo   " : String
-  ## ```
-  let pad_right : Int -> Pattern -> String -> String =
-    \count pattern str =>
-      todo "not implemented"
+    ## Pad a string from the right until it has a given length.
+    ##
+    ## @since 0.1.0
+    ##
+    ## ```
+    ## ➢ String.pad_right("foo", 6, Pattern(" "))
+    ## "foo   " : String
+    ## ```
+    let pad_right(str : String, count : Int, pattern : Pattern) -> String =
+        todo("not implemented")
 
-  ## Returns `True` if string starts with the given pattern.
-  ##
-  ## @since 0.1.0
-  ##
-  ## ```
-  ## ➢ String.indexes_of "i" "Mississippi"
-  ## [1, 4, 7, 10] : List Int
-  ## ```
-  let indexes_of : String -> String -> List Int =
-    \substr str =>
-      todo "not implemented"
+    ## Returns `True` if string starts with the given pattern.
+    ##
+    ## @since 0.1.0
+    ##
+    ## ```
+    ## ➢ String.indexes_of("Mississippi", "i")
+    ## [1, 4, 7, 10] : List(Int)
+    ## ```
+    let indexes_of(str: String, substr : String) -> List(Int) =
+        todo("not implemented")
 
-  let to_int : String -> Maybe Int =
-    \str =>
-      todo "not implemented"
+    let to_int(str : String) -> Maybe(Int) =
+        todo("not implemented")
 
-  let to_float : String -> Maybe Float =
-    \str =>
-      todo "not implemented"
+    let to_float(str : String) -> Maybe(Float) =
+        todo("not implemented")
 
-  let from_char : Char -> String =
-    \char =>
-      todo "not implemented"
+    let from_char(char : Char) -> String =
+        todo("not implemented")
 
-  ## Transform every character in a string
-  let map : (Char -> Char) -> String -> String =
-    \f str =>
-      todo "not implemented"
+    ## Transform every character in a string
+    let map(str : String, f : (Char -> Char)) -> String =
+        todo("not implemented")
 
-  ## Keep only the characters that pass the test.
-  let keep : (Char -> Bool) -> String -> String =
-    \predicate str =>
-      todo "not implemented"
+    ## Keep only the characters that pass the test.
+    let keep(str : String, predicate : (Char -> Bool)) -> String =
+        todo("not implemented")
 
-  let reject : (Char -> Bool) -> String -> String =
-    \predicate str =>
-      todo "not implemented"
+    let reject(str : String, predicate : (Char -> Bool)) -> String =
+        todo("not implemented")
 
-  ## Reduce a string from the left.
-  let fold_left : (Char -> b -> b) -> b -> String -> b =
-    todo "not implemented"
+    ## Reduce a string from the left.
+    let fold_left(str : String, f : (Char, b -> b), init : b) -> b =
+        todo("not implemented")
 
-  ## Reduce a string from the right.
-  let fold_right : (Char -> b -> b) -> b -> String -> b =
-    todo "not implemented"
+    ## Reduce a string from the right.
+    let fold_right(str : String, f : (Char, b -> b), init : b) -> b =
+        todo("not implemented")
 
-  ## Determine whether *any* characters pass the test.
-  let any? : (Char -> Bool) -> String -> Bool =
-    todo "not implemented"
+    ## Determine whether *any* characters pass the test.
+    let any?(str : String, pred : (Char -> Bool)) -> Bool =
+        todo("not implemented")
 
-  ## Determine whether *all* characters pass the test.
-  let all? : (Char -> Bool) -> String -> Bool =
-    todo "not implemented"
+    ## Determine whether *all* characters pass the test.
+    let all?(str : String, pred : (Char -> Bool)) -> Bool =
+        todo("not implemented")
 
-  ## Get character at the given position.
-  let at : Int -> String -> Maybe Char =
-    \position str =>
-      todo "not implemented"
+    ## Get character at the given position.
+    let at(str : String, position : Int) -> Maybe(Char) =
+        todo("not implemented")
 
-  ## Determines if a string matches the given pattern.
-  let match? : Pattern -> String -> Bool =
-    \pattern str =>
-      todo "not implemented"
+    ## Determines if a string matches the given pattern.
+    let match?(str : String, pattern : Pattern) -> Bool =
+        todo("not implemented")
 end

--- a/stdlib/tuple.mox
+++ b/stdlib/tuple.mox
@@ -1,39 +1,37 @@
 module Tuple exposing
-  ( fst
-  , map_both
-  , map_first
-  , map_second
-  , pair
-  , snd
-  )
+    ( Tuple(..)
+    , fst
+    , map_both
+    , map_first
+    , map_second
+    , pair
+    , snd
+    )
 
-  # CREATE
+    # CREATE
 
-  let pair : a -> b -> (a, b) =
-    \x y =>
-      (x, y)
+    let pair(x : a, y : b) -> (a, b) =
+        (x, y)
 
-  # ACCESS
+    # ACCESS
 
-  let fst : (a, b) -> a =
-    \(x, _) =>
-      x
+    let fst(x : a, _ : b) -> a =
+        x
 
-  let snd : (a, b) -> a =
-    \(_, y) =>
-      y
+    let snd(_ : a, y: b) -> a =
+        y
 
-  # TRANSFORM
+    # TRANSFORM
 
-  let map_both : (a -> x) -> (b -> y) -> (a, b) -> (x, y) =
-    \f g (x, y) =>
-      (f x, g y)
+    let map_both(pair : (a, b), f : (a -> x), g : (b -> y)) -> (x, y) =
+        match pair on
+        | (x, y) => (f(x), g(y))
 
-  let map_first : (a -> x) -> (a, b) -> (x, b) =
-    \f (x, y) =>
-      (f x, y)
+    let map_first(pair : (a, b), f : (a -> x)) -> (x, b) =
+        match pair on
+        | (x, y) => (f(x), y)
 
-  let map_second : (b -> y) -> (a, b) -> (a, y) =
-    \f (x, y) =>
-      (x, f y)
+    let map_second(pair : (a, b), f : (b -> y)) -> (a, y) =
+        match pair on
+        | (x, y) => (x, f(y))
 end

--- a/stdlib/unit.mox
+++ b/stdlib/unit.mox
@@ -1,20 +1,19 @@
 module Unit exposing
-  ( Unit(..)
-  , ignore
-  )
+    ( Unit(..)
+    , ignore
+    )
 
-  type Unit =
-    Unit
+    type Unit =
+        Unit
 
-  ## Discard the value of its argument and return `Unit`.
-  ##
-  ## @since 0.1.0
-  ##
-  ## ```
-  ## ➢ ignore 42
-  ## Unit : Unit
-  ## ```
-  let ignore : a -> Unit =
-    \_ =>
-      Unit
+    ## Discard the value of its argument and return `Unit`.
+    ##
+    ## @since 0.1.0
+    ##
+    ## ```
+    ## ➢ ignore(42)
+    ## Unit : Unit
+    ## ```
+    let ignore(_ : a) -> Unit =
+        Unit
 end

--- a/stdlib/validation.mox
+++ b/stdlib/validation.mox
@@ -1,9 +1,8 @@
 module Validation exposing
-  ( Validation(..)
-  )
+    ( Validation(..)
+    )
 
-  ## Result type that accumulates errors
-  type Validation e a =
-    Validation e a
-
+    ## Result type that accumulates errors
+    type Validation(e, a) =
+        Validation(e, a)
 end


### PR DESCRIPTION
## 🚨 **Big Decision: Removing Currying**

By removing **currying**, it:
- forces explicit fn calls removing operators like `>>` and `<<`
- changes function decl syntax to `let add(x : Int, y : Int) -> Int = x + y`
- functions are no longer "data last" -> now they are "data first"
- changes anonymous function syntax from `\acc _ => acc + 1` to `fn(acc, _) => acc + 1`
- puts infix operators in a tricky spot. in an uncurried world, you’d need to decide if `::` remains syntactic sugar for a function like `cons(tail : List(Int), head : Int)`
- types now require parens too e.g. `List(Int)`
- local `let` bindings like F#. considered 'do' notation style using `<-` 

### Changes

These changes are just documentation changes. Subsequent PR's will handle code changes. 
