### PR TITLE
New syntax refactor

### DIFF
--- a/.envrc.example
+++ b/.envrc.example
@@ -1,2 +1,1 @@
-watch_file *.cabal nix/modules/*.nix
 use flake

--- a/compiler/frontend/ast.zig
+++ b/compiler/frontend/ast.zig
@@ -804,6 +804,7 @@ pub const VariantConstructorNode = struct {
 
     pub fn deinit(self: *VariantConstructorNode, allocator: std.mem.Allocator) void {
         self.name.deinit(allocator);
+        allocator.destroy(self.name);
 
         for (self.parameters.items) |param| {
             param.deinit(allocator);
@@ -811,8 +812,6 @@ pub const VariantConstructorNode = struct {
         }
 
         self.parameters.deinit();
-
-        allocator.destroy(self);
     }
 };
 
@@ -840,6 +839,7 @@ pub const VariantTypeNode = struct {
 
     pub fn deinit(self: *VariantTypeNode, allocator: std.mem.Allocator) void {
         self.name.deinit(allocator);
+        allocator.destroy(self.name);
 
         for (self.type_params.items) |param| {
             allocator.free(param);
@@ -849,6 +849,7 @@ pub const VariantTypeNode = struct {
 
         for (self.constructors.items) |constructor| {
             constructor.deinit(allocator);
+            allocator.destroy(constructor);
         }
 
         self.constructors.deinit();
@@ -1131,7 +1132,6 @@ pub const ImportSpecNode = struct {
 /// Examples:
 /// - `include MyModule`
 /// - `include Data.List`
-/// - `include Parser.Internal`
 pub const IncludeNode = struct {
     /// The module path being included.
     path: *ModulePathNode,

--- a/compiler/frontend/ast.zig
+++ b/compiler/frontend/ast.zig
@@ -1447,8 +1447,8 @@ test "[CommentNode]" {
     const comment_node = try allocator.create(CommentNode);
     comment_node.* = .{
         .text = try allocator.dupe(u8, text),
-        .token = lexer.Token{
-            .kind = lexer.TokenKind{ .comment = .Regular },
+        .token = .{
+            .kind = .{ .comment = .Regular },
             .lexeme = "#",
             .loc = .{
                 .filename = TEST_FILE,
@@ -1493,8 +1493,8 @@ test "[DocCommentNode]" {
     const comment_node = try allocator.create(DocCommentNode);
     comment_node.* = .{
         .text = try allocator.dupe(u8, text),
-        .token = lexer.Token{
-            .kind = lexer.TokenKind{ .comment = .Doc },
+        .token = .{
+            .kind = .{ .comment = .Doc },
             .lexeme = "##",
             .loc = .{
                 .filename = TEST_FILE,
@@ -1538,8 +1538,8 @@ test "[IntLiteralNode]" {
     // Action
     const int_node = .{
         .value = value,
-        .token = lexer.Token{
-            .kind = lexer.TokenKind{ .literal = .Int },
+        .token = .{
+            .kind = .{ .literal = .Int },
             .lexeme = "42",
             .loc = .{
                 .filename = TEST_FILE,
@@ -1583,8 +1583,8 @@ test "[FloatLiteralNode]" {
     // Action
     const float_node = .{
         .value = value,
-        .token = lexer.Token{
-            .kind = lexer.TokenKind{ .literal = .Float },
+        .token = .{
+            .kind = .{ .literal = .Float },
             .lexeme = "42.0",
             .loc = .{
                 .filename = TEST_FILE,
@@ -1628,8 +1628,8 @@ test "[CharLiteralNode]" {
     // Action
     const char_node = .{
         .value = value,
-        .token = lexer.Token{
-            .kind = lexer.TokenKind{ .literal = .Char },
+        .token = .{
+            .kind = .{ .literal = .Char },
             .lexeme = "\'",
             .loc = .{
                 .filename = TEST_FILE,
@@ -1674,8 +1674,8 @@ test "[StrLiteralNode]" {
     const literal_node = try allocator.create(StrLiteralNode);
     literal_node.* = .{
         .value = try allocator.dupe(u8, value),
-        .token = lexer.Token{
-            .kind = lexer.TokenKind{ .literal = .String },
+        .token = .{
+            .kind = .{ .literal = .String },
             .lexeme = "\"",
             .loc = .{
                 .filename = TEST_FILE,
@@ -1727,8 +1727,8 @@ test "[MultilineStrLiteralNode]" {
     const literal_node = try allocator.create(MultilineStrLiteralNode);
     literal_node.* = .{
         .value = try allocator.dupe(u8, value),
-        .token = lexer.Token{
-            .kind = lexer.TokenKind{ .literal = .MultilineString },
+        .token = .{
+            .kind = .{ .literal = .MultilineString },
             .lexeme = "\"\"\"",
             .loc = .{
                 .filename = TEST_FILE,
@@ -1773,8 +1773,8 @@ test "[LowerIdentifierNode]" {
     const ident_node = try allocator.create(LowerIdentifierNode);
     ident_node.* = .{
         .identifier = try allocator.dupe(u8, identifier),
-        .token = lexer.Token{
-            .kind = lexer.TokenKind{ .identifier = .Lower },
+        .token = .{
+            .kind = .{ .identifier = .Lower },
             .lexeme = identifier,
             .loc = .{
                 .filename = TEST_FILE,
@@ -1822,8 +1822,8 @@ test "[UpperIdentifierNode]" {
     const ident_node = try allocator.create(UpperIdentifierNode);
     ident_node.* = .{
         .identifier = try allocator.dupe(u8, identifier),
-        .token = lexer.Token{
-            .kind = lexer.TokenKind{ .identifier = .Upper },
+        .token = .{
+            .kind = .{ .identifier = .Upper },
             .lexeme = identifier,
             .loc = .{
                 .filename = TEST_FILE,
@@ -1870,8 +1870,8 @@ test "[ListNode]" {
     elem1.* = .{
         .int_literal = .{
             .value = 1,
-            .token = lexer.Token{
-                .kind = lexer.TokenKind{ .literal = .Int },
+            .token = .{
+                .kind = .{ .literal = .Int },
                 .lexeme = "1",
                 .loc = .{
                     .filename = TEST_FILE,
@@ -1886,8 +1886,8 @@ test "[ListNode]" {
     elem2.* = .{
         .int_literal = .{
             .value = 2,
-            .token = lexer.Token{
-                .kind = lexer.TokenKind{ .literal = .Int },
+            .token = .{
+                .kind = .{ .literal = .Int },
                 .lexeme = "2",
                 .loc = .{
                     .filename = TEST_FILE,
@@ -1905,8 +1905,8 @@ test "[ListNode]" {
     const list_node = try allocator.create(ListNode);
     list_node.* = .{
         .elements = elements,
-        .token = lexer.Token{
-            .kind = lexer.TokenKind{ .delimiter = .LeftBracket },
+        .token = .{
+            .kind = .{ .delimiter = .LeftBracket },
             .lexeme = "[",
             .loc = .{
                 .filename = TEST_FILE,
@@ -1954,8 +1954,8 @@ test "[TupleNode]" {
     first.* = .{
         .int_literal = .{
             .value = 1,
-            .token = lexer.Token{
-                .kind = lexer.TokenKind{ .literal = .Int },
+            .token = .{
+                .kind = .{ .literal = .Int },
                 .lexeme = "1",
                 .loc = .{
                     .filename = TEST_FILE,
@@ -1969,8 +1969,8 @@ test "[TupleNode]" {
     const second_str = try allocator.create(StrLiteralNode);
     second_str.* = .{
         .value = try allocator.dupe(u8, "hello"),
-        .token = lexer.Token{
-            .kind = lexer.TokenKind{ .literal = .String },
+        .token = .{
+            .kind = .{ .literal = .String },
             .lexeme = "\"hello\"",
             .loc = .{
                 .filename = TEST_FILE,
@@ -1990,8 +1990,8 @@ test "[TupleNode]" {
     const tuple_node = try allocator.create(TupleNode);
     tuple_node.* = .{
         .elements = elements,
-        .token = lexer.Token{
-            .kind = lexer.TokenKind{ .delimiter = .LeftParen },
+        .token = .{
+            .kind = .{ .delimiter = .LeftParen },
             .lexeme = "(",
             .loc = .{
                 .filename = TEST_FILE,
@@ -2043,8 +2043,8 @@ test "[UnaryExprNode]" {
     operand.* = .{
         .int_literal = .{
             .value = 42,
-            .token = lexer.Token{
-                .kind = lexer.TokenKind{ .literal = .Int },
+            .token = .{
+                .kind = .{ .literal = .Int },
                 .lexeme = "42",
                 .loc = .{
                     .filename = TEST_FILE,
@@ -2058,8 +2058,8 @@ test "[UnaryExprNode]" {
     const unary_node = try allocator.create(UnaryExprNode);
     unary_node.* = .{
         .operand = operand,
-        .operator = lexer.Token{
-            .kind = lexer.TokenKind{ .operator = .IntSub },
+        .operator = .{
+            .kind = .{ .operator = .IntSub },
             .lexeme = "-",
             .loc = .{
                 .filename = TEST_FILE,
@@ -2141,7 +2141,7 @@ test "[ArithmeticExprNode]" {
     arithmetic_node.* = .{
         .left = left,
         .right = right,
-        .operator = lexer.Token{
+        .operator = .{
             .kind = .{ .operator = .IntMul },
             .lexeme = "*",
             .loc = .{
@@ -2191,7 +2191,7 @@ test "[LogicalExprNode]" {
     const left_ident = try allocator.create(LowerIdentifierNode);
     left_ident.* = .{
         .identifier = try allocator.dupe(u8, "a"),
-        .token = lexer.Token{
+        .token = .{
             .kind = .{ .identifier = .Lower },
             .lexeme = "a",
             .loc = .{
@@ -2208,7 +2208,7 @@ test "[LogicalExprNode]" {
     const right_ident = try allocator.create(LowerIdentifierNode);
     right_ident.* = .{
         .identifier = try allocator.dupe(u8, "b"),
-        .token = lexer.Token{
+        .token = .{
             .kind = .{ .identifier = .Lower },
             .lexeme = "b",
             .loc = .{
@@ -2226,7 +2226,7 @@ test "[LogicalExprNode]" {
     logical_node.* = .{
         .left = left,
         .right = right,
-        .operator = lexer.Token{
+        .operator = .{
             .kind = .{ .operator = .LogicalAnd },
             .lexeme = "&&",
             .loc = .{
@@ -2276,7 +2276,7 @@ test "[ComparisonExprNode]" {
     const left_ident = try allocator.create(LowerIdentifierNode);
     left_ident.* = .{
         .identifier = try allocator.dupe(u8, "x"),
-        .token = lexer.Token{
+        .token = .{
             .kind = .{ .identifier = .Lower },
             .lexeme = "x",
             .loc = .{
@@ -2293,7 +2293,7 @@ test "[ComparisonExprNode]" {
     const right_ident = try allocator.create(LowerIdentifierNode);
     right_ident.* = .{
         .identifier = try allocator.dupe(u8, "y"),
-        .token = lexer.Token{
+        .token = .{
             .kind = .{ .identifier = .Lower },
             .lexeme = "y",
             .loc = .{
@@ -2311,7 +2311,7 @@ test "[ComparisonExprNode]" {
     comparison_node.* = .{
         .left = left,
         .right = right,
-        .operator = lexer.Token{
+        .operator = .{
             .kind = .{ .operator = .LessThanEqual },
             .lexeme = "<=",
             .loc = .{
@@ -2363,7 +2363,7 @@ test "[MatchExprNode]" {
         const opt_ident = try allocator.create(LowerIdentifierNode);
         opt_ident.* = .{
             .identifier = try allocator.dupe(u8, "opt"),
-            .token = lexer.Token{
+            .token = .{
                 .kind = .{ .identifier = .Lower },
                 .lexeme = "opt",
                 .loc = .{
@@ -3094,8 +3094,8 @@ test "[FunctionSignatureNode]" {
     const int_type1 = try allocator.create(UpperIdentifierNode);
     int_type1.* = .{
         .identifier = try allocator.dupe(u8, "Int"),
-        .token = lexer.Token{
-            .kind = lexer.TokenKind{ .identifier = .Upper },
+        .token = .{
+            .kind = .{ .identifier = .Upper },
             .lexeme = "Int",
             .loc = .{
                 .filename = TEST_FILE,
@@ -3111,8 +3111,8 @@ test "[FunctionSignatureNode]" {
     const int_type2 = try allocator.create(UpperIdentifierNode);
     int_type2.* = .{
         .identifier = try allocator.dupe(u8, "Int"),
-        .token = lexer.Token{
-            .kind = lexer.TokenKind{ .identifier = .Upper },
+        .token = .{
+            .kind = .{ .identifier = .Upper },
             .lexeme = "Int",
             .loc = .{
                 .filename = TEST_FILE,
@@ -3128,8 +3128,8 @@ test "[FunctionSignatureNode]" {
     const int_type3 = try allocator.create(UpperIdentifierNode);
     int_type3.* = .{
         .identifier = try allocator.dupe(u8, "Int"),
-        .token = lexer.Token{
-            .kind = lexer.TokenKind{ .identifier = .Upper },
+        .token = .{
+            .kind = .{ .identifier = .Upper },
             .lexeme = "Int",
             .loc = .{
                 .filename = TEST_FILE,
@@ -3152,8 +3152,8 @@ test "[FunctionSignatureNode]" {
     func_signature.* = .{
         .parameter_types = parameter_types,
         .return_type = return_type_node,
-        .token = lexer.Token{
-            .kind = lexer.TokenKind{ .symbol = .ArrowRight },
+        .token = .{
+            .kind = .{ .symbol = .ArrowRight },
             .lexeme = "->",
             .loc = .{
                 .filename = TEST_FILE,
@@ -3211,8 +3211,8 @@ test "[LambdaExprNode]" {
     const x_param_ident = try allocator.create(LowerIdentifierNode);
     x_param_ident.* = .{
         .identifier = try allocator.dupe(u8, "x"),
-        .token = lexer.Token{
-            .kind = lexer.TokenKind{ .identifier = .Lower },
+        .token = .{
+            .kind = .{ .identifier = .Lower },
             .lexeme = "x",
             .loc = .{
                 .filename = TEST_FILE,
@@ -3232,8 +3232,8 @@ test "[LambdaExprNode]" {
     const y_param_ident = try allocator.create(LowerIdentifierNode);
     y_param_ident.* = .{
         .identifier = try allocator.dupe(u8, "y"),
-        .token = lexer.Token{
-            .kind = lexer.TokenKind{ .identifier = .Lower },
+        .token = .{
+            .kind = .{ .identifier = .Lower },
             .lexeme = "y",
             .loc = .{
                 .filename = TEST_FILE,
@@ -3256,8 +3256,8 @@ test "[LambdaExprNode]" {
     const x_ident = try allocator.create(LowerIdentifierNode);
     x_ident.* = .{
         .identifier = try allocator.dupe(u8, "x"),
-        .token = lexer.Token{
-            .kind = lexer.TokenKind{ .identifier = .Lower },
+        .token = .{
+            .kind = .{ .identifier = .Lower },
             .lexeme = "x",
             .loc = .{
                 .filename = TEST_FILE,
@@ -3271,10 +3271,10 @@ test "[LambdaExprNode]" {
     x_node.* = .{ .lower_identifier = x_ident };
 
     const y_ident = try allocator.create(LowerIdentifierNode);
-    y_ident.* = LowerIdentifierNode{
+    y_ident.* = .{
         .identifier = try allocator.dupe(u8, "y"),
-        .token = lexer.Token{
-            .kind = lexer.TokenKind{ .identifier = .Lower },
+        .token = .{
+            .kind = .{ .identifier = .Lower },
             .lexeme = "y",
             .loc = .{
                 .filename = TEST_FILE,
@@ -3291,8 +3291,8 @@ test "[LambdaExprNode]" {
     arithmetic_node.* = .{
         .left = x_node,
         .right = y_node,
-        .operator = lexer.Token{
-            .kind = lexer.TokenKind{ .operator = .IntAdd },
+        .operator = .{
+            .kind = .{ .operator = .IntAdd },
             .lexeme = "+",
             .loc = .{
                 .filename = TEST_FILE,
@@ -3309,8 +3309,8 @@ test "[LambdaExprNode]" {
     lambda_node.* = .{
         .parameters = parameters,
         .body = body_node,
-        .token = lexer.Token{
-            .kind = lexer.TokenKind{ .keyword = .Fn },
+        .token = .{
+            .kind = .{ .keyword = .Fn },
             .lexeme = "fn",
             .loc = .{
                 .filename = TEST_FILE,
@@ -3386,8 +3386,8 @@ test "[FunctionCallNode]" {
     const not_ident = try allocator.create(LowerIdentifierNode);
     not_ident.* = .{
         .identifier = try allocator.dupe(u8, "not"),
-        .token = lexer.Token{
-            .kind = lexer.TokenKind{ .identifier = .Lower },
+        .token = .{
+            .kind = .{ .identifier = .Lower },
             .lexeme = "not",
             .loc = .{
                 .filename = TEST_FILE,
@@ -3403,10 +3403,10 @@ test "[FunctionCallNode]" {
     var arguments = std.ArrayList(*Node).init(allocator);
 
     const true_ident = try allocator.create(UpperIdentifierNode);
-    true_ident.* = UpperIdentifierNode{
+    true_ident.* = .{
         .identifier = try allocator.dupe(u8, "True"),
-        .token = lexer.Token{
-            .kind = lexer.TokenKind{ .identifier = .Upper },
+        .token = .{
+            .kind = .{ .identifier = .Upper },
             .lexeme = "True",
             .loc = .{
                 .filename = TEST_FILE,
@@ -3425,8 +3425,8 @@ test "[FunctionCallNode]" {
     function_call_node.* = .{
         .function = func_node,
         .arguments = arguments,
-        .token = lexer.Token{
-            .kind = lexer.TokenKind{ .identifier = .Lower },
+        .token = .{
+            .kind = .{ .identifier = .Lower },
             .lexeme = "not",
             .loc = .{
                 .filename = TEST_FILE,
@@ -3531,8 +3531,8 @@ test "[ConsExprNode]" {
     const list_node = try allocator.create(ListNode);
     list_node.* = .{
         .elements = elements,
-        .token = lexer.Token{
-            .kind = lexer.TokenKind{ .delimiter = .LeftBracket },
+        .token = .{
+            .kind = .{ .delimiter = .LeftBracket },
             .lexeme = "[",
             .loc = .{
                 .filename = TEST_FILE,
@@ -3549,8 +3549,8 @@ test "[ConsExprNode]" {
     cons_node.* = .{
         .head = one_node,
         .tail = tail_node,
-        .operator = lexer.Token{
-            .kind = lexer.TokenKind{ .operator = .Cons },
+        .operator = .{
+            .kind = .{ .operator = .Cons },
             .lexeme = "::",
             .loc = .{
                 .filename = TEST_FILE,
@@ -4329,7 +4329,7 @@ test "[TypeAliasNode]" {
     const type_params = std.ArrayList([]const u8).init(allocator);
 
     const string_ident = try allocator.create(UpperIdentifierNode);
-    string_ident.* = UpperIdentifierNode{
+    string_ident.* = .{
         .identifier = try allocator.dupe(u8, "String"),
         .token = .{
             .kind = .{ .identifier = .Upper },
@@ -4800,7 +4800,6 @@ test "[ModulePathNode]" {
             },
         },
     };
-    try segments.append(std_ident);
 
     const list_ident = try allocator.create(UpperIdentifierNode);
     list_ident.* = .{
@@ -4815,6 +4814,8 @@ test "[ModulePathNode]" {
             },
         },
     };
+
+    try segments.append(std_ident);
     try segments.append(list_ident);
 
     const path_node = try allocator.create(ModulePathNode);
@@ -4887,8 +4888,6 @@ test "[ExportSpecNode]" {
     };
 
     var items = std.ArrayList(ExportItem).init(allocator);
-    // defer items.deinit();
-
     try items.append(item1);
     try items.append(item2);
 
@@ -5516,8 +5515,8 @@ test "[FunctionDeclNode]" {
     const add_ident = try allocator.create(LowerIdentifierNode);
     add_ident.* = .{
         .identifier = try allocator.dupe(u8, "add"),
-        .token = lexer.Token{
-            .kind = lexer.TokenKind{ .identifier = .Lower },
+        .token = .{
+            .kind = .{ .identifier = .Lower },
             .lexeme = "add",
             .loc = .{
                 .filename = TEST_FILE,
@@ -5530,8 +5529,8 @@ test "[FunctionDeclNode]" {
     const x_ident = try allocator.create(LowerIdentifierNode);
     x_ident.* = .{
         .identifier = try allocator.dupe(u8, "x"),
-        .token = lexer.Token{
-            .kind = lexer.TokenKind{ .identifier = .Lower },
+        .token = .{
+            .kind = .{ .identifier = .Lower },
             .lexeme = "x",
             .loc = .{
                 .filename = TEST_FILE,
@@ -5544,8 +5543,8 @@ test "[FunctionDeclNode]" {
     const int_type1 = try allocator.create(UpperIdentifierNode);
     int_type1.* = .{
         .identifier = try allocator.dupe(u8, "Int"),
-        .token = lexer.Token{
-            .kind = lexer.TokenKind{ .identifier = .Upper },
+        .token = .{
+            .kind = .{ .identifier = .Upper },
             .lexeme = "Int",
             .loc = .{
                 .filename = TEST_FILE,
@@ -5568,8 +5567,8 @@ test "[FunctionDeclNode]" {
     const y_ident = try allocator.create(LowerIdentifierNode);
     y_ident.* = .{
         .identifier = try allocator.dupe(u8, "y"),
-        .token = lexer.Token{
-            .kind = lexer.TokenKind{ .identifier = .Lower },
+        .token = .{
+            .kind = .{ .identifier = .Lower },
             .lexeme = "y",
             .loc = .{
                 .filename = TEST_FILE,
@@ -5582,8 +5581,8 @@ test "[FunctionDeclNode]" {
     const int_type2 = try allocator.create(UpperIdentifierNode);
     int_type2.* = .{
         .identifier = try allocator.dupe(u8, "Int"),
-        .token = lexer.Token{
-            .kind = lexer.TokenKind{ .identifier = .Upper },
+        .token = .{
+            .kind = .{ .identifier = .Upper },
             .lexeme = "Int",
             .loc = .{
                 .filename = TEST_FILE,
@@ -5610,8 +5609,8 @@ test "[FunctionDeclNode]" {
     const int_type3 = try allocator.create(UpperIdentifierNode);
     int_type3.* = .{
         .identifier = try allocator.dupe(u8, "Int"),
-        .token = lexer.Token{
-            .kind = lexer.TokenKind{ .identifier = .Upper },
+        .token = .{
+            .kind = .{ .identifier = .Upper },
             .lexeme = "Int",
             .loc = .{
                 .filename = TEST_FILE,
@@ -5627,8 +5626,8 @@ test "[FunctionDeclNode]" {
     const x_body_ident = try allocator.create(LowerIdentifierNode);
     x_body_ident.* = .{
         .identifier = try allocator.dupe(u8, "x"),
-        .token = lexer.Token{
-            .kind = lexer.TokenKind{ .identifier = .Lower },
+        .token = .{
+            .kind = .{ .identifier = .Lower },
             .lexeme = "x",
             .loc = .{
                 .filename = TEST_FILE,
@@ -5644,8 +5643,8 @@ test "[FunctionDeclNode]" {
     const y_body_ident = try allocator.create(LowerIdentifierNode);
     y_body_ident.* = .{
         .identifier = try allocator.dupe(u8, "y"),
-        .token = lexer.Token{
-            .kind = lexer.TokenKind{ .identifier = .Lower },
+        .token = .{
+            .kind = .{ .identifier = .Lower },
             .lexeme = "y",
             .loc = .{
                 .filename = TEST_FILE,
@@ -5662,8 +5661,8 @@ test "[FunctionDeclNode]" {
     arith_node.* = .{
         .left = x_body_node,
         .right = y_body_node,
-        .operator = lexer.Token{
-            .kind = lexer.TokenKind{ .operator = .IntAdd },
+        .operator = .{
+            .kind = .{ .operator = .IntAdd },
             .lexeme = "+",
             .loc = .{
                 .filename = TEST_FILE,
@@ -5682,8 +5681,8 @@ test "[FunctionDeclNode]" {
         .parameters = parameters,
         .return_type = return_type_node,
         .value = body_node,
-        .token = lexer.Token{
-            .kind = lexer.TokenKind{ .keyword = .Let },
+        .token = .{
+            .kind = .{ .keyword = .Let },
             .lexeme = "let",
             .loc = .{
                 .filename = TEST_FILE,
@@ -5762,8 +5761,8 @@ test "[ForeignFunctionDeclNode]" {
     const float_type1 = try allocator.create(UpperIdentifierNode);
     float_type1.* = .{
         .identifier = try allocator.dupe(u8, "Float"),
-        .token = lexer.Token{
-            .kind = lexer.TokenKind{ .identifier = .Upper },
+        .token = .{
+            .kind = .{ .identifier = .Upper },
             .lexeme = "Float",
             .loc = .{
                 .filename = TEST_FILE,
@@ -5779,8 +5778,8 @@ test "[ForeignFunctionDeclNode]" {
     const x_ident = try allocator.create(LowerIdentifierNode);
     x_ident.* = .{
         .identifier = try allocator.dupe(u8, "x"),
-        .token = lexer.Token{
-            .kind = lexer.TokenKind{ .identifier = .Lower },
+        .token = .{
+            .kind = .{ .identifier = .Lower },
             .lexeme = "x",
             .loc = .{
                 .filename = TEST_FILE,
@@ -5794,8 +5793,8 @@ test "[ForeignFunctionDeclNode]" {
     x_param.* = .{
         .name = x_ident,
         .type_annotation = x_type_node,
-        .token = lexer.Token{
-            .kind = lexer.TokenKind{ .identifier = .Lower },
+        .token = .{
+            .kind = .{ .identifier = .Lower },
             .lexeme = "x",
             .loc = .{
                 .filename = TEST_FILE,
@@ -5811,8 +5810,8 @@ test "[ForeignFunctionDeclNode]" {
     const float_type2 = try allocator.create(UpperIdentifierNode);
     float_type2.* = .{
         .identifier = try allocator.dupe(u8, "Float"),
-        .token = lexer.Token{
-            .kind = lexer.TokenKind{ .identifier = .Upper },
+        .token = .{
+            .kind = .{ .identifier = .Upper },
             .lexeme = "Float",
             .loc = .{
                 .filename = TEST_FILE,
@@ -5828,8 +5827,8 @@ test "[ForeignFunctionDeclNode]" {
     const external_name_node = try allocator.create(StrLiteralNode);
     external_name_node.* = .{
         .value = try allocator.dupe(u8, "c_sqrt"),
-        .token = lexer.Token{
-            .kind = lexer.TokenKind{ .literal = .String },
+        .token = .{
+            .kind = .{ .literal = .String },
             .lexeme = "\"c_sqrt\"",
             .loc = .{
                 .filename = TEST_FILE,
@@ -5842,8 +5841,8 @@ test "[ForeignFunctionDeclNode]" {
     const sqrt_ident = try allocator.create(LowerIdentifierNode);
     sqrt_ident.* = .{
         .identifier = try allocator.dupe(u8, "sqrt"),
-        .token = lexer.Token{
-            .kind = lexer.TokenKind{ .identifier = .Lower },
+        .token = .{
+            .kind = .{ .identifier = .Lower },
             .lexeme = "sqrt",
             .loc = .{
                 .filename = TEST_FILE,
@@ -5859,8 +5858,8 @@ test "[ForeignFunctionDeclNode]" {
         .parameters = parameters,
         .return_type = return_type_node,
         .external_name = external_name_node,
-        .token = lexer.Token{
-            .kind = lexer.TokenKind{ .keyword = .Foreign },
+        .token = .{
+            .kind = .{ .keyword = .Foreign },
             .lexeme = "foreign",
             .loc = .{
                 .filename = TEST_FILE,

--- a/compiler/frontend/ast.zig
+++ b/compiler/frontend/ast.zig
@@ -499,11 +499,14 @@ pub const FunctionSignatureNode = struct {
 ///
 /// Examples:
 /// - `fn(x, y) => x + y`
-/// - `fn(x : Int, y : Int) => x + y`
+/// - `fn(x : Int, y : Int) -> Int => x + y`
 /// - `fn(f, xs) => xs |> map(f)`
 pub const LambdaExprNode = struct {
     /// Array of parameter declarations.
     parameters: std.ArrayList(*ParamDeclNode),
+
+    /// Optional AST node representing the return type annotation.
+    return_type: ?*Node,
 
     /// The AST node representing the function body expression.
     body: *Node,
@@ -515,6 +518,11 @@ pub const LambdaExprNode = struct {
         for (self.parameters.items) |param| {
             param.deinit(allocator);
             allocator.destroy(param);
+        }
+
+        if (self.return_type) |rt| {
+            rt.deinit(allocator);
+            allocator.destroy(rt);
         }
 
         self.parameters.deinit();

--- a/compiler/frontend/ast.zig
+++ b/compiler/frontend/ast.zig
@@ -107,9 +107,9 @@ pub const StrLiteralNode = struct {
 ///
 /// Examples:
 /// - `"""
-/// first line
-/// second line
-/// """`
+///first line
+///second line
+///"""`
 pub const MultilineStrLiteralNode = struct {
     /// The parsed multiline string value with escape sequences processed.
     value: []const u8,
@@ -282,11 +282,11 @@ pub const ComparisonExprNode = BinaryOp;
 /// constructors, list patterns, and wildcards.
 ///
 /// Examples:
-/// - `_` matches anything
-/// - `42` matches literal integer
-/// - `Some x` matches constructor with variable (parameters bind sub-patterns)
-/// - `head :: tail` matches list with head and tail
-/// - `[]` matches empty list
+/// - `_`
+/// - `42`
+/// - `Some(x)`
+/// - `head :: tail`
+/// - `[]`
 pub const PatternNode = union(enum) {
     wildcard: struct {
         token: lexer.Token,
@@ -304,7 +304,7 @@ pub const PatternNode = union(enum) {
     },
     variable: struct {
         /// The name of the variable to bind.
-        name: []const u8,
+        name: LowerIdentifierNode,
 
         /// The token representing the variable.
         token: lexer.Token,
@@ -353,7 +353,7 @@ pub const PatternNode = union(enum) {
                 list.patterns.deinit();
             },
             .variable => |variable| {
-                allocator.free(variable.name);
+                variable.name.deinit(allocator);
             },
             .constructor => |constructor| {
                 allocator.free(constructor.name);
@@ -381,7 +381,7 @@ pub const PatternNode = union(enum) {
 ///
 /// Examples:
 /// - `when x > 0`
-/// - `when is_valid? name`
+/// - `when is_valid?(name)`
 pub const GuardNode = struct {
     /// The AST node representing the boolean condition.
     condition: *Node,
@@ -400,7 +400,7 @@ pub const GuardNode = struct {
 ///
 /// Examples:
 /// - `0 => "zero"`
-/// - `x :: xs when length xs > 0 => count + 1`
+/// - `x :: xs when length(xs) > 0 => count + 1`
 pub const MatchCase = struct {
     /// The pattern to match against.
     pattern: *PatternNode,
@@ -433,8 +433,8 @@ pub const MatchCase = struct {
 ///
 /// Examples:
 /// - `match x on | 0 => "zero" | _ => "other"`
-/// - `match list on | [] => 0 | x :: xs => 1 + length xs`
-/// - `match result on | Ok v => v | Err e => default`
+/// - `match list on | [] => 0 | x :: xs => 1 + length(xs)`
+/// - `match result on | Ok(v) => v | Err(e) => default`
 pub const MatchExprNode = struct {
     /// The AST node representing the value being matched.
     subject: *Node,
@@ -464,34 +464,44 @@ pub const MatchExprNode = struct {
 // Functions and Applications
 //==========================================================================
 
-/// Represents a function type annotation.
+/// Represents a function type annotation with parameter types and a return type.
 ///
 /// Examples:
-/// - `Int -> Int -> Int`
-pub const FunctionTypeNode = struct {
-    /// Array of AST nodes representing the full signature (parameters and return type).
-    signature_types: std.ArrayList(*Node),
+/// - As parameter types: `map(f : (a) -> b, xs : List(a))`
+/// - As return types: `curry() -> (a, b) -> c`
+/// - In type aliases: `type Predicate(a) = (a) -> Bool`
+pub const FunctionSignatureNode = struct {
+    /// Array of AST nodes representing parameter types.
+    parameter_types: std.ArrayList(*Node),
+
+    /// The AST node representing the return type.
+    return_type: *Node,
 
     /// The token representing the start of this declaration.
     token: lexer.Token,
 
-    pub fn deinit(self: *FunctionTypeNode, allocator: std.mem.Allocator) void {
-        for (self.signature_types.items) |stype| {
-            stype.deinit(allocator);
-            allocator.destroy(stype);
+    pub fn deinit(self: *FunctionSignatureNode, allocator: std.mem.Allocator) void {
+        for (self.parameter_types.items) |param_type| {
+            param_type.deinit(allocator);
+            allocator.destroy(param_type);
         }
 
-        self.signature_types.deinit();
+        self.parameter_types.deinit();
+
+        self.return_type.deinit(allocator);
+        allocator.destroy(self.return_type);
     }
 };
 
-/// Represents a lambda expression.
+/// Represents a lambda expression with a parameter list.
 ///
 /// Examples:
-/// - `\x y => x + y`
+/// - `fn(x, y) => x + y`
+/// - `fn(x : Int, y : Int) => x + y`
+/// - `fn(f, xs) => xs |> map(f)`
 pub const LambdaExprNode = struct {
-    /// Array of parameter names.
-    param_names: std.ArrayList([]const u8),
+    /// Array of parameter declarations.
+    parameters: std.ArrayList(*ParamDeclNode),
 
     /// The AST node representing the function body expression.
     body: *Node,
@@ -500,11 +510,12 @@ pub const LambdaExprNode = struct {
     token: lexer.Token,
 
     pub fn deinit(self: *LambdaExprNode, allocator: std.mem.Allocator) void {
-        for (self.param_names.items) |param| {
-            allocator.free(param);
+        for (self.parameters.items) |param| {
+            param.deinit(allocator);
+            allocator.destroy(param);
         }
 
-        self.param_names.deinit();
+        self.parameters.deinit();
 
         self.body.deinit(allocator);
         allocator.destroy(self.body);
@@ -513,29 +524,56 @@ pub const LambdaExprNode = struct {
     }
 };
 
-/// Represents a function application where a function is applied to an argument.
+/// Represents a function call where a function is invoked with arguments.
 ///
 /// Examples:
-/// - `f 42`
-/// - `not (and x y)`
-pub const FuncApplicationNode = struct {
+/// - `add(42, 17)`
+/// - `not(and(x, y))`
+/// - `map(double, [1, 2, 3])`
+pub const FunctionCallNode = struct {
     /// The AST node representing the function being applied.
     function: *Node,
 
-    /// The AST node representing the argument the function is being applied to.
-    argument: *Node,
+    /// Array of AST nodes representing the arguments passed to the function.
+    arguments: std.ArrayList(*Node),
 
     /// The token representing the start of this application (usually the function's token).
     token: lexer.Token,
 
-    pub fn deinit(self: *FuncApplicationNode, allocator: std.mem.Allocator) void {
+    pub fn deinit(self: *FunctionCallNode, allocator: std.mem.Allocator) void {
         self.function.deinit(allocator);
         allocator.destroy(self.function);
 
-        self.argument.deinit(allocator);
-        allocator.destroy(self.argument);
+        for (self.arguments.items) |argument| {
+            argument.deinit(allocator);
+            allocator.destroy(argument);
+        }
+
+        self.arguments.deinit();
 
         allocator.destroy(self);
+    }
+};
+
+/// Represents a parameter declaration with a name and type annotation.
+pub const ParamDeclNode = struct {
+    /// The name of the parameter.
+    name: LowerIdentifierNode,
+
+    /// The AST node representing the parameter's type annotation.
+    /// This is optional for regular functions but required for foreign functions.
+    type_annotation: ?*Node,
+
+    /// The token representing this parameter declaration.
+    token: lexer.Token,
+
+    pub fn deinit(self: *ParamDeclNode, allocator: std.mem.Allocator) void {
+        self.name.deinit(allocator);
+
+        if (self.type_annotation) |type_ann| {
+            type_ann.deinit(allocator);
+            allocator.destroy(type_ann);
+        }
     }
 };
 
@@ -585,38 +623,11 @@ pub const StrConcatExprNode = BinaryOp;
 /// - `[] ++ xs`
 pub const ListConcatExprNode = BinaryOp;
 
-/// Represents a binary operation that combines functions through composition.
-///
-/// Examples:
-/// - `f >> g` (forward composition)
-/// - `f << g` (backward composition)
-pub const CompositionExprNode = struct {
-    /// The AST node representing the first function in the composition.
-    first: *Node,
-
-    /// The AST node representing the second function in the composition.
-    second: *Node,
-
-    /// The token representing the composition operator.
-    operator: lexer.Token,
-
-    pub fn deinit(self: *CompositionExprNode, allocator: std.mem.Allocator) void {
-        self.first.deinit(allocator);
-        allocator.destroy(self.first);
-
-        self.second.deinit(allocator);
-        allocator.destroy(self.second);
-
-        allocator.destroy(self);
-    }
-};
-
 /// Represents a binary operation that passes a value through a pipeline
 /// of function applications.
 ///
 /// Examples:
-/// - `x |> f` (forward pipe)
-/// - `f <| x` (backward pipe)
+/// - `x |> f()`
 pub const PipeExprNode = struct {
     /// The AST node representing the value being piped.
     value: *Node,
@@ -648,8 +659,8 @@ pub const PipeExprNode = struct {
 ///
 /// Examples:
 /// - `if x > 0 then 1 else 0`
-/// - `if empty? list then None else Some (head list)`
-/// - `if even? n then n / 2 else 3 * n + 1`
+/// - `if empty?(list) then None else Some(head(list))`
+/// - `if even?(n) then n / 2 else 3 * n + 1`
 pub const IfThenElseStmtNode = struct {
     /// The AST node representing the boolean condition.
     condition: *Node,
@@ -694,13 +705,13 @@ pub const TypedHoleNode = struct {
 };
 
 /// Represents an application of type arguments to a type constructor.
-/// For example: in `Map k v`, Map is the base type being applied to args k and v.
+/// For example: in `Map(k, v)`, Map is the base type being applied to args k and v.
 ///
 /// Examples:
-/// - `List a`
-/// - `Map k v`
-/// - `Result e a`
-/// - `Tree (Maybe a)`
+/// - `List(a)`
+/// - `Map(k, v)`
+/// - `Result(e, a)`
+/// - `Tree(Maybe(a))`
 pub const TypeApplicationNode = struct {
     /// The type constructor being applied (e.g., Map, List, Maybe).
     constructor: UpperIdentifierNode,
@@ -731,12 +742,12 @@ pub const TypeApplicationNode = struct {
 ///
 /// Examples:
 /// - `type alias UserId = String`
-/// - `type alias Dict k v = Map k v`
-/// - `type alias Reducer a b = a -> b -> b`
-/// - `type alias TreeMap k v = Tree (Pair k v) (Compare k)`
+/// - `type alias Dict(k, v) = Map(k, v)`
+/// - `type alias Reducer(a, b) = (a, b) -> b`
+/// - `type alias TreeMap(k, v) = Tree(Pair(k, v), Compare(k))`
 pub const TypeAliasNode = struct {
     /// The name of the type alias.
-    name: []const u8,
+    name: UpperIdentifierNode,
 
     /// Array of type parameter names.
     type_params: std.ArrayList([]const u8),
@@ -748,7 +759,7 @@ pub const TypeAliasNode = struct {
     token: lexer.Token,
 
     pub fn deinit(self: *TypeAliasNode, allocator: std.mem.Allocator) void {
-        allocator.free(self.name);
+        self.name.deinit(allocator);
 
         for (self.type_params.items) |param| {
             allocator.free(param);
@@ -767,13 +778,13 @@ pub const TypeAliasNode = struct {
 /// Each constructor can have zero or more type parameters.
 ///
 /// Examples:
-/// - `None` (no parameters)
-/// - `Some a` (one type parameter)
-/// - `Entry k v` (two type parameters)
-/// - `Node a (Tree a)` (nested type parameters)
+/// - `None`
+/// - `Some(a)`
+/// - `Entry(k, v)`
+/// - `Node(a, Tree(a))`
 pub const VariantConstructorNode = struct {
     /// The name of the constructor.
-    name: []const u8,
+    name: UpperIdentifierNode,
 
     /// Array of AST nodes representing the constructor's parameter types.
     parameters: std.ArrayList(*Node),
@@ -782,7 +793,7 @@ pub const VariantConstructorNode = struct {
     token: lexer.Token,
 
     pub fn deinit(self: *VariantConstructorNode, allocator: std.mem.Allocator) void {
-        allocator.free(self.name);
+        self.name.deinit(allocator);
 
         for (self.parameters.items) |param| {
             param.deinit(allocator);
@@ -800,13 +811,13 @@ pub const VariantConstructorNode = struct {
 /// in its constructors.
 ///
 /// Examples:
-/// - `type Maybe a = None | Some a`
-/// - `type List a = Nil | Cons a (List a)`
-/// - `type Tree a = Leaf | Branch (Tree a) a (Tree a)`
-/// - `type Result e a = Err e | Ok a`
+/// - `type Maybe(a) = None | Some(a)`
+/// - `type List(a) = Nil | Cons(a, List(a))`
+/// - `type Tree(a) = Leaf | Branch(Tree(a), a, Tree(a))`
+/// - `type Result(e, a) = Err(e) | Ok(a)`
 pub const VariantTypeNode = struct {
     /// The name of the variant type.
-    name: []const u8,
+    name: UpperIdentifierNode,
 
     /// Array of type parameter names.
     type_params: std.ArrayList([]const u8),
@@ -818,7 +829,7 @@ pub const VariantTypeNode = struct {
     token: lexer.Token,
 
     pub fn deinit(self: *VariantTypeNode, allocator: std.mem.Allocator) void {
-        allocator.free(self.name);
+        self.name.deinit(allocator);
 
         for (self.type_params.items) |param| {
             allocator.free(param);
@@ -839,7 +850,7 @@ pub const VariantTypeNode = struct {
 /// Represents a field in a record type with a name and type.
 pub const RecordFieldNode = struct {
     /// The name of the field.
-    name: []const u8,
+    name: LowerIdentifierNode,
 
     /// The AST node representing the field's type.
     type: *Node,
@@ -848,7 +859,7 @@ pub const RecordFieldNode = struct {
     token: lexer.Token,
 
     pub fn deinit(self: *RecordFieldNode, allocator: std.mem.Allocator) void {
-        allocator.free(self.name);
+        self.name.deinit(allocator);
 
         self.type.deinit(allocator);
         allocator.destroy(self.type);
@@ -858,11 +869,11 @@ pub const RecordFieldNode = struct {
 /// Represents a record type declaration with named fields and types.
 ///
 /// Examples:
-/// - `type Point = { x: Int, y: Int }`
-/// - `type User = { name: String, email: String }`
+/// - `type Point = { x : Int, y : Int }`
+/// - `type User = { name : String, email : String }`
 pub const RecordTypeNode = struct {
     /// The name of the record type.
-    name: []const u8,
+    name: UpperIdentifierNode,
 
     /// Array of type parameter names.
     type_params: std.ArrayList([]const u8),
@@ -874,7 +885,7 @@ pub const RecordTypeNode = struct {
     token: lexer.Token,
 
     pub fn deinit(self: *RecordTypeNode, allocator: std.mem.Allocator) void {
-        allocator.free(self.name);
+        self.name.deinit(allocator);
 
         for (self.type_params.items) |param| {
             allocator.free(param);
@@ -903,17 +914,17 @@ pub const RecordTypeNode = struct {
 /// Examples:
 /// - `MyModule`
 /// - `MyModule.SubModule`
-/// - `Std.List`
 pub const ModulePathNode = struct {
     /// Array of identifiers forming the module path.
-    segments: std.ArrayList([]const u8),
+    segments: std.ArrayList(*UpperIdentifierNode),
 
     /// The token representing the start of this declaration.
     token: lexer.Token,
 
     pub fn deinit(self: *ModulePathNode, allocator: std.mem.Allocator) void {
         for (self.segments.items) |segment| {
-            allocator.free(segment);
+            segment.deinit(allocator);
+            allocator.destroy(segment);
         }
 
         self.segments.deinit();
@@ -1075,7 +1086,7 @@ pub const ImportSpecNode = struct {
 
     /// Optional alias name for the imported module.
     /// Only used when kind is .Alias
-    alias: ?[]const u8,
+    alias: ?UpperIdentifierNode,
 
     /// Optional list of items being imported or renamed.
     /// Used when kind is .Using or .Hiding
@@ -1089,7 +1100,7 @@ pub const ImportSpecNode = struct {
         allocator.destroy(self.path);
 
         if (self.alias) |alias| {
-            allocator.free(alias);
+            alias.deinit(allocator);
         }
 
         if (self.items) |*items| {
@@ -1135,14 +1146,17 @@ pub const IncludeNode = struct {
 /// The value is typically a lambda expression but can be any valid expression.
 ///
 /// Examples:
-/// - `let add : Int -> Int -> Int = \x y => x + y`
-/// - `let compose : (b -> c) -> (a -> b) -> a -> c = \f g x => f (g x)`
+/// - `let add(x : Int, y : Int) -> Int = x + y`
+/// - `let compose(f : (b) -> c, g : (a) -> b, x : a) -> c = f(g(x))`
 pub const FunctionDeclNode = struct {
     /// The name of the function being declared.
-    name: []const u8,
+    name: LowerIdentifierNode,
 
-    /// Optional AST node representing the type annotation.
-    type_annotation: ?*FunctionTypeNode,
+    /// Array of parameter declarations.
+    parameters: std.ArrayList(*ParamDeclNode),
+
+    /// Optional AST node representing the return type annotation.
+    return_type: ?*Node,
 
     // doc_comments: []*DocCommentNode,
 
@@ -1153,11 +1167,18 @@ pub const FunctionDeclNode = struct {
     token: lexer.Token,
 
     pub fn deinit(self: *FunctionDeclNode, allocator: std.mem.Allocator) void {
-        allocator.free(self.name);
+        self.name.deinit(allocator);
 
-        if (self.type_annotation) |type_annotation| {
-            type_annotation.deinit(allocator);
-            allocator.destroy(type_annotation);
+        for (self.parameters.items) |param| {
+            param.deinit(allocator);
+            allocator.destroy(param);
+        }
+
+        self.parameters.deinit();
+
+        if (self.return_type) |ret_type| {
+            ret_type.deinit(allocator);
+            allocator.destroy(ret_type);
         }
 
         self.value.deinit(allocator);
@@ -1171,28 +1192,38 @@ pub const FunctionDeclNode = struct {
 /// the internal name/type and external symbol to link against.
 ///
 /// Example:
-/// - `foreign sqrt : Float -> Float = "c_sqrt"`
-/// - `foreign print : String -> Unit = "c_print"`
+/// - `foreign sqrt(x : Float) -> Float = "c_sqrt"`
+/// - `foreign print(str : String) -> Unit = "c_print"`
 pub const ForeignFunctionDeclNode = struct {
     /// The internal name used to refer to this function.
-    name: []const u8,
+    name: LowerIdentifierNode,
 
-    /// The function's type signature.
-    type_annotation: *FunctionTypeNode,
+    /// Array of parameter declarations.
+    parameters: std.ArrayList(*ParamDeclNode),
+
+    /// The AST node representing the return type.
+    return_type: *Node,
 
     /// The external symbol name to link against.
-    external_name: []const u8,
+    external_name: *StrLiteralNode,
 
     /// The token representing the start of this declaration.
     token: lexer.Token,
 
     pub fn deinit(self: *ForeignFunctionDeclNode, allocator: std.mem.Allocator) void {
-        allocator.free(self.name);
+        self.name.deinit(allocator);
 
-        self.type_annotation.deinit(allocator);
-        allocator.destroy(self.type_annotation);
+        for (self.parameters.items) |param| {
+            param.deinit(allocator);
+            allocator.destroy(param);
+        }
 
-        allocator.free(self.external_name);
+        self.parameters.deinit();
+
+        self.return_type.deinit(allocator);
+        allocator.destroy(self.return_type);
+
+        self.external_name.deinit(allocator);
 
         allocator.destroy(self);
     }
@@ -1291,15 +1322,14 @@ pub const Node = union(enum) {
     match_expr: *MatchExprNode,
 
     // Functions and Applications
-    function_type: *FunctionTypeNode,
+    function_signature: *FunctionSignatureNode,
     lambda_expr: *LambdaExprNode,
-    function_application: *FuncApplicationNode,
+    function_call: *FunctionCallNode,
 
     // Advanced Expressions
     cons_expr: *ConsExprNode,
     str_concat_expr: *StrConcatExprNode,
     list_concat_expr: *ListConcatExprNode,
-    composition_expr: *CompositionExprNode,
     pipe_expr: *PipeExprNode,
 
     // Control Flow
@@ -1358,15 +1388,14 @@ pub const Node = union(enum) {
             .match_expr => |expr| expr.deinit(allocator),
 
             // Functions and Applications
-            .function_type => |ftype| ftype.deinit(allocator),
+            .function_signature => |sig| sig.deinit(allocator),
             .lambda_expr => |expr| expr.deinit(allocator),
-            .function_application => |expr| expr.deinit(allocator),
+            .function_call => |expr| expr.deinit(allocator),
 
             // Advanced Expressions
             .cons_expr => |expr| expr.deinit(allocator),
             .str_concat_expr => |expr| expr.deinit(allocator),
             .list_concat_expr => |expr| expr.deinit(allocator),
-            .composition_expr => |expr| expr.deinit(allocator),
             .pipe_expr => |expr| expr.deinit(allocator),
 
             // Control Flow
@@ -2297,37 +2326,48 @@ test "[MatchExprNode]" {
 
     {
         // Test basic constructor pattern matching
-        // Test input: match opt on | Some x => x | None => 0
+        // Test input: match opt on | Some(x) => x | None => 0
 
         // Action
-        const value_ident = LowerIdentifierNode{
-            .identifier = try allocator.dupe(u8, "opt"),
-            .token = lexer.Token{
-                .kind = .{ .identifier = .Lower },
-                .lexeme = "opt",
-                .loc = .{
-                    .filename = TEST_FILE,
-                    .span = .{ .start = 0, .end = 3 },
-                    .src = .{ .line = 1, .col = 1 },
+        const subject_node = try allocator.create(Node);
+        subject_node.* = .{
+            .lower_identifier = .{
+                .identifier = try allocator.dupe(u8, "opt"),
+                .token = lexer.Token{
+                    .kind = .{ .identifier = .Lower },
+                    .lexeme = "opt",
+                    .loc = .{
+                        .filename = TEST_FILE,
+                        .span = .{ .start = 6, .end = 9 },
+                        .src = .{ .line = 1, .col = 7 },
+                    },
                 },
             },
         };
-
-        const subject_node = try allocator.create(Node);
-        subject_node.* = .{ .lower_identifier = value_ident };
 
         // Case 1: Some x => x
         const var_pattern = try allocator.create(PatternNode);
         var_pattern.* = .{
             .variable = .{
-                .name = try allocator.dupe(u8, "x"),
+                .name = .{
+                    .identifier = try allocator.dupe(u8, "x"),
+                    .token = .{
+                        .kind = .{ .identifier = .Lower },
+                        .lexeme = "x",
+                        .loc = .{
+                            .filename = TEST_FILE,
+                            .span = .{ .start = 20, .end = 21 },
+                            .src = .{ .line = 1, .col = 21 },
+                        },
+                    },
+                },
                 .token = .{
                     .kind = .{ .identifier = .Lower },
                     .lexeme = "x",
                     .loc = .{
                         .filename = TEST_FILE,
-                        .span = .{ .start = 0, .end = 1 },
-                        .src = .{ .line = 1, .col = 1 },
+                        .span = .{ .start = 20, .end = 21 },
+                        .src = .{ .line = 1, .col = 21 },
                     },
                 },
             },
@@ -2346,28 +2386,28 @@ test "[MatchExprNode]" {
                     .lexeme = "Some",
                     .loc = .{
                         .filename = TEST_FILE,
-                        .span = .{ .start = 0, .end = 4 },
-                        .src = .{ .line = 1, .col = 1 },
+                        .span = .{ .start = 15, .end = 19 },
+                        .src = .{ .line = 1, .col = 16 },
                     },
                 },
             },
         };
 
-        const var_result = LowerIdentifierNode{
-            .identifier = try allocator.dupe(u8, "x"),
-            .token = .{
-                .kind = .{ .identifier = .Lower },
-                .lexeme = "x",
-                .loc = .{
-                    .filename = TEST_FILE,
-                    .span = .{ .start = 0, .end = 1 },
-                    .src = .{ .line = 1, .col = 1 },
+        const some_expr = try allocator.create(Node);
+        some_expr.* = .{
+            .lower_identifier = .{
+                .identifier = try allocator.dupe(u8, "x"),
+                .token = .{
+                    .kind = .{ .identifier = .Lower },
+                    .lexeme = "x",
+                    .loc = .{
+                        .filename = TEST_FILE,
+                        .span = .{ .start = 26, .end = 27 },
+                        .src = .{ .line = 1, .col = 27 },
+                    },
                 },
             },
         };
-
-        const some_expr = try allocator.create(Node);
-        some_expr.* = .{ .lower_identifier = var_result };
 
         const some_case = try allocator.create(MatchCase);
         some_case.* = .{
@@ -2379,8 +2419,8 @@ test "[MatchExprNode]" {
                 .lexeme = "|",
                 .loc = .{
                     .filename = TEST_FILE,
-                    .span = .{ .start = 0, .end = 1 },
-                    .src = .{ .line = 1, .col = 1 },
+                    .span = .{ .start = 13, .end = 14 },
+                    .src = .{ .line = 1, .col = 14 },
                 },
             },
         };
@@ -2396,8 +2436,8 @@ test "[MatchExprNode]" {
                     .lexeme = "None",
                     .loc = .{
                         .filename = TEST_FILE,
-                        .span = .{ .start = 0, .end = 4 },
-                        .src = .{ .line = 1, .col = 1 },
+                        .span = .{ .start = 30, .end = 34 },
+                        .src = .{ .line = 1, .col = 31 },
                     },
                 },
             },
@@ -2412,8 +2452,8 @@ test "[MatchExprNode]" {
                     .lexeme = "0",
                     .loc = .{
                         .filename = TEST_FILE,
-                        .span = .{ .start = 0, .end = 1 },
-                        .src = .{ .line = 1, .col = 1 },
+                        .span = .{ .start = 38, .end = 39 },
+                        .src = .{ .line = 1, .col = 39 },
                     },
                 },
             },
@@ -2429,8 +2469,8 @@ test "[MatchExprNode]" {
                 .lexeme = "|",
                 .loc = .{
                     .filename = TEST_FILE,
-                    .span = .{ .start = 0, .end = 1 },
-                    .src = .{ .line = 1, .col = 1 },
+                    .span = .{ .start = 28, .end = 29 },
+                    .src = .{ .line = 1, .col = 29 },
                 },
             },
         };
@@ -2477,7 +2517,7 @@ test "[MatchExprNode]" {
         try testing.expectEqualStrings("Some", case1.pattern.constructor.name);
 
         // Check the argument for the "Some" constructor is a variable named "x"
-        try testing.expectEqualStrings("x", case1.pattern.constructor.parameters.items[0].variable.name);
+        try testing.expectEqualStrings("x", case1.pattern.constructor.parameters.items[0].variable.name.identifier);
 
         // Ensure the constructor name for the second case is "None"
         const case2 = match.cases.items[1];
@@ -2493,34 +2533,45 @@ test "[MatchExprNode]" {
 
         // Action
         // Value to match on (a list variable)
-        const value_ident = LowerIdentifierNode{
-            .identifier = try allocator.dupe(u8, "list"),
-            .token = .{
-                .kind = .{ .identifier = .Lower },
-                .lexeme = "list",
-                .loc = .{
-                    .filename = TEST_FILE,
-                    .span = .{ .start = 0, .end = 4 },
-                    .src = .{ .line = 1, .col = 1 },
+        const subject_node = try allocator.create(Node);
+        subject_node.* = .{
+            .lower_identifier = .{
+                .identifier = try allocator.dupe(u8, "list"),
+                .token = .{
+                    .kind = .{ .identifier = .Lower },
+                    .lexeme = "list",
+                    .loc = .{
+                        .filename = TEST_FILE,
+                        .span = .{ .start = 6, .end = 10 },
+                        .src = .{ .line = 1, .col = 7 },
+                    },
                 },
             },
         };
-
-        const subject_node = try allocator.create(Node);
-        subject_node.* = .{ .lower_identifier = value_ident };
 
         // Case 1: head :: tail => head
         const head_pattern = try allocator.create(PatternNode);
         head_pattern.* = .{
             .variable = .{
-                .name = try allocator.dupe(u8, "head"),
+                .name = .{
+                    .identifier = try allocator.dupe(u8, "head"),
+                    .token = .{
+                        .kind = .{ .identifier = .Lower },
+                        .lexeme = "head",
+                        .loc = .{
+                            .filename = TEST_FILE,
+                            .span = .{ .start = 15, .end = 19 },
+                            .src = .{ .line = 1, .col = 16 },
+                        },
+                    },
+                },
                 .token = .{
                     .kind = .{ .identifier = .Lower },
                     .lexeme = "head",
                     .loc = .{
                         .filename = TEST_FILE,
-                        .span = .{ .start = 0, .end = 4 },
-                        .src = .{ .line = 1, .col = 1 },
+                        .span = .{ .start = 15, .end = 19 },
+                        .src = .{ .line = 1, .col = 16 },
                     },
                 },
             },
@@ -2529,14 +2580,25 @@ test "[MatchExprNode]" {
         const tail_pattern = try allocator.create(PatternNode);
         tail_pattern.* = .{
             .variable = .{
-                .name = try allocator.dupe(u8, "tail"),
+                .name = .{
+                    .identifier = try allocator.dupe(u8, "tail"),
+                    .token = .{
+                        .kind = .{ .identifier = .Lower },
+                        .lexeme = "tail",
+                        .loc = .{
+                            .filename = TEST_FILE,
+                            .span = .{ .start = 23, .end = 27 },
+                            .src = .{ .line = 1, .col = 24 },
+                        },
+                    },
+                },
                 .token = .{
                     .kind = .{ .identifier = .Lower },
                     .lexeme = "tail",
                     .loc = .{
                         .filename = TEST_FILE,
-                        .span = .{ .start = 0, .end = 4 },
-                        .src = .{ .line = 1, .col = 1 },
+                        .span = .{ .start = 23, .end = 27 },
+                        .src = .{ .line = 1, .col = 24 },
                     },
                 },
             },
@@ -2552,28 +2614,28 @@ test "[MatchExprNode]" {
                     .lexeme = "::",
                     .loc = .{
                         .filename = TEST_FILE,
-                        .span = .{ .start = 0, .end = 2 },
-                        .src = .{ .line = 1, .col = 1 },
+                        .span = .{ .start = 20, .end = 22 },
+                        .src = .{ .line = 1, .col = 21 },
                     },
                 },
             },
         };
 
-        const head_ident = LowerIdentifierNode{
-            .identifier = try allocator.dupe(u8, "head"),
-            .token = .{
-                .kind = .{ .identifier = .Lower },
-                .lexeme = "head",
-                .loc = .{
-                    .filename = TEST_FILE,
-                    .span = .{ .start = 0, .end = 4 },
-                    .src = .{ .line = 1, .col = 1 },
+        const head_expr = try allocator.create(Node);
+        head_expr.* = .{
+            .lower_identifier = .{
+                .identifier = try allocator.dupe(u8, "head"),
+                .token = .{
+                    .kind = .{ .identifier = .Lower },
+                    .lexeme = "head",
+                    .loc = .{
+                        .filename = TEST_FILE,
+                        .span = .{ .start = 32, .end = 36 },
+                        .src = .{ .line = 1, .col = 33 },
+                    },
                 },
             },
         };
-
-        const head_expr = try allocator.create(Node);
-        head_expr.* = .{ .lower_identifier = head_ident };
 
         const cons_case = try allocator.create(MatchCase);
         cons_case.* = .{
@@ -2585,8 +2647,8 @@ test "[MatchExprNode]" {
                 .lexeme = "|",
                 .loc = .{
                     .filename = TEST_FILE,
-                    .span = .{ .start = 0, .end = 1 },
-                    .src = .{ .line = 1, .col = 1 },
+                    .span = .{ .start = 13, .end = 14 },
+                    .src = .{ .line = 1, .col = 14 },
                 },
             },
         };
@@ -2600,8 +2662,8 @@ test "[MatchExprNode]" {
                     .lexeme = "[]",
                     .loc = .{
                         .filename = TEST_FILE,
-                        .span = .{ .start = 0, .end = 2 },
-                        .src = .{ .line = 1, .col = 1 },
+                        .span = .{ .start = 39, .end = 41 },
+                        .src = .{ .line = 1, .col = 40 },
                     },
                 },
             },
@@ -2616,8 +2678,8 @@ test "[MatchExprNode]" {
                     .lexeme = "0",
                     .loc = .{
                         .filename = TEST_FILE,
-                        .span = .{ .start = 0, .end = 1 },
-                        .src = .{ .line = 1, .col = 1 },
+                        .span = .{ .start = 45, .end = 46 },
+                        .src = .{ .line = 1, .col = 46 },
                     },
                 },
             },
@@ -2633,8 +2695,8 @@ test "[MatchExprNode]" {
                 .lexeme = "|",
                 .loc = .{
                     .filename = TEST_FILE,
-                    .span = .{ .start = 0, .end = 1 },
-                    .src = .{ .line = 1, .col = 1 },
+                    .span = .{ .start = 37, .end = 38 },
+                    .src = .{ .line = 1, .col = 38 },
                 },
             },
         };
@@ -2682,10 +2744,10 @@ test "[MatchExprNode]" {
         try testing.expect(list_cons_case.pattern.* == .cons);
 
         // Ensure the name of the head variable in the cons pattern is "head"
-        try testing.expectEqualStrings("head", list_cons_case.pattern.cons.head.variable.name);
+        try testing.expectEqualStrings("head", list_cons_case.pattern.cons.head.variable.name.identifier);
 
         // Ensure the name of the tail variable in the cons pattern is "tail"
-        try testing.expectEqualStrings("tail", list_cons_case.pattern.cons.tail.variable.name);
+        try testing.expectEqualStrings("tail", list_cons_case.pattern.cons.tail.variable.name.identifier);
 
         // Test the second case (empty list pattern)
         const empty_list_case = match.cases.items[1];
@@ -2699,54 +2761,65 @@ test "[MatchExprNode]" {
         // Test input: match x on | n when n > 0 => "positive" | n => "non-positive"
 
         // Action
-        const value_ident = LowerIdentifierNode{
-            .identifier = try allocator.dupe(u8, "x"),
-            .token = .{
-                .kind = .{ .identifier = .Lower },
-                .lexeme = "x",
-                .loc = .{
-                    .filename = TEST_FILE,
-                    .span = .{ .start = 0, .end = 1 },
-                    .src = .{ .line = 1, .col = 1 },
-                },
-            },
-        };
-
         const subject_node = try allocator.create(Node);
-        subject_node.* = .{ .lower_identifier = value_ident };
-
-        // Case 1: n when n > 0 => "positive"
-        const n_pattern = try allocator.create(PatternNode);
-        n_pattern.* = .{
-            .variable = .{
-                .name = try allocator.dupe(u8, "n"),
+        subject_node.* = .{
+            .lower_identifier = .{
+                .identifier = try allocator.dupe(u8, "x"),
                 .token = .{
                     .kind = .{ .identifier = .Lower },
-                    .lexeme = "n",
+                    .lexeme = "x",
                     .loc = .{
                         .filename = TEST_FILE,
-                        .span = .{ .start = 0, .end = 1 },
-                        .src = .{ .line = 1, .col = 1 },
+                        .span = .{ .start = 6, .end = 7 },
+                        .src = .{ .line = 1, .col = 7 },
                     },
                 },
             },
         };
 
-        const n_ident = LowerIdentifierNode{
-            .identifier = try allocator.dupe(u8, "n"),
-            .token = .{
-                .kind = .{ .identifier = .Lower },
-                .lexeme = "n",
-                .loc = .{
-                    .filename = TEST_FILE,
-                    .span = .{ .start = 0, .end = 1 },
-                    .src = .{ .line = 1, .col = 1 },
+        // Case 1: n when n > 0 => "positive"
+        const n_pattern = try allocator.create(PatternNode);
+        n_pattern.* = .{
+            .variable = .{
+                .name = .{
+                    .identifier = try allocator.dupe(u8, "n"),
+                    .token = .{
+                        .kind = .{ .identifier = .Lower },
+                        .lexeme = "n",
+                        .loc = .{
+                            .filename = TEST_FILE,
+                            .span = .{ .start = 13, .end = 14 },
+                            .src = .{ .line = 1, .col = 14 },
+                        },
+                    },
+                },
+                .token = .{
+                    .kind = .{ .identifier = .Lower },
+                    .lexeme = "n",
+                    .loc = .{
+                        .filename = TEST_FILE,
+                        .span = .{ .start = 13, .end = 14 },
+                        .src = .{ .line = 1, .col = 14 },
+                    },
                 },
             },
         };
 
         const n_ref = try allocator.create(Node);
-        n_ref.* = .{ .lower_identifier = n_ident };
+        n_ref.* = .{
+            .lower_identifier = .{
+                .identifier = try allocator.dupe(u8, "n"),
+                .token = .{
+                    .kind = .{ .identifier = .Lower },
+                    .lexeme = "n",
+                    .loc = .{
+                        .filename = TEST_FILE,
+                        .span = .{ .start = 15, .end = 16 },
+                        .src = .{ .line = 1, .col = 16 },
+                    },
+                },
+            },
+        };
 
         const zero_node = try allocator.create(Node);
         zero_node.* = .{
@@ -2757,8 +2830,8 @@ test "[MatchExprNode]" {
                     .lexeme = "0",
                     .loc = .{
                         .filename = TEST_FILE,
-                        .span = .{ .start = 0, .end = 1 },
-                        .src = .{ .line = 1, .col = 1 },
+                        .span = .{ .start = 19, .end = 20 },
+                        .src = .{ .line = 1, .col = 20 },
                     },
                 },
             },
@@ -2773,8 +2846,8 @@ test "[MatchExprNode]" {
                 .lexeme = ">",
                 .loc = .{
                     .filename = TEST_FILE,
-                    .span = .{ .start = 0, .end = 1 },
-                    .src = .{ .line = 1, .col = 1 },
+                    .span = .{ .start = 17, .end = 18 },
+                    .src = .{ .line = 1, .col = 18 },
                 },
             },
         };
@@ -2790,8 +2863,8 @@ test "[MatchExprNode]" {
                 .lexeme = "when",
                 .loc = .{
                     .filename = TEST_FILE,
-                    .span = .{ .start = 0, .end = 4 },
-                    .src = .{ .line = 1, .col = 1 },
+                    .span = .{ .start = 15, .end = 19 },
+                    .src = .{ .line = 1, .col = 16 },
                 },
             },
         };
@@ -2804,8 +2877,8 @@ test "[MatchExprNode]" {
                 .lexeme = "\"positive\"",
                 .loc = .{
                     .filename = TEST_FILE,
-                    .span = .{ .start = 0, .end = 10 },
-                    .src = .{ .line = 1, .col = 1 },
+                    .span = .{ .start = 24, .end = 34 },
+                    .src = .{ .line = 1, .col = 25 },
                 },
             },
         };
@@ -2823,8 +2896,8 @@ test "[MatchExprNode]" {
                 .lexeme = "|",
                 .loc = .{
                     .filename = TEST_FILE,
-                    .span = .{ .start = 0, .end = 1 },
-                    .src = .{ .line = 1, .col = 1 },
+                    .span = .{ .start = 12, .end = 13 },
+                    .src = .{ .line = 1, .col = 13 },
                 },
             },
         };
@@ -2833,14 +2906,25 @@ test "[MatchExprNode]" {
         const n2_pattern = try allocator.create(PatternNode);
         n2_pattern.* = .{
             .variable = .{
-                .name = try allocator.dupe(u8, "n"),
+                .name = .{
+                    .identifier = try allocator.dupe(u8, "n"),
+                    .token = .{
+                        .kind = .{ .identifier = .Lower },
+                        .lexeme = "n",
+                        .loc = .{
+                            .filename = TEST_FILE,
+                            .span = .{ .start = 36, .end = 37 },
+                            .src = .{ .line = 1, .col = 37 },
+                        },
+                    },
+                },
                 .token = .{
                     .kind = .{ .identifier = .Lower },
                     .lexeme = "n",
                     .loc = .{
                         .filename = TEST_FILE,
-                        .span = .{ .start = 0, .end = 1 },
-                        .src = .{ .line = 1, .col = 1 },
+                        .span = .{ .start = 36, .end = 37 },
+                        .src = .{ .line = 1, .col = 37 },
                     },
                 },
             },
@@ -2854,8 +2938,8 @@ test "[MatchExprNode]" {
                 .lexeme = "\"non-positive\"",
                 .loc = .{
                     .filename = TEST_FILE,
-                    .span = .{ .start = 0, .end = 14 },
-                    .src = .{ .line = 1, .col = 1 },
+                    .span = .{ .start = 41, .end = 55 },
+                    .src = .{ .line = 1, .col = 42 },
                 },
             },
         };
@@ -2873,8 +2957,8 @@ test "[MatchExprNode]" {
                 .lexeme = "|",
                 .loc = .{
                     .filename = TEST_FILE,
-                    .span = .{ .start = 0, .end = 1 },
-                    .src = .{ .line = 1, .col = 1 },
+                    .span = .{ .start = 35, .end = 36 },
+                    .src = .{ .line = 1, .col = 36 },
                 },
             },
         };
@@ -2922,7 +3006,7 @@ test "[MatchExprNode]" {
         try testing.expect(positive_case.pattern.* == .variable);
 
         // Verify the name of the variable
-        try testing.expectEqualStrings("n", positive_case.pattern.variable.name);
+        try testing.expectEqualStrings("n", positive_case.pattern.variable.name.identifier);
 
         // Ensure the guarded case has a guard condition
         try testing.expect(positive_case.guard != null);
@@ -2937,7 +3021,7 @@ test "[MatchExprNode]" {
         try testing.expect(non_positive_case.pattern.* == .variable);
 
         // Ensure the name of the variable in the pattern is "n"
-        try testing.expectEqualStrings("n", non_positive_case.pattern.variable.name);
+        try testing.expectEqualStrings("n", non_positive_case.pattern.variable.name.identifier);
 
         // Ensure the catch-all case does not have a guard condition
         try testing.expect(non_positive_case.guard == null);
@@ -2947,8 +3031,8 @@ test "[MatchExprNode]" {
     }
 }
 
-test "[FunctionTypeNode]" {
-    // Test input: : Int -> Int -> Int
+test "[FunctionSignatureNode]" {
+    // Test input: : (Int, Int) -> Int
 
     // Setup
     var gpa = std.heap.GeneralPurposeAllocator(.{}){};
@@ -2963,8 +3047,8 @@ test "[FunctionTypeNode]" {
             .lexeme = "Int",
             .loc = .{
                 .filename = TEST_FILE,
-                .span = .{ .start = 2, .end = 5 },
-                .src = .{ .line = 1, .col = 3 },
+                .span = .{ .start = 1, .end = 4 },
+                .src = .{ .line = 1, .col = 2 },
             },
         },
     };
@@ -2979,8 +3063,8 @@ test "[FunctionTypeNode]" {
             .lexeme = "Int",
             .loc = .{
                 .filename = TEST_FILE,
-                .span = .{ .start = 9, .end = 12 },
-                .src = .{ .line = 1, .col = 10 },
+                .span = .{ .start = 6, .end = 9 },
+                .src = .{ .line = 1, .col = 7 },
             },
         },
     };
@@ -2995,30 +3079,32 @@ test "[FunctionTypeNode]" {
             .lexeme = "Int",
             .loc = .{
                 .filename = TEST_FILE,
-                .span = .{ .start = 16, .end = 19 },
-                .src = .{ .line = 1, .col = 17 },
+                .span = .{ .start = 14, .end = 17 },
+                .src = .{ .line = 1, .col = 15 },
             },
         },
     };
 
-    const int_node3 = try allocator.create(Node);
-    int_node3.* = .{ .upper_identifier = int_type3 };
+    const return_type_node = try allocator.create(Node);
+    return_type_node.* = .{ .upper_identifier = int_type3 };
 
-    var signature_types = std.ArrayList(*Node).init(allocator);
-    try signature_types.append(int_node1);
-    try signature_types.append(int_node2);
-    try signature_types.append(int_node3);
+    var parameter_types = std.ArrayList(*Node).init(allocator);
+    try parameter_types.append(int_node1);
+    try parameter_types.append(int_node2);
 
-    const ftype_node = try allocator.create(FunctionTypeNode);
-    ftype_node.* = .{
-        .signature_types = signature_types,
+    const func_signature = try allocator.create(FunctionSignatureNode);
+    defer allocator.destroy(func_signature);
+
+    func_signature.* = .{
+        .parameter_types = parameter_types,
+        .return_type = return_type_node,
         .token = lexer.Token{
-            .kind = lexer.TokenKind{ .delimiter = .Colon },
-            .lexeme = ":",
+            .kind = lexer.TokenKind{ .symbol = .ArrowRight },
+            .lexeme = "->",
             .loc = .{
                 .filename = TEST_FILE,
-                .span = .{ .start = 0, .end = 1 },
-                .src = .{ .line = 1, .col = 1 },
+                .span = .{ .start = 11, .end = 13 },
+                .src = .{ .line = 1, .col = 12 },
             },
         },
     };
@@ -3027,44 +3113,38 @@ test "[FunctionTypeNode]" {
     defer {
         node.deinit(allocator);
         allocator.destroy(node);
-
-        allocator.destroy(ftype_node);
     }
 
-    node.* = .{ .function_type = ftype_node };
+    node.* = .{ .function_signature = func_signature };
 
     // Assertions
-    // Verify the node is a function type
-    try testing.expect(node.* == .function_type);
+    // Verify the node is a function signature
+    try testing.expect(node.* == .function_signature);
 
-    const ftype = node.function_type;
+    const signature = node.function_signature;
 
-    // Check the delimiter in the function type is a colon (:)
-    try testing.expectEqual(lexer.TokenKind{ .delimiter = .Colon }, ftype.token.kind);
+    // Verify function signature has exactly two parameter types
+    try testing.expectEqual(@as(usize, 2), signature.parameter_types.items.len);
 
-    // Verify the lexeme
-    try testing.expectEqualStrings(":", ftype.token.lexeme);
+    // Check the first parameter type is Int
+    try testing.expect(signature.parameter_types.items[0].* == .upper_identifier);
+    try testing.expectEqualStrings("Int", signature.parameter_types.items[0].upper_identifier.identifier);
 
-    // Check the function type has exactly three parameter types
-    try testing.expectEqual(@as(usize, 3), ftype.signature_types.items.len);
+    // Check the second parameter type is Int
+    try testing.expect(signature.parameter_types.items[1].* == .upper_identifier);
+    try testing.expectEqualStrings("Int", signature.parameter_types.items[1].upper_identifier.identifier);
 
-    for (ftype.signature_types.items) |stype| {
-        // Verify the parameter type is an upper-case identifier
-        try testing.expect(stype.* == .upper_identifier);
+    // Check the return type is Int
+    try testing.expect(signature.return_type.* == .upper_identifier);
+    try testing.expectEqualStrings("Int", signature.return_type.upper_identifier.identifier);
 
-        // Ensure the token kind of the parameter type is an upper-case identifier
-        try testing.expectEqual(lexer.TokenKind{ .identifier = .Upper }, stype.upper_identifier.token.kind);
-
-        // Check the name of the parameter type
-        try testing.expectEqualStrings("Int", stype.upper_identifier.identifier);
-
-        // Check the lexeme for the parameter type
-        try testing.expectEqualStrings("Int", stype.upper_identifier.token.lexeme);
-    }
+    // Verify the token is the arrow symbol
+    try testing.expectEqual(lexer.TokenKind{ .symbol = .ArrowRight }, signature.token.kind);
+    try testing.expectEqualStrings("->", signature.token.lexeme);
 }
 
 test "[LambdaExprNode]" {
-    // Test input: \x y => x + y
+    // Test input: fn(x, y) => x + y
 
     // Setup
     var gpa = std.heap.GeneralPurposeAllocator(.{}){};
@@ -3072,9 +3152,50 @@ test "[LambdaExprNode]" {
     const allocator = gpa.allocator();
 
     // Action
-    var param_names = std.ArrayList([]const u8).init(allocator);
-    try param_names.append(try allocator.dupe(u8, "x"));
-    try param_names.append(try allocator.dupe(u8, "y"));
+    var parameters = std.ArrayList(*ParamDeclNode).init(allocator);
+
+    const x_param_ident = LowerIdentifierNode{
+        .identifier = try allocator.dupe(u8, "x"),
+        .token = lexer.Token{
+            .kind = lexer.TokenKind{ .identifier = .Lower },
+            .lexeme = "x",
+            .loc = .{
+                .filename = TEST_FILE,
+                .span = .{ .start = 3, .end = 4 },
+                .src = .{ .line = 1, .col = 4 },
+            },
+        },
+    };
+
+    const x_param = try allocator.create(ParamDeclNode);
+    x_param.* = .{
+        .name = x_param_ident,
+        .type_annotation = null,
+        .token = x_param_ident.token,
+    };
+
+    const y_param_ident = LowerIdentifierNode{
+        .identifier = try allocator.dupe(u8, "y"),
+        .token = lexer.Token{
+            .kind = lexer.TokenKind{ .identifier = .Lower },
+            .lexeme = "y",
+            .loc = .{
+                .filename = TEST_FILE,
+                .span = .{ .start = 6, .end = 7 },
+                .src = .{ .line = 1, .col = 7 },
+            },
+        },
+    };
+
+    const y_param = try allocator.create(ParamDeclNode);
+    y_param.* = .{
+        .name = y_param_ident,
+        .type_annotation = null,
+        .token = y_param_ident.token,
+    };
+
+    try parameters.append(x_param);
+    try parameters.append(y_param);
 
     const x_ident = LowerIdentifierNode{
         .identifier = try allocator.dupe(u8, "x"),
@@ -3083,8 +3204,8 @@ test "[LambdaExprNode]" {
             .lexeme = "x",
             .loc = .{
                 .filename = TEST_FILE,
-                .span = .{ .start = 7, .end = 8 },
-                .src = .{ .line = 1, .col = 8 },
+                .span = .{ .start = 12, .end = 13 },
+                .src = .{ .line = 1, .col = 13 },
             },
         },
     };
@@ -3099,8 +3220,8 @@ test "[LambdaExprNode]" {
             .lexeme = "y",
             .loc = .{
                 .filename = TEST_FILE,
-                .span = .{ .start = 10, .end = 11 },
-                .src = .{ .line = 1, .col = 11 },
+                .span = .{ .start = 16, .end = 17 },
+                .src = .{ .line = 1, .col = 17 },
             },
         },
     };
@@ -3117,8 +3238,8 @@ test "[LambdaExprNode]" {
             .lexeme = "+",
             .loc = .{
                 .filename = TEST_FILE,
-                .span = .{ .start = 8, .end = 9 },
-                .src = .{ .line = 1, .col = 9 },
+                .span = .{ .start = 14, .end = 15 },
+                .src = .{ .line = 1, .col = 15 },
             },
         },
     };
@@ -3128,14 +3249,14 @@ test "[LambdaExprNode]" {
 
     const lambda_node = try allocator.create(LambdaExprNode);
     lambda_node.* = .{
-        .param_names = param_names,
+        .parameters = parameters,
         .body = body_node,
         .token = lexer.Token{
-            .kind = lexer.TokenKind{ .operator = .Lambda },
-            .lexeme = "\\",
+            .kind = lexer.TokenKind{ .keyword = .Fn },
+            .lexeme = "fn",
             .loc = .{
                 .filename = TEST_FILE,
-                .span = .{ .start = 0, .end = 1 },
+                .span = .{ .start = 0, .end = 2 },
                 .src = .{ .line = 1, .col = 1 },
             },
         },
@@ -3156,19 +3277,23 @@ test "[LambdaExprNode]" {
     const expr = node.lambda_expr;
 
     // Verify that the lambda expression has exactly two parameters
-    try testing.expectEqual(@as(usize, 2), expr.param_names.items.len);
-
-    // Ensure the first parameter is named "x"
-    try testing.expectEqualStrings("x", expr.param_names.items[0]);
-
-    // Ensure the second parameter is named "y"
-    try testing.expectEqualStrings("y", expr.param_names.items[1]);
+    try testing.expectEqual(@as(usize, 2), expr.parameters.items.len);
 
     // Verify the token kind matches
-    try testing.expectEqual(lexer.TokenKind{ .operator = .Lambda }, expr.token.kind);
+    try testing.expectEqual(lexer.TokenKind{ .keyword = .Fn }, expr.token.kind);
 
     // Verify the token lexeme matches
-    try testing.expectEqualStrings("\\", expr.token.lexeme);
+    try testing.expectEqualStrings("fn", expr.token.lexeme);
+
+    // Check first parameter (x)
+    const first_param = expr.parameters.items[0];
+    try testing.expectEqualStrings("x", first_param.name.identifier);
+    try testing.expect(first_param.type_annotation == null);
+
+    // Check second parameter (y)
+    const second_param = expr.parameters.items[1];
+    try testing.expectEqualStrings("y", second_param.name.identifier);
+    try testing.expect(second_param.type_annotation == null);
 
     const lambda_body = expr.body.arithmetic_expr;
 
@@ -3184,12 +3309,15 @@ test "[LambdaExprNode]" {
     // Verify the name of the left identifier is "x"
     try testing.expectEqualStrings("x", lambda_body.left.lower_identifier.identifier);
 
-    // Ensure the token kind of the left identifier is a lower-case identifier
-    try testing.expectEqual(lexer.TokenKind{ .identifier = .Lower }, lambda_body.left.lower_identifier.token.kind);
+    // Check the right operand is a lower-case identifier
+    try testing.expect(lambda_body.right.* == .lower_identifier);
+
+    // Verify the name of the right identifier is "y"
+    try testing.expectEqualStrings("y", lambda_body.right.lower_identifier.identifier);
 }
 
-test "[FuncApplicationNode]" {
-    // Test input: not True
+test "[FunctionCallNode]" {
+    // Test input: not(True)
 
     // Setup
     var gpa = std.heap.GeneralPurposeAllocator(.{}){};
@@ -3213,6 +3341,8 @@ test "[FuncApplicationNode]" {
     const func_node = try allocator.create(Node);
     func_node.* = .{ .lower_identifier = not_ident };
 
+    var arguments = std.ArrayList(*Node).init(allocator);
+
     const true_ident = UpperIdentifierNode{
         .identifier = try allocator.dupe(u8, "True"),
         .token = lexer.Token{
@@ -3229,10 +3359,12 @@ test "[FuncApplicationNode]" {
     const arg_node = try allocator.create(Node);
     arg_node.* = .{ .upper_identifier = true_ident };
 
-    const func_app = try allocator.create(FuncApplicationNode);
-    func_app.* = .{
+    try arguments.append(arg_node);
+
+    const function_call_node = try allocator.create(FunctionCallNode);
+    function_call_node.* = .{
         .function = func_node,
-        .argument = arg_node,
+        .arguments = arguments,
         .token = lexer.Token{
             .kind = lexer.TokenKind{ .identifier = .Lower },
             .lexeme = "not",
@@ -3250,29 +3382,28 @@ test "[FuncApplicationNode]" {
         allocator.destroy(node);
     }
 
-    node.* = .{ .function_application = func_app };
+    node.* = .{ .function_call = function_call_node };
 
     // Assertions
-    // Verify the node is a function application
-    try testing.expect(node.* == .function_application);
+    // Verify the node is a function call
+    try testing.expect(node.* == .function_call);
 
-    const app = node.function_application;
+    const call = node.function_call;
 
     // Verify that the function is a lower identifier named "not"
-    try testing.expect(app.function.* == .lower_identifier);
-    try testing.expectEqualStrings("not", app.function.lower_identifier.identifier);
-    try testing.expectEqual(lexer.TokenKind{ .identifier = .Lower }, app.function.lower_identifier.token.kind);
-    try testing.expectEqualStrings("not", app.function.lower_identifier.token.lexeme);
+    try testing.expect(call.function.* == .lower_identifier);
+    try testing.expectEqualStrings("not", call.function.lower_identifier.identifier);
+    try testing.expectEqual(lexer.TokenKind{ .identifier = .Lower }, call.function.lower_identifier.token.kind);
 
     // Verify that the argument is an upper identifier named "True"
-    try testing.expect(app.argument.* == .upper_identifier);
-    try testing.expectEqualStrings("True", app.argument.upper_identifier.identifier);
-    try testing.expectEqual(lexer.TokenKind{ .identifier = .Upper }, app.argument.upper_identifier.token.kind);
-    try testing.expectEqualStrings("True", app.argument.upper_identifier.token.lexeme);
+    const first_arg = call.arguments.items[0];
+    try testing.expect(first_arg.* == .upper_identifier);
+    try testing.expectEqualStrings("True", first_arg.upper_identifier.identifier);
+    try testing.expectEqual(lexer.TokenKind{ .identifier = .Upper }, first_arg.upper_identifier.token.kind);
 
     // Verify the function application token matches the function's token
-    try testing.expectEqual(app.token.kind, app.function.lower_identifier.token.kind);
-    try testing.expectEqualStrings(app.token.lexeme, app.function.lower_identifier.token.lexeme);
+    try testing.expectEqual(call.token.kind, call.function.lower_identifier.token.kind);
+    try testing.expectEqualStrings(call.token.lexeme, call.function.lower_identifier.token.lexeme);
 }
 
 test "[ConsExprNode]" {
@@ -3284,6 +3415,8 @@ test "[ConsExprNode]" {
     const allocator = gpa.allocator();
 
     // Action
+    var elements = std.ArrayList(*Node).init(allocator);
+
     const one_node = try allocator.create(Node);
     one_node.* = .{
         .int_literal = .{
@@ -3332,7 +3465,6 @@ test "[ConsExprNode]" {
         },
     };
 
-    var elements = std.ArrayList(*Node).init(allocator);
     try elements.append(two_node);
     try elements.append(three_node);
 
@@ -3503,6 +3635,8 @@ test "[ListConcatExprNode]" {
     const allocator = gpa.allocator();
 
     // Action
+    var left_elements = std.ArrayList(*Node).init(allocator);
+
     const one_node = try allocator.create(Node);
     one_node.* = .{
         .int_literal = .{
@@ -3535,7 +3669,6 @@ test "[ListConcatExprNode]" {
         },
     };
 
-    var left_elements = std.ArrayList(*Node).init(allocator);
     try left_elements.append(one_node);
     try left_elements.append(two_node);
 
@@ -3555,6 +3688,8 @@ test "[ListConcatExprNode]" {
 
     const left_node = try allocator.create(Node);
     left_node.* = .{ .list = left_list };
+
+    var right_elements = std.ArrayList(*Node).init(allocator);
 
     const three_node = try allocator.create(Node);
     three_node.* = .{
@@ -3588,7 +3723,6 @@ test "[ListConcatExprNode]" {
         },
     };
 
-    var right_elements = std.ArrayList(*Node).init(allocator);
     try right_elements.append(three_node);
     try right_elements.append(four_node);
 
@@ -3673,103 +3807,8 @@ test "[ListConcatExprNode]" {
     try testing.expectEqual(@as(i64, 4), expr.right.list.elements.items[1].int_literal.value);
 }
 
-test "[CompositionExprNode]" {
-    // Test input: f >> g (compose right)
-
-    // Setup
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
-    defer _ = gpa.deinit();
-    const allocator = gpa.allocator();
-
-    // Action
-    const f_ident = LowerIdentifierNode{
-        .identifier = try allocator.dupe(u8, "f"),
-        .token = .{
-            .kind = .{ .identifier = .Lower },
-            .lexeme = "f",
-            .loc = .{
-                .filename = TEST_FILE,
-                .span = .{ .start = 0, .end = 1 },
-                .src = .{ .line = 1, .col = 1 },
-            },
-        },
-    };
-
-    const first_node = try allocator.create(Node);
-    first_node.* = .{ .lower_identifier = f_ident };
-
-    const g_ident = LowerIdentifierNode{
-        .identifier = try allocator.dupe(u8, "g"),
-        .token = .{
-            .kind = .{ .identifier = .Lower },
-            .lexeme = "g",
-            .loc = .{
-                .filename = TEST_FILE,
-                .span = .{ .start = 5, .end = 6 },
-                .src = .{ .line = 1, .col = 6 },
-            },
-        },
-    };
-
-    const second_node = try allocator.create(Node);
-    second_node.* = .{ .lower_identifier = g_ident };
-
-    const composition_node = try allocator.create(CompositionExprNode);
-    composition_node.* = .{
-        .first = first_node,
-        .second = second_node,
-        .operator = .{
-            .kind = .{ .operator = .ComposeRight },
-            .lexeme = ">>",
-            .loc = .{
-                .filename = TEST_FILE,
-                .span = .{ .start = 2, .end = 4 },
-                .src = .{ .line = 1, .col = 3 },
-            },
-        },
-    };
-
-    const node = try allocator.create(Node);
-    defer {
-        node.deinit(allocator);
-        allocator.destroy(node);
-    }
-
-    node.* = .{ .composition_expr = composition_node };
-
-    // Assertions
-    // Verify the expression is a composition expression
-    try testing.expect(node.* == .composition_expr);
-
-    const expr = node.composition_expr;
-
-    // Verify the operator in the composition expression is a compose-right operator (>>)
-    try testing.expectEqual(lexer.TokenKind{ .operator = .ComposeRight }, expr.operator.kind);
-
-    // Verify the lexeme of the compose-right operator
-    try testing.expectEqualStrings(">>", expr.operator.lexeme);
-
-    // Verify the first function in the composition is a lower identifier
-    try testing.expect(expr.first.* == .lower_identifier);
-
-    // Verify the token kind of the first function is a lower identifier
-    try testing.expectEqual(lexer.TokenKind{ .identifier = .Lower }, expr.first.lower_identifier.token.kind);
-
-    // Verify the name of the first function is "f"
-    try testing.expectEqualStrings("f", expr.first.lower_identifier.identifier);
-
-    // Verify the second function in the composition is a lower identifier
-    try testing.expect(expr.second.* == .lower_identifier);
-
-    // Verify the token kind of the second function is a lower identifier
-    try testing.expectEqual(lexer.TokenKind{ .identifier = .Lower }, expr.second.lower_identifier.token.kind);
-
-    // Verify the name of the second function is "g"
-    try testing.expectEqualStrings("g", expr.second.lower_identifier.identifier);
-}
-
 test "[PipeExprNode]" {
-    // Test input: x |> f (pipe right)
+    // Test input: x |> f() (pipe right)
 
     // Setup
     var gpa = std.heap.GeneralPurposeAllocator(.{}){};
@@ -3806,8 +3845,28 @@ test "[PipeExprNode]" {
         },
     };
 
+    const f_node = try allocator.create(Node);
+    f_node.* = .{ .lower_identifier = f_ident };
+
+    const arguments = std.ArrayList(*Node).init(allocator);
+
+    const func_call_node = try allocator.create(FunctionCallNode);
+    func_call_node.* = .{
+        .function = f_node,
+        .arguments = arguments,
+        .token = .{
+            .kind = .{ .identifier = .Lower },
+            .lexeme = "f",
+            .loc = .{
+                .filename = TEST_FILE,
+                .span = .{ .start = 5, .end = 6 },
+                .src = .{ .line = 1, .col = 6 },
+            },
+        },
+    };
+
     const func_node = try allocator.create(Node);
-    func_node.* = .{ .lower_identifier = f_ident };
+    func_node.* = .{ .function_call = func_call_node };
 
     const pipe_node = try allocator.create(PipeExprNode);
     pipe_node.* = .{
@@ -3847,20 +3906,17 @@ test "[PipeExprNode]" {
     // Verify the value being piped is a lower identifier
     try testing.expect(expr.value.* == .lower_identifier);
 
-    // Verify the token kind of the value being piped is a lower identifier
-    try testing.expectEqual(lexer.TokenKind{ .identifier = .Lower }, expr.value.lower_identifier.token.kind);
+    // Verify the function being applied is a function call
+    try testing.expect(expr.func.* == .function_call);
 
-    // Verify the name of the value being piped is "x"
-    try testing.expectEqualStrings("x", expr.value.lower_identifier.identifier);
+    const func_call = expr.func.function_call;
 
-    // Verify the function being applied is a lower identifier
-    try testing.expect(expr.func.* == .lower_identifier);
+    // Verify the function call's function is a lower identifier with name "f"
+    try testing.expect(func_call.function.* == .lower_identifier);
+    try testing.expectEqualStrings("f", func_call.function.lower_identifier.identifier);
 
-    // Verify the token kind of the function being applied is a lower identifier
-    try testing.expectEqual(lexer.TokenKind{ .identifier = .Lower }, expr.func.lower_identifier.token.kind);
-
-    // Verify the name of the function being applied is "f".
-    try testing.expectEqualStrings("f", expr.func.lower_identifier.identifier);
+    // Verify the function call has no arguments (empty list)
+    try testing.expectEqual(@as(usize, 0), func_call.arguments.items.len);
 }
 
 test "[IfThenElseStmtNode]" {
@@ -4076,7 +4132,7 @@ test "[TypedHoleNode]" {
 }
 
 test "[TypeApplicationNode]" {
-    // Test input: Map k v
+    // Test input: Map(k, v)
 
     // Setup
     var gpa = std.heap.GeneralPurposeAllocator(.{}){};
@@ -4120,8 +4176,8 @@ test "[TypeApplicationNode]" {
             .lexeme = "v",
             .loc = .{
                 .filename = TEST_FILE,
-                .span = .{ .start = 6, .end = 7 },
-                .src = .{ .line = 1, .col = 7 },
+                .span = .{ .start = 7, .end = 8 },
+                .src = .{ .line = 1, .col = 8 },
             },
         },
     };
@@ -4187,6 +4243,19 @@ test "[TypeAliasNode]" {
     const allocator = gpa.allocator();
 
     // Action
+    const user_id_ident = UpperIdentifierNode{
+        .identifier = try allocator.dupe(u8, "UserId"),
+        .token = .{
+            .kind = .{ .identifier = .Upper },
+            .lexeme = "UserId",
+            .loc = .{
+                .filename = TEST_FILE,
+                .span = .{ .start = 11, .end = 17 },
+                .src = .{ .line = 1, .col = 12 },
+            },
+        },
+    };
+
     const type_params = std.ArrayList([]const u8).init(allocator);
 
     const string_ident = UpperIdentifierNode{
@@ -4196,8 +4265,8 @@ test "[TypeAliasNode]" {
             .lexeme = "String",
             .loc = .{
                 .filename = TEST_FILE,
-                .span = .{ .start = 18, .end = 24 },
-                .src = .{ .line = 1, .col = 19 },
+                .span = .{ .start = 20, .end = 26 },
+                .src = .{ .line = 1, .col = 21 },
             },
         },
     };
@@ -4207,7 +4276,7 @@ test "[TypeAliasNode]" {
 
     const type_alias = try allocator.create(TypeAliasNode);
     type_alias.* = .{
-        .name = try allocator.dupe(u8, "UserId"),
+        .name = user_id_ident,
         .type_params = type_params,
         .value = value_node,
         .token = .{
@@ -4243,7 +4312,7 @@ test "[TypeAliasNode]" {
     try testing.expectEqualStrings("type", node.type_alias.token.lexeme);
 
     // Verify the name of the type alias
-    try testing.expectEqualStrings("UserId", node.type_alias.name);
+    try testing.expectEqualStrings("UserId", node.type_alias.name.identifier);
 
     // Check the value node is an upper identifier
     try testing.expect(node.type_alias.value.* == .upper_identifier);
@@ -4261,7 +4330,7 @@ test "[TypeAliasNode]" {
 }
 
 test "[VariantTypeNode]" {
-    // Test input: type Result e a = | Err e | Ok a
+    // Test input: type Result(e, a) = | Err(e) | Ok(a)
 
     // Setup
     var gpa = std.heap.GeneralPurposeAllocator(.{}){};
@@ -4269,6 +4338,19 @@ test "[VariantTypeNode]" {
     const allocator = gpa.allocator();
 
     // Action
+    const result_ident = UpperIdentifierNode{
+        .identifier = try allocator.dupe(u8, "Result"),
+        .token = .{
+            .kind = .{ .identifier = .Upper },
+            .lexeme = "Result",
+            .loc = .{
+                .filename = TEST_FILE,
+                .span = .{ .start = 5, .end = 11 },
+                .src = .{ .line = 1, .col = 6 },
+            },
+        },
+    };
+
     var type_params = std.ArrayList([]const u8).init(allocator);
     try type_params.append(try allocator.dupe(u8, "e"));
     try type_params.append(try allocator.dupe(u8, "a"));
@@ -4280,8 +4362,8 @@ test "[VariantTypeNode]" {
             .lexeme = "e",
             .loc = .{
                 .filename = TEST_FILE,
-                .span = .{ .start = 18, .end = 19 },
-                .src = .{ .line = 1, .col = 19 },
+                .span = .{ .start = 22, .end = 23 },
+                .src = .{ .line = 1, .col = 23 },
             },
         },
     };
@@ -4292,17 +4374,30 @@ test "[VariantTypeNode]" {
     var err_params = std.ArrayList(*Node).init(allocator);
     try err_params.append(e_node);
 
+    const err_ident = UpperIdentifierNode{
+        .identifier = try allocator.dupe(u8, "Err"),
+        .token = .{
+            .kind = .{ .identifier = .Upper },
+            .lexeme = "Err",
+            .loc = .{
+                .filename = TEST_FILE,
+                .span = .{ .start = 18, .end = 21 },
+                .src = .{ .line = 1, .col = 19 },
+            },
+        },
+    };
+
     const err_constructor = try allocator.create(VariantConstructorNode);
     err_constructor.* = .{
-        .name = try allocator.dupe(u8, "Err"),
+        .name = err_ident,
         .parameters = err_params,
         .token = .{
             .kind = .{ .identifier = .Upper },
             .lexeme = "Err",
             .loc = .{
                 .filename = TEST_FILE,
-                .span = .{ .start = 24, .end = 27 },
-                .src = .{ .line = 1, .col = 25 },
+                .span = .{ .start = 18, .end = 21 },
+                .src = .{ .line = 1, .col = 19 },
             },
         },
     };
@@ -4314,8 +4409,8 @@ test "[VariantTypeNode]" {
             .lexeme = "a",
             .loc = .{
                 .filename = TEST_FILE,
-                .span = .{ .start = 32, .end = 33 },
-                .src = .{ .line = 1, .col = 33 },
+                .span = .{ .start = 29, .end = 30 },
+                .src = .{ .line = 1, .col = 30 },
             },
         },
     };
@@ -4326,17 +4421,30 @@ test "[VariantTypeNode]" {
     var ok_params = std.ArrayList(*Node).init(allocator);
     try ok_params.append(a_node);
 
+    const ok_ident = UpperIdentifierNode{
+        .identifier = try allocator.dupe(u8, "Ok"),
+        .token = .{
+            .kind = .{ .identifier = .Upper },
+            .lexeme = "Ok",
+            .loc = .{
+                .filename = TEST_FILE,
+                .span = .{ .start = 26, .end = 28 },
+                .src = .{ .line = 1, .col = 27 },
+            },
+        },
+    };
+
     const ok_constructor = try allocator.create(VariantConstructorNode);
     ok_constructor.* = .{
-        .name = try allocator.dupe(u8, "Ok"),
+        .name = ok_ident,
         .parameters = ok_params,
         .token = .{
             .kind = .{ .identifier = .Upper },
             .lexeme = "Ok",
             .loc = .{
                 .filename = TEST_FILE,
-                .span = .{ .start = 30, .end = 32 },
-                .src = .{ .line = 1, .col = 31 },
+                .span = .{ .start = 26, .end = 28 },
+                .src = .{ .line = 1, .col = 27 },
             },
         },
     };
@@ -4347,7 +4455,7 @@ test "[VariantTypeNode]" {
 
     const variant_type = try allocator.create(VariantTypeNode);
     variant_type.* = .{
-        .name = try allocator.dupe(u8, "Result"),
+        .name = result_ident,
         .type_params = type_params,
         .constructors = constructors,
         .token = .{
@@ -4373,48 +4481,47 @@ test "[VariantTypeNode]" {
     // Verify the node is a variant type
     try testing.expect(node.* == .variant_type);
 
+    const vtype = node.variant_type;
+
     // Verify the name of the variant type is "Result"
-    try testing.expectEqualStrings("Result", node.variant_type.name);
+    try testing.expectEqualStrings("Result", vtype.name.identifier);
 
     // Verify the variant type has exactly two type parameters
-    try testing.expectEqual(@as(usize, 2), node.variant_type.type_params.items.len);
+    try testing.expectEqual(@as(usize, 2), vtype.type_params.items.len);
 
     // Verify the name of the first type parameter is "e"
-    try testing.expectEqualStrings("e", node.variant_type.type_params.items[0]);
+    try testing.expectEqualStrings("e", vtype.type_params.items[0]);
 
     // Verify the name of the second type parameter is "a"
-    try testing.expectEqualStrings("a", node.variant_type.type_params.items[1]);
+    try testing.expectEqualStrings("a", vtype.type_params.items[1]);
+
+    const err_variant = vtype.constructors.items[0];
+
+    // Verify the name of the first constructor is "Err"
+    try testing.expectEqualStrings("Err", err_variant.name.identifier);
 
     // Verify the variant type has exactly two constructors
     try testing.expectEqual(@as(usize, 2), node.variant_type.constructors.items.len);
 
-    // Verify the name of the first constructor is "Err"
-    try testing.expectEqualStrings("Err", node.variant_type.constructors.items[0].name);
-
-    // Verify the name of the second constructor is "Ok"
-    try testing.expectEqualStrings("Ok", node.variant_type.constructors.items[1].name);
-
-    // "Err" constructor
-    const err_variant = node.variant_type.constructors.items[0];
-
-    // Verify the "Err" constructor has one parameter
-    try testing.expectEqual(@as(usize, 1), err_variant.parameters.items.len);
-
-    // Verify the name of the parameter for the "Err" constructor is "e"
+    // Verify the parameter for the "Err" constructor is "e"
+    try testing.expect(err_variant.parameters.items[0].* == .lower_identifier);
     try testing.expectEqualStrings("e", err_variant.parameters.items[0].lower_identifier.identifier);
 
-    // "Ok" constructor
-    const ok_variant = node.variant_type.constructors.items[1];
+    const ok_variant = vtype.constructors.items[1];
 
-    // Verify the "Ok" constructor has one parameter.
+    // Verify the name of the second constructor is "Ok"
+    try testing.expectEqualStrings("Ok", ok_variant.name.identifier);
+
+    // Verify the "Ok" constructor has one parameter
     try testing.expectEqual(@as(usize, 1), ok_variant.parameters.items.len);
 
-    // Verify the name of the parameter for the "Ok" constructor is "a".
+    // Verify the parameter for the "Ok" constructor is "a"
+    try testing.expect(ok_variant.parameters.items[0].* == .lower_identifier);
     try testing.expectEqualStrings("a", ok_variant.parameters.items[0].lower_identifier.identifier);
 }
 
 test "[RecordTypeNode]" {
-    // Test input: type Point a = { x: a, y: a }
+    // Test input: type Point a = { x : a, y : a }
 
     // Setup
     var gpa = std.heap.GeneralPurposeAllocator(.{}){};
@@ -4422,78 +4529,114 @@ test "[RecordTypeNode]" {
     const allocator = gpa.allocator();
 
     // Action
-    var type_params = std.ArrayList([]const u8).init(allocator);
-    try type_params.append(try allocator.dupe(u8, "a"));
-
-    const a_ident = LowerIdentifierNode{
-        .identifier = try allocator.dupe(u8, "a"),
+    const point_ident = UpperIdentifierNode{
+        .identifier = try allocator.dupe(u8, "Point"),
         .token = .{
-            .kind = .{ .identifier = .Lower },
-            .lexeme = "a",
+            .kind = .{ .identifier = .Upper },
+            .lexeme = "Point",
             .loc = .{
                 .filename = TEST_FILE,
-                .span = .{ .start = 15, .end = 16 },
-                .src = .{ .line = 1, .col = 16 },
+                .span = .{ .start = 5, .end = 10 },
+                .src = .{ .line = 1, .col = 6 },
             },
         },
     };
 
-    const type_x = try allocator.create(Node);
-    type_x.* = .{ .lower_identifier = a_ident };
+    var type_params = std.ArrayList([]const u8).init(allocator);
+    try type_params.append(try allocator.dupe(u8, "a"));
 
-    const a_ident2 = LowerIdentifierNode{
-        .identifier = try allocator.dupe(u8, "a"),
-        .token = .{
-            .kind = .{ .identifier = .Lower },
-            .lexeme = "a",
-            .loc = .{
-                .filename = TEST_FILE,
-                .span = .{ .start = 21, .end = 22 },
-                .src = .{ .line = 1, .col = 22 },
+    const type_x = try allocator.create(Node);
+    type_x.* = .{
+        .lower_identifier = .{
+            .identifier = try allocator.dupe(u8, "a"),
+            .token = .{
+                .kind = .{ .identifier = .Lower },
+                .lexeme = "a",
+                .loc = .{
+                    .filename = TEST_FILE,
+                    .span = .{ .start = 19, .end = 20 },
+                    .src = .{ .line = 1, .col = 20 },
+                },
             },
         },
     };
 
     const type_y = try allocator.create(Node);
-    type_y.* = .{ .lower_identifier = a_ident2 };
+    type_y.* = .{
+        .lower_identifier = .{
+            .identifier = try allocator.dupe(u8, "a"),
+            .token = .{
+                .kind = .{ .identifier = .Lower },
+                .lexeme = "a",
+                .loc = .{
+                    .filename = TEST_FILE,
+                    .span = .{ .start = 25, .end = 26 },
+                    .src = .{ .line = 1, .col = 26 },
+                },
+            },
+        },
+    };
+
+    var fields = std.ArrayList(*RecordFieldNode).init(allocator);
 
     const field_x = try allocator.create(RecordFieldNode);
     field_x.* = .{
-        .name = try allocator.dupe(u8, "x"),
+        .name = .{
+            .identifier = try allocator.dupe(u8, "x"),
+            .token = .{
+                .kind = .{ .identifier = .Lower },
+                .lexeme = "x",
+                .loc = .{
+                    .filename = TEST_FILE,
+                    .span = .{ .start = 17, .end = 18 },
+                    .src = .{ .line = 1, .col = 18 },
+                },
+            },
+        },
         .type = type_x,
         .token = .{
             .kind = .{ .identifier = .Lower },
             .lexeme = "x",
             .loc = .{
                 .filename = TEST_FILE,
-                .span = .{ .start = 13, .end = 14 },
-                .src = .{ .line = 1, .col = 14 },
+                .span = .{ .start = 17, .end = 18 },
+                .src = .{ .line = 1, .col = 18 },
             },
         },
     };
 
     const field_y = try allocator.create(RecordFieldNode);
     field_y.* = .{
-        .name = try allocator.dupe(u8, "y"),
+        .name = .{
+            .identifier = try allocator.dupe(u8, "y"),
+            .token = .{
+                .kind = .{ .identifier = .Lower },
+                .lexeme = "y",
+                .loc = .{
+                    .filename = TEST_FILE,
+                    .span = .{ .start = 23, .end = 24 },
+                    .src = .{ .line = 1, .col = 24 },
+                },
+            },
+        },
         .type = type_y,
         .token = .{
             .kind = .{ .identifier = .Lower },
             .lexeme = "y",
             .loc = .{
                 .filename = TEST_FILE,
-                .span = .{ .start = 19, .end = 20 },
-                .src = .{ .line = 1, .col = 20 },
+                .span = .{ .start = 23, .end = 24 },
+                .src = .{ .line = 1, .col = 24 },
             },
         },
     };
 
-    var fields = std.ArrayList(*RecordFieldNode).init(allocator);
     try fields.append(field_x);
     try fields.append(field_y);
 
     const rtype_node = try allocator.create(RecordTypeNode);
     rtype_node.* = .{
-        .name = try allocator.dupe(u8, "Point"),
+        .name = point_ident,
         .type_params = type_params,
         .fields = fields,
         .token = .{
@@ -4522,7 +4665,7 @@ test "[RecordTypeNode]" {
     const record = node.record_type;
 
     // Verify the name of the record type is "Point"
-    try testing.expectEqualStrings("Point", record.name);
+    try testing.expectEqualStrings("Point", record.name.identifier);
 
     // Ensure the record type has exactly one type parameter
     try testing.expectEqual(@as(usize, 1), record.type_params.items.len);
@@ -4537,7 +4680,7 @@ test "[RecordTypeNode]" {
     const x_field = record.fields.items[0];
 
     // Ensure the name of the first field is "x"
-    try testing.expectEqualStrings("x", x_field.name);
+    try testing.expectEqualStrings("x", x_field.name.identifier);
 
     // Verify the type of the first field is a lower-case identifier
     try testing.expect(x_field.type.* == .lower_identifier);
@@ -4549,7 +4692,7 @@ test "[RecordTypeNode]" {
     const y_field = record.fields.items[1];
 
     // Ensure the name of the second field is "y"
-    try testing.expectEqualStrings("y", y_field.name);
+    try testing.expectEqualStrings("y", y_field.name.identifier);
 
     // Verify the type of the second field is a lower-case identifier
     try testing.expect(y_field.type.* == .lower_identifier);
@@ -4573,13 +4716,12 @@ test "[ModulePathNode]" {
     const allocator = gpa.allocator();
 
     // Action
-    var segments = std.ArrayList([]const u8).init(allocator);
-    try segments.append(try allocator.dupe(u8, "Std"));
-    try segments.append(try allocator.dupe(u8, "List"));
+    var segments = std.ArrayList(*UpperIdentifierNode).init(allocator);
 
-    const path_node = try allocator.create(ModulePathNode);
-    path_node.* = .{
-        .segments = segments,
+    // Create the first segment (Std)
+    const std_ident = try allocator.create(UpperIdentifierNode);
+    std_ident.* = .{
+        .identifier = try allocator.dupe(u8, "Std"),
         .token = .{
             .kind = .{ .identifier = .Upper },
             .lexeme = "Std",
@@ -4590,13 +4732,36 @@ test "[ModulePathNode]" {
             },
         },
     };
+    try segments.append(std_ident);
+
+    // Create the second segment (List)
+    const list_ident = try allocator.create(UpperIdentifierNode);
+    list_ident.* = .{
+        .identifier = try allocator.dupe(u8, "List"),
+        .token = .{
+            .kind = .{ .identifier = .Upper },
+            .lexeme = "List",
+            .loc = .{
+                .filename = TEST_FILE,
+                .span = .{ .start = 4, .end = 8 },
+                .src = .{ .line = 1, .col = 5 },
+            },
+        },
+    };
+    try segments.append(list_ident);
+
+    const path_node = try allocator.create(ModulePathNode);
+    defer allocator.destroy(path_node);
+
+    path_node.* = .{
+        .segments = segments,
+        .token = std_ident.token,
+    };
 
     const node = try allocator.create(Node);
     defer {
         node.deinit(allocator);
         allocator.destroy(node);
-
-        allocator.destroy(path_node);
     }
 
     node.* = .{ .module_path = path_node };
@@ -4611,10 +4776,10 @@ test "[ModulePathNode]" {
     try testing.expectEqual(@as(usize, 2), path.segments.items.len);
 
     // Ensure the first segment of the include path is "Std"
-    try testing.expectEqualStrings("Std", path.segments.items[0]);
+    try testing.expectEqualStrings("Std", path.segments.items[0].identifier);
 
     // Ensure the second segment of the include path is "List"
-    try testing.expectEqualStrings("List", path.segments.items[1]);
+    try testing.expectEqualStrings("List", path.segments.items[1].identifier);
 }
 
 test "[ExportSpecNode]" {
@@ -4712,12 +4877,12 @@ test "[ImportSpecNode]" {
 
     {
         // Test input: open MyModule
-        var segments = std.ArrayList([]const u8).init(allocator);
-        try segments.append(try allocator.dupe(u8, "MyModule"));
 
-        const path_node = try allocator.create(ModulePathNode);
-        path_node.* = .{
-            .segments = segments,
+        var segments = std.ArrayList(*UpperIdentifierNode).init(allocator);
+
+        const module_ident = try allocator.create(UpperIdentifierNode);
+        module_ident.* = .{
+            .identifier = try allocator.dupe(u8, "MyModule"),
             .token = .{
                 .kind = .{ .identifier = .Upper },
                 .lexeme = "MyModule",
@@ -4727,6 +4892,14 @@ test "[ImportSpecNode]" {
                     .src = .{ .line = 1, .col = 6 },
                 },
             },
+        };
+
+        try segments.append(module_ident);
+
+        const path_node = try allocator.create(ModulePathNode);
+        path_node.* = .{
+            .segments = segments,
+            .token = module_ident.token,
         };
 
         const import_node = try allocator.create(ImportSpecNode);
@@ -4767,7 +4940,7 @@ test "[ImportSpecNode]" {
         try testing.expectEqual(@as(usize, 1), spec.path.segments.items.len);
 
         // Verify the module name
-        try testing.expectEqualStrings("MyModule", spec.path.segments.items[0]);
+        try testing.expectEqualStrings("MyModule", spec.path.segments.items[0].identifier);
 
         // Verify it has no alias or items
         try testing.expect(spec.alias == null);
@@ -4776,12 +4949,12 @@ test "[ImportSpecNode]" {
 
     {
         // Test input: open MyModule as M
-        var segments = std.ArrayList([]const u8).init(allocator);
-        try segments.append(try allocator.dupe(u8, "MyModule"));
 
-        const path_node = try allocator.create(ModulePathNode);
-        path_node.* = .{
-            .segments = segments,
+        var segments = std.ArrayList(*UpperIdentifierNode).init(allocator);
+
+        const module_ident = try allocator.create(UpperIdentifierNode);
+        module_ident.* = .{
+            .identifier = try allocator.dupe(u8, "MyModule"),
             .token = .{
                 .kind = .{ .identifier = .Upper },
                 .lexeme = "MyModule",
@@ -4793,11 +4966,32 @@ test "[ImportSpecNode]" {
             },
         };
 
+        try segments.append(module_ident);
+
+        const path_node = try allocator.create(ModulePathNode);
+        path_node.* = .{
+            .segments = segments,
+            .token = module_ident.token,
+        };
+
+        const alias_ident = UpperIdentifierNode{
+            .identifier = try allocator.dupe(u8, "M"),
+            .token = .{
+                .kind = .{ .identifier = .Upper },
+                .lexeme = "M",
+                .loc = .{
+                    .filename = TEST_FILE,
+                    .span = .{ .start = 17, .end = 18 },
+                    .src = .{ .line = 1, .col = 18 },
+                },
+            },
+        };
+
         const import_node = try allocator.create(ImportSpecNode);
         import_node.* = .{
             .path = path_node,
             .kind = .Alias,
-            .alias = try allocator.dupe(u8, "M"),
+            .alias = alias_ident,
             .items = null,
             .token = .{
                 .kind = .{ .keyword = .Open },
@@ -4831,11 +5025,11 @@ test "[ImportSpecNode]" {
         try testing.expectEqual(@as(usize, 1), spec.path.segments.items.len);
 
         // Verify the module name
-        try testing.expectEqualStrings("MyModule", spec.path.segments.items[0]);
+        try testing.expectEqualStrings("MyModule", spec.path.segments.items[0].identifier);
 
         // Verify the alias
         try testing.expect(spec.alias != null);
-        try testing.expectEqualStrings("M", spec.alias.?);
+        try testing.expectEqualStrings("M", spec.alias.?.identifier);
 
         // Verify it has no items
         try testing.expect(spec.items == null);
@@ -4843,12 +5037,12 @@ test "[ImportSpecNode]" {
 
     {
         // Test input: open MyModule using (map, filter, Maybe, Either(..))
-        var segments = std.ArrayList([]const u8).init(allocator);
-        try segments.append(try allocator.dupe(u8, "MyModule"));
 
-        const path_node = try allocator.create(ModulePathNode);
-        path_node.* = .{
-            .segments = segments,
+        var segments = std.ArrayList(*UpperIdentifierNode).init(allocator);
+
+        const module_ident = try allocator.create(UpperIdentifierNode);
+        module_ident.* = .{
+            .identifier = try allocator.dupe(u8, "MyModule"),
             .token = .{
                 .kind = .{ .identifier = .Upper },
                 .lexeme = "MyModule",
@@ -4858,6 +5052,14 @@ test "[ImportSpecNode]" {
                     .src = .{ .line = 1, .col = 6 },
                 },
             },
+        };
+
+        try segments.append(module_ident);
+
+        const path_node = try allocator.create(ModulePathNode);
+        path_node.* = .{
+            .segments = segments,
+            .token = module_ident.token,
         };
 
         const map_item = try allocator.create(ImportItem);
@@ -4938,7 +5140,7 @@ test "[ImportSpecNode]" {
         try testing.expectEqual(@as(usize, 1), spec.path.segments.items.len);
 
         // Verify the module name
-        try testing.expectEqualStrings("MyModule", spec.path.segments.items[0]);
+        try testing.expectEqualStrings("MyModule", spec.path.segments.items[0].identifier);
 
         // Verify it has no alias
         try testing.expect(spec.alias == null);
@@ -4969,12 +5171,12 @@ test "[ImportSpecNode]" {
 
     {
         // Test input: open MyModule using (map as list_map)
-        var segments = std.ArrayList([]const u8).init(allocator);
-        try segments.append(try allocator.dupe(u8, "MyModule"));
 
-        const path_node = try allocator.create(ModulePathNode);
-        path_node.* = .{
-            .segments = segments,
+        var segments = std.ArrayList(*UpperIdentifierNode).init(allocator);
+
+        const module_ident = try allocator.create(UpperIdentifierNode);
+        module_ident.* = .{
+            .identifier = try allocator.dupe(u8, "MyModule"),
             .token = .{
                 .kind = .{ .identifier = .Upper },
                 .lexeme = "MyModule",
@@ -4986,6 +5188,16 @@ test "[ImportSpecNode]" {
             },
         };
 
+        try segments.append(module_ident);
+
+        const path_node = try allocator.create(ModulePathNode);
+        path_node.* = .{
+            .segments = segments,
+            .token = module_ident.token,
+        };
+
+        var items = std.ArrayList(*ImportItem).init(allocator);
+
         const map_item = try allocator.create(ImportItem);
         map_item.* = .{
             .function = .{
@@ -4994,7 +5206,6 @@ test "[ImportSpecNode]" {
             },
         };
 
-        var items = std.ArrayList(*ImportItem).init(allocator);
         try items.append(map_item);
 
         const import_node = try allocator.create(ImportSpecNode);
@@ -5035,7 +5246,7 @@ test "[ImportSpecNode]" {
         try testing.expectEqual(@as(usize, 1), spec.path.segments.items.len);
 
         // Verify the module name
-        try testing.expectEqualStrings("MyModule", spec.path.segments.items[0]);
+        try testing.expectEqualStrings("MyModule", spec.path.segments.items[0].identifier);
 
         // Verify it has no alias
         try testing.expect(spec.alias == null);
@@ -5050,12 +5261,12 @@ test "[ImportSpecNode]" {
 
     {
         // Test input: open MyModule hiding (internal_func)
-        var segments = std.ArrayList([]const u8).init(allocator);
-        try segments.append(try allocator.dupe(u8, "MyModule"));
 
-        const path_node = try allocator.create(ModulePathNode);
-        path_node.* = .{
-            .segments = segments,
+        var segments = std.ArrayList(*UpperIdentifierNode).init(allocator);
+
+        const module_ident = try allocator.create(UpperIdentifierNode);
+        module_ident.* = .{
+            .identifier = try allocator.dupe(u8, "MyModule"),
             .token = .{
                 .kind = .{ .identifier = .Upper },
                 .lexeme = "MyModule",
@@ -5067,6 +5278,16 @@ test "[ImportSpecNode]" {
             },
         };
 
+        try segments.append(module_ident);
+
+        const path_node = try allocator.create(ModulePathNode);
+        path_node.* = .{
+            .segments = segments,
+            .token = module_ident.token,
+        };
+
+        var items = std.ArrayList(*ImportItem).init(allocator);
+
         const internal_func = try allocator.create(ImportItem);
         internal_func.* = .{
             .function = .{
@@ -5075,7 +5296,6 @@ test "[ImportSpecNode]" {
             },
         };
 
-        var items = std.ArrayList(*ImportItem).init(allocator);
         try items.append(internal_func);
 
         const import_node = try allocator.create(ImportSpecNode);
@@ -5116,7 +5336,7 @@ test "[ImportSpecNode]" {
         try testing.expectEqual(@as(usize, 1), spec.path.segments.items.len);
 
         // Verify the module name
-        try testing.expectEqualStrings("MyModule", spec.path.segments.items[0]);
+        try testing.expectEqualStrings("MyModule", spec.path.segments.items[0].identifier);
 
         // Verify it has no alias
         try testing.expect(spec.alias == null);
@@ -5139,22 +5359,45 @@ test "[IncludeNode]" {
     const allocator = gpa.allocator();
 
     // Action
-    var segments = std.ArrayList([]const u8).init(allocator);
-    try segments.append(try allocator.dupe(u8, "Std"));
-    try segments.append(try allocator.dupe(u8, "List"));
+    var segments = std.ArrayList(*UpperIdentifierNode).init(allocator);
 
-    const path_node = try allocator.create(ModulePathNode);
-    path_node.* = .{
-        .segments = segments,
+    // Create the first segment (Std)
+    const std_ident = try allocator.create(UpperIdentifierNode);
+    std_ident.* = .{
+        .identifier = try allocator.dupe(u8, "Std"),
         .token = .{
             .kind = .{ .identifier = .Upper },
             .lexeme = "Std",
             .loc = .{
                 .filename = TEST_FILE,
-                .span = .{ .start = 8, .end = 12 },
+                .span = .{ .start = 8, .end = 11 },
                 .src = .{ .line = 1, .col = 9 },
             },
         },
+    };
+
+    // Create the second segment (List)
+    const list_ident = try allocator.create(UpperIdentifierNode);
+    list_ident.* = .{
+        .identifier = try allocator.dupe(u8, "List"),
+        .token = .{
+            .kind = .{ .identifier = .Upper },
+            .lexeme = "List",
+            .loc = .{
+                .filename = TEST_FILE,
+                .span = .{ .start = 12, .end = 15 },
+                .src = .{ .line = 1, .col = 13 },
+            },
+        },
+    };
+
+    try segments.append(std_ident);
+    try segments.append(list_ident);
+
+    const path_node = try allocator.create(ModulePathNode);
+    path_node.* = .{
+        .segments = segments,
+        .token = std_ident.token,
     };
 
     const include_node = try allocator.create(IncludeNode);
@@ -5189,14 +5432,14 @@ test "[IncludeNode]" {
     try testing.expectEqual(@as(usize, 2), include.path.segments.items.len);
 
     // Ensure the first segment of the include path is "Std"
-    try testing.expectEqualStrings("Std", include.path.segments.items[0]);
+    try testing.expectEqualStrings("Std", include.path.segments.items[0].identifier);
 
     // Ensure the second segment of the include path is "List"
-    try testing.expectEqualStrings("List", include.path.segments.items[1]);
+    try testing.expectEqualStrings("List", include.path.segments.items[1].identifier);
 }
 
 test "[FunctionDeclNode]" {
-    // Test input: let add : Int -> Int -> Int = \x y => x + y
+    // Test input: let add(x : Int, y : Int) -> Int => x + y
 
     // Setup
     var gpa = std.heap.GeneralPurposeAllocator(.{}){};
@@ -5204,76 +5447,18 @@ test "[FunctionDeclNode]" {
     const allocator = gpa.allocator();
 
     // Action
-    const int_type1 = UpperIdentifierNode{
-        .identifier = try allocator.dupe(u8, "Int"),
+    const add_ident = LowerIdentifierNode{
+        .identifier = try allocator.dupe(u8, "add"),
         .token = lexer.Token{
-            .kind = lexer.TokenKind{ .identifier = .Upper },
-            .lexeme = "Int",
+            .kind = lexer.TokenKind{ .identifier = .Lower },
+            .lexeme = "add",
             .loc = .{
                 .filename = TEST_FILE,
-                .span = .{ .start = 9, .end = 12 },
-                .src = .{ .line = 1, .col = 10 },
+                .span = .{ .start = 4, .end = 7 },
+                .src = .{ .line = 1, .col = 5 },
             },
         },
     };
-
-    const int_node1 = try allocator.create(Node);
-    int_node1.* = .{ .upper_identifier = int_type1 };
-
-    const int_type2 = UpperIdentifierNode{
-        .identifier = try allocator.dupe(u8, "Int"),
-        .token = lexer.Token{
-            .kind = lexer.TokenKind{ .identifier = .Upper },
-            .lexeme = "Int",
-            .loc = .{
-                .filename = TEST_FILE,
-                .span = .{ .start = 16, .end = 19 },
-                .src = .{ .line = 1, .col = 17 },
-            },
-        },
-    };
-
-    const int_node2 = try allocator.create(Node);
-    int_node2.* = .{ .upper_identifier = int_type2 };
-
-    const int_type3 = UpperIdentifierNode{
-        .identifier = try allocator.dupe(u8, "Int"),
-        .token = lexer.Token{
-            .kind = lexer.TokenKind{ .identifier = .Upper },
-            .lexeme = "Int",
-            .loc = .{
-                .filename = TEST_FILE,
-                .span = .{ .start = 23, .end = 26 },
-                .src = .{ .line = 1, .col = 24 },
-            },
-        },
-    };
-
-    const int_node3 = try allocator.create(Node);
-    int_node3.* = .{ .upper_identifier = int_type3 };
-
-    var signature_types = std.ArrayList(*Node).init(allocator);
-    try signature_types.append(int_node1);
-    try signature_types.append(int_node2);
-    try signature_types.append(int_node3);
-
-    const ftype_node = try allocator.create(FunctionTypeNode);
-    ftype_node.* = .{
-        .signature_types = signature_types,
-        .token = lexer.Token{
-            .kind = lexer.TokenKind{ .delimiter = .Colon },
-            .lexeme = ":",
-            .loc = .{
-                .filename = TEST_FILE,
-                .span = .{ .start = 7, .end = 8 },
-                .src = .{ .line = 1, .col = 8 },
-            },
-        },
-    };
-
-    var param_names = std.ArrayList([]const u8).init(allocator);
-    try param_names.append(try allocator.dupe(u8, "x"));
-    try param_names.append(try allocator.dupe(u8, "y"));
 
     const x_ident = LowerIdentifierNode{
         .identifier = try allocator.dupe(u8, "x"),
@@ -5282,14 +5467,34 @@ test "[FunctionDeclNode]" {
             .lexeme = "x",
             .loc = .{
                 .filename = TEST_FILE,
-                .span = .{ .start = 37, .end = 38 },
-                .src = .{ .line = 1, .col = 38 },
+                .span = .{ .start = 8, .end = 9 },
+                .src = .{ .line = 1, .col = 9 },
             },
         },
     };
 
-    const x_node = try allocator.create(Node);
-    x_node.* = .{ .lower_identifier = x_ident };
+    const int_type1 = UpperIdentifierNode{
+        .identifier = try allocator.dupe(u8, "Int"),
+        .token = lexer.Token{
+            .kind = lexer.TokenKind{ .identifier = .Upper },
+            .lexeme = "Int",
+            .loc = .{
+                .filename = TEST_FILE,
+                .span = .{ .start = 12, .end = 15 },
+                .src = .{ .line = 1, .col = 13 },
+            },
+        },
+    };
+
+    const x_type_node = try allocator.create(Node);
+    x_type_node.* = .{ .upper_identifier = int_type1 };
+
+    const x_param = try allocator.create(ParamDeclNode);
+    x_param.* = .{
+        .name = x_ident,
+        .type_annotation = x_type_node,
+        .token = x_ident.token,
+    };
 
     const y_ident = LowerIdentifierNode{
         .identifier = try allocator.dupe(u8, "y"),
@@ -5298,22 +5503,76 @@ test "[FunctionDeclNode]" {
             .lexeme = "y",
             .loc = .{
                 .filename = TEST_FILE,
-                .span = .{ .start = 41, .end = 42 },
-                .src = .{ .line = 1, .col = 42 },
+                .span = .{ .start = 17, .end = 18 },
+                .src = .{ .line = 1, .col = 18 },
             },
         },
     };
 
-    const y_node = try allocator.create(Node);
-    y_node.* = .{ .lower_identifier = y_ident };
+    const int_type2 = UpperIdentifierNode{
+        .identifier = try allocator.dupe(u8, "Int"),
+        .token = lexer.Token{
+            .kind = lexer.TokenKind{ .identifier = .Upper },
+            .lexeme = "Int",
+            .loc = .{
+                .filename = TEST_FILE,
+                .span = .{ .start = 21, .end = 24 },
+                .src = .{ .line = 1, .col = 22 },
+            },
+        },
+    };
 
-    const arith_node = try allocator.create(ArithmeticExprNode);
-    arith_node.* = .{
-        .left = x_node,
-        .right = y_node,
-        .operator = lexer.Token{
-            .kind = lexer.TokenKind{ .operator = .IntAdd },
-            .lexeme = "+",
+    const y_type_node = try allocator.create(Node);
+    y_type_node.* = .{ .upper_identifier = int_type2 };
+
+    const y_param = try allocator.create(ParamDeclNode);
+    y_param.* = .{
+        .name = y_ident,
+        .type_annotation = y_type_node,
+        .token = y_ident.token,
+    };
+
+    var parameters = std.ArrayList(*ParamDeclNode).init(allocator);
+    try parameters.append(x_param);
+    try parameters.append(y_param);
+
+    const int_type3 = UpperIdentifierNode{
+        .identifier = try allocator.dupe(u8, "Int"),
+        .token = lexer.Token{
+            .kind = lexer.TokenKind{ .identifier = .Upper },
+            .lexeme = "Int",
+            .loc = .{
+                .filename = TEST_FILE,
+                .span = .{ .start = 29, .end = 32 },
+                .src = .{ .line = 1, .col = 30 },
+            },
+        },
+    };
+
+    const return_type_node = try allocator.create(Node);
+    return_type_node.* = .{ .upper_identifier = int_type3 };
+
+    const x_body_ident = LowerIdentifierNode{
+        .identifier = try allocator.dupe(u8, "x"),
+        .token = lexer.Token{
+            .kind = lexer.TokenKind{ .identifier = .Lower },
+            .lexeme = "x",
+            .loc = .{
+                .filename = TEST_FILE,
+                .span = .{ .start = 35, .end = 36 },
+                .src = .{ .line = 1, .col = 36 },
+            },
+        },
+    };
+
+    const x_body_node = try allocator.create(Node);
+    x_body_node.* = .{ .lower_identifier = x_body_ident };
+
+    const y_body_ident = LowerIdentifierNode{
+        .identifier = try allocator.dupe(u8, "y"),
+        .token = lexer.Token{
+            .kind = lexer.TokenKind{ .identifier = .Lower },
+            .lexeme = "y",
             .loc = .{
                 .filename = TEST_FILE,
                 .span = .{ .start = 39, .end = 40 },
@@ -5322,32 +5581,33 @@ test "[FunctionDeclNode]" {
         },
     };
 
-    const body_node = try allocator.create(Node);
-    body_node.* = .{ .arithmetic_expr = arith_node };
+    const y_body_node = try allocator.create(Node);
+    y_body_node.* = .{ .lower_identifier = y_body_ident };
 
-    const lambda_node = try allocator.create(LambdaExprNode);
-    lambda_node.* = .{
-        .param_names = param_names,
-        .body = body_node,
-        .token = lexer.Token{
-            .kind = lexer.TokenKind{ .operator = .Lambda },
-            .lexeme = "\\",
+    const arith_node = try allocator.create(ArithmeticExprNode);
+    arith_node.* = .{
+        .left = x_body_node,
+        .right = y_body_node,
+        .operator = lexer.Token{
+            .kind = lexer.TokenKind{ .operator = .IntAdd },
+            .lexeme = "+",
             .loc = .{
                 .filename = TEST_FILE,
-                .span = .{ .start = 30, .end = 31 },
-                .src = .{ .line = 1, .col = 31 },
+                .span = .{ .start = 37, .end = 38 },
+                .src = .{ .line = 1, .col = 38 },
             },
         },
     };
 
-    const lambda_expr_node = try allocator.create(Node);
-    lambda_expr_node.* = .{ .lambda_expr = lambda_node };
+    const body_node = try allocator.create(Node);
+    body_node.* = .{ .arithmetic_expr = arith_node };
 
-    const func_decl_node = try allocator.create(FunctionDeclNode);
-    func_decl_node.* = .{
-        .name = try allocator.dupe(u8, "add"),
-        .type_annotation = ftype_node,
-        .value = lambda_expr_node,
+    const func_decl = try allocator.create(FunctionDeclNode);
+    func_decl.* = .{
+        .name = add_ident,
+        .parameters = parameters,
+        .return_type = return_type_node,
+        .value = body_node,
         .token = lexer.Token{
             .kind = lexer.TokenKind{ .keyword = .Let },
             .lexeme = "let",
@@ -5365,86 +5625,59 @@ test "[FunctionDeclNode]" {
         allocator.destroy(node);
     }
 
-    node.* = .{ .function_decl = func_decl_node };
+    node.* = .{ .function_decl = func_decl };
 
     // Assertions
     // Verify the node is a function declaration
     try testing.expect(node.* == .function_decl);
 
-    const func_decl = node.function_decl;
+    const decl = node.function_decl;
 
-    // Check the keyword for the function declaration is "let"
-    try testing.expectEqual(lexer.TokenKind{ .keyword = .Let }, func_decl.token.kind);
+    // Verify the function name
+    try testing.expectEqualStrings("add", decl.name.identifier);
 
-    // Verify the lexeme for the "let" keyword matches "let"
-    try testing.expectEqualStrings("let", func_decl.token.lexeme);
+    // Verify the declaration has exactly two parameters
+    try testing.expectEqual(@as(usize, 2), decl.parameters.items.len);
 
-    // Verify the function name is "add"
-    try testing.expectEqualStrings("add", func_decl.name);
+    // Check the first parameter (x : Int)
+    const first_param = decl.parameters.items[0];
+    try testing.expectEqualStrings("x", first_param.name.identifier);
+    try testing.expect(first_param.type_annotation != null);
+    try testing.expect(first_param.type_annotation.?.* == .upper_identifier);
+    try testing.expectEqualStrings("Int", first_param.type_annotation.?.upper_identifier.identifier);
 
-    const type_annot = func_decl.type_annotation.?;
+    // Check the second parameter (y : Int)
+    const second_param = decl.parameters.items[1];
+    try testing.expectEqualStrings("y", second_param.name.identifier);
+    try testing.expect(second_param.type_annotation != null);
+    try testing.expect(second_param.type_annotation.?.* == .upper_identifier);
+    try testing.expectEqualStrings("Int", second_param.type_annotation.?.upper_identifier.identifier);
 
-    // Check the token for the type annotation is a colon (":")
-    try testing.expectEqual(lexer.TokenKind{ .delimiter = .Colon }, type_annot.token.kind);
+    // Check the return type (Int)
+    try testing.expect(decl.return_type != null);
+    try testing.expect(decl.return_type.?.* == .upper_identifier);
+    try testing.expectEqualStrings("Int", decl.return_type.?.upper_identifier.identifier);
 
-    // Check the function type has exactly 3 parameter types (Int -> Int -> Int)
-    try testing.expectEqual(@as(usize, 3), type_annot.signature_types.items.len);
+    // Check the function body (x + y)
+    try testing.expect(decl.value.* == .arithmetic_expr);
 
-    // Verify lambda parameter count matches function type (excluding return type)
-    try testing.expectEqual(type_annot.signature_types.items.len - 1, func_decl.value.lambda_expr.param_names.items.len);
+    const body = decl.value.arithmetic_expr;
 
-    for (type_annot.signature_types.items) |stype| {
-        // Check the type node is an upper identifier
-        try testing.expect(stype.* == .upper_identifier);
+    // Check the operator
+    try testing.expectEqual(lexer.TokenKind{ .operator = .IntAdd }, body.operator.kind);
+    try testing.expectEqualStrings("+", body.operator.lexeme);
 
-        // Check the token kind for the type node is an upper identifier
-        try testing.expectEqual(lexer.TokenKind{ .identifier = .Upper }, stype.upper_identifier.token.kind);
+    // Check left operand
+    try testing.expect(body.left.* == .lower_identifier);
+    try testing.expectEqualStrings("x", body.left.lower_identifier.identifier);
 
-        // Check the name of the type node is "Int"
-        try testing.expectEqualStrings("Int", stype.upper_identifier.identifier);
-    }
-
-    // Check the function body is a lambda expression
-    try testing.expect(func_decl.value.* == .lambda_expr);
-
-    const lambda_value = func_decl.value.lambda_expr;
-
-    // Check the token for the lambda expression is a lambda operator ("\")
-    try testing.expectEqual(lexer.TokenKind{ .operator = .Lambda }, lambda_value.token.kind);
-
-    // Check the lambda has exactly 2 parameters
-    try testing.expectEqual(@as(usize, 2), lambda_value.param_names.items.len);
-
-    // Verify the names of the lambda parameters are "x" and "y"
-    try testing.expectEqualStrings("x", lambda_value.param_names.items[0]);
-    try testing.expectEqualStrings("y", lambda_value.param_names.items[1]);
-
-    const lambda_body = lambda_value.body;
-
-    // Check the lambda body is an arithmetic expression
-    try testing.expect(lambda_body.* == .arithmetic_expr);
-
-    // Check the operator in the arithmetic expression is integer addition ("+")
-    try testing.expectEqual(lexer.TokenKind{ .operator = .IntAdd }, lambda_body.arithmetic_expr.operator.kind);
-
-    // Check the lexeme for the addition operator matches "+"
-    try testing.expectEqualStrings("+", lambda_body.arithmetic_expr.operator.lexeme);
-
-    const body_left = lambda_body.arithmetic_expr.left;
-
-    // Check the left operand is a lower identifier with the name "x"
-    try testing.expect(body_left.* == .lower_identifier);
-    try testing.expectEqualStrings("x", body_left.lower_identifier.identifier);
-
-    const body_right = lambda_body.arithmetic_expr.right;
-
-    // Check the left operand is a lower identifier with the name "y"
-    try testing.expect(body_right.* == .lower_identifier);
-    try testing.expectEqualStrings("y", body_right.lower_identifier.identifier);
+    // Check right operand
+    try testing.expect(body.right.* == .lower_identifier);
+    try testing.expectEqualStrings("y", body.right.lower_identifier.identifier);
 }
 
 test "[ForeignFunctionDeclNode]" {
-    // Test input: foreign sqrt : Float -> Float = "c_sqrt"
+    // Test input: foreign sqrt(x : Float) -> Float = "c_sqrt"
 
     // Setup
     var gpa = std.heap.GeneralPurposeAllocator(.{}){};
@@ -5452,63 +5685,100 @@ test "[ForeignFunctionDeclNode]" {
     const allocator = gpa.allocator();
 
     // Action
-    const float_type1 = UpperIdentifierNode{
-        .identifier = try allocator.dupe(u8, "Float"),
-        .token = .{
-            .kind = .{ .identifier = .Upper },
-            .lexeme = "Float",
-            .loc = .{
-                .filename = TEST_FILE,
-                .span = .{ .start = 0, .end = 5 },
-                .src = .{ .line = 1, .col = 1 },
+    const x_type_node = try allocator.create(Node);
+    x_type_node.* = .{
+        .upper_identifier = .{
+            .identifier = try allocator.dupe(u8, "Float"),
+            .token = lexer.Token{
+                .kind = lexer.TokenKind{ .identifier = .Upper },
+                .lexeme = "Float",
+                .loc = .{
+                    .filename = TEST_FILE,
+                    .span = .{ .start = 17, .end = 22 },
+                    .src = .{ .line = 1, .col = 18 },
+                },
             },
         },
     };
 
-    const float_node1 = try allocator.create(Node);
-    float_node1.* = .{ .upper_identifier = float_type1 };
+    const x_param = try allocator.create(ParamDeclNode);
+    x_param.* = .{
+        .name = .{
+            .identifier = try allocator.dupe(u8, "x"),
+            .token = lexer.Token{
+                .kind = lexer.TokenKind{ .identifier = .Lower },
+                .lexeme = "x",
+                .loc = .{
+                    .filename = TEST_FILE,
+                    .span = .{ .start = 13, .end = 14 },
+                    .src = .{ .line = 1, .col = 14 },
+                },
+            },
+        },
+        .type_annotation = x_type_node,
+        .token = lexer.Token{
+            .kind = lexer.TokenKind{ .identifier = .Lower },
+            .lexeme = "x",
+            .loc = .{
+                .filename = TEST_FILE,
+                .span = .{ .start = 13, .end = 14 },
+                .src = .{ .line = 1, .col = 14 },
+            },
+        },
+    };
+
+    var parameters = std.ArrayList(*ParamDeclNode).init(allocator);
+    try parameters.append(x_param);
 
     const float_type2 = UpperIdentifierNode{
         .identifier = try allocator.dupe(u8, "Float"),
-        .token = .{
-            .kind = .{ .identifier = .Upper },
+        .token = lexer.Token{
+            .kind = lexer.TokenKind{ .identifier = .Upper },
             .lexeme = "Float",
             .loc = .{
                 .filename = TEST_FILE,
-                .span = .{ .start = 0, .end = 5 },
-                .src = .{ .line = 1, .col = 1 },
+                .span = .{ .start = 26, .end = 31 },
+                .src = .{ .line = 1, .col = 27 },
             },
         },
     };
 
-    const float_node2 = try allocator.create(Node);
-    float_node2.* = .{ .upper_identifier = float_type2 };
+    const return_type_node = try allocator.create(Node);
+    return_type_node.* = .{ .upper_identifier = float_type2 };
 
-    var signature_types = std.ArrayList(*Node).init(allocator);
-    try signature_types.append(float_node1);
-    try signature_types.append(float_node2);
-
-    const ftype_node = try allocator.create(FunctionTypeNode);
-    ftype_node.* = .{
-        .signature_types = signature_types,
-        .token = .{
-            .kind = .{ .symbol = .ArrowRight },
-            .lexeme = "->",
+    const external_name_node = try allocator.create(StrLiteralNode);
+    external_name_node.* = .{
+        .value = try allocator.dupe(u8, "c_sqrt"),
+        .token = lexer.Token{
+            .kind = lexer.TokenKind{ .literal = .String },
+            .lexeme = "\"c_sqrt\"",
             .loc = .{
                 .filename = TEST_FILE,
-                .span = .{ .start = 0, .end = 2 },
-                .src = .{ .line = 1, .col = 1 },
+                .span = .{ .start = 34, .end = 42 },
+                .src = .{ .line = 1, .col = 35 },
             },
         },
     };
 
-    const foreign_node = try allocator.create(ForeignFunctionDeclNode);
-    foreign_node.* = .{
-        .name = try allocator.dupe(u8, "sqrt"),
-        .type_annotation = ftype_node,
-        .external_name = try allocator.dupe(u8, "c_sqrt"),
-        .token = .{
-            .kind = .{ .keyword = .Foreign },
+    const foreign_func_decl = try allocator.create(ForeignFunctionDeclNode);
+    foreign_func_decl.* = .{
+        .name = .{
+            .identifier = try allocator.dupe(u8, "sqrt"),
+            .token = lexer.Token{
+                .kind = lexer.TokenKind{ .identifier = .Lower },
+                .lexeme = "sqrt",
+                .loc = .{
+                    .filename = TEST_FILE,
+                    .span = .{ .start = 8, .end = 12 },
+                    .src = .{ .line = 1, .col = 9 },
+                },
+            },
+        },
+        .parameters = parameters,
+        .return_type = return_type_node,
+        .external_name = external_name_node,
+        .token = lexer.Token{
+            .kind = lexer.TokenKind{ .keyword = .Foreign },
             .lexeme = "foreign",
             .loc = .{
                 .filename = TEST_FILE,
@@ -5524,7 +5794,7 @@ test "[ForeignFunctionDeclNode]" {
         allocator.destroy(node);
     }
 
-    node.* = .{ .foreign_function_decl = foreign_node };
+    node.* = .{ .foreign_function_decl = foreign_func_decl };
 
     // Assertions
     // Verify the node is a foreign function declaration
@@ -5532,22 +5802,29 @@ test "[ForeignFunctionDeclNode]" {
 
     const decl = node.foreign_function_decl;
 
-    // Verify the name of the declaration
-    try testing.expectEqualStrings("sqrt", decl.name);
+    // Verify the function name
+    try testing.expectEqualStrings("sqrt", decl.name.identifier);
 
-    // Verify the external name of the declaration
-    try testing.expectEqualStrings("c_sqrt", decl.external_name);
+    // Verify the external name
+    try testing.expectEqualStrings("c_sqrt", decl.external_name.value);
 
-    // Check the function type annotation specifies exactly two parameter types
-    try testing.expectEqual(@as(usize, 2), decl.type_annotation.signature_types.items.len);
+    // Verify the declaration has exactly one parameter
+    try testing.expectEqual(@as(usize, 1), decl.parameters.items.len);
 
-    // Verify both parameter types are Float
-    const fn_signature_types = decl.type_annotation.signature_types.items;
+    // Check the parameter (x : Float)
+    const param = decl.parameters.items[0];
+    try testing.expectEqualStrings("x", param.name.identifier);
+    try testing.expect(param.type_annotation != null);
+    try testing.expect(param.type_annotation.?.* == .upper_identifier);
+    try testing.expectEqualStrings("Float", param.type_annotation.?.upper_identifier.identifier);
 
-    try testing.expect(fn_signature_types[0].* == .upper_identifier);
-    try testing.expectEqualStrings("Float", fn_signature_types[0].upper_identifier.identifier);
-    try testing.expect(fn_signature_types[1].* == .upper_identifier);
-    try testing.expectEqualStrings("Float", fn_signature_types[1].upper_identifier.identifier);
+    // Check the return type (Float)
+    try testing.expect(decl.return_type.* == .upper_identifier);
+    try testing.expectEqualStrings("Float", decl.return_type.upper_identifier.identifier);
+
+    // Verify the token is the "foreign" keyword
+    try testing.expectEqual(lexer.TokenKind{ .keyword = .Foreign }, decl.token.kind);
+    try testing.expectEqualStrings("foreign", decl.token.lexeme);
 }
 
 test "[ModuleDeclNode]" {
@@ -5559,8 +5836,23 @@ test "[ModuleDeclNode]" {
     const allocator = gpa.allocator();
 
     // Action
-    var segments = std.ArrayList([]const u8).init(allocator);
-    try segments.append(try allocator.dupe(u8, "MyModule"));
+    var segments = std.ArrayList(*UpperIdentifierNode).init(allocator);
+
+    const module_ident = try allocator.create(UpperIdentifierNode);
+    module_ident.* = .{
+        .identifier = try allocator.dupe(u8, "MyModule"),
+        .token = .{
+            .kind = .{ .identifier = .Upper },
+            .lexeme = "MyModule",
+            .loc = .{
+                .filename = TEST_FILE,
+                .span = .{ .start = 6, .end = 14 },
+                .src = .{ .line = 1, .col = 7 },
+            },
+        },
+    };
+
+    try segments.append(module_ident);
 
     const path_node = try allocator.create(ModulePathNode);
     path_node.* = .{
@@ -5606,10 +5898,11 @@ test "[ModuleDeclNode]" {
         },
     };
 
+    var declarations = std.ArrayList(*Node).init(allocator);
+
     const comment_decl = try allocator.create(Node);
     comment_decl.* = .{ .comment = comment_node };
 
-    var declarations = std.ArrayList(*Node).init(allocator);
     try declarations.append(comment_decl);
 
     const module_node = try allocator.create(ModuleDeclNode);
@@ -5642,7 +5935,7 @@ test "[ModuleDeclNode]" {
 
     // Verify module path
     try testing.expectEqual(@as(usize, 1), node.module_decl.path.segments.items.len);
-    try testing.expectEqualStrings("MyModule", node.module_decl.path.segments.items[0]);
+    try testing.expectEqualStrings("MyModule", node.module_decl.path.segments.items[0].identifier);
 
     // Verify exports
     try testing.expect(node.module_decl.exports.exposing_all);
@@ -5676,10 +5969,11 @@ test "[ProgramNode]" {
         },
     };
 
+    var statements = std.ArrayList(*Node).init(allocator);
+
     const stmt = try allocator.create(Node);
     stmt.* = .{ .comment = comment_node };
 
-    var statements = std.ArrayList(*Node).init(allocator);
     try statements.append(stmt);
 
     const program_node = try allocator.create(ProgramNode);

--- a/compiler/frontend/ast.zig
+++ b/compiler/frontend/ast.zig
@@ -3316,6 +3316,7 @@ test "[LambdaExprNode]" {
     const lambda_node = try allocator.create(LambdaExprNode);
     lambda_node.* = .{
         .parameters = parameters,
+        .return_type = null,
         .body = body_node,
         .token = .{
             .kind = .{ .keyword = .Fn },

--- a/compiler/frontend/ast_printer.zig
+++ b/compiler/frontend/ast_printer.zig
@@ -322,20 +322,20 @@ pub const AstPrinter = struct {
             },
 
             // Functions and Applications
-            .function_type => |ftype| {
-                try self.writer.styled(term.Color.Bold, "FunctionType");
+            .function_signature => |ftype| {
+                try self.writer.styled(term.Color.Bold, "FuncSignatureNode");
                 try self.writer.styled(term.Color.Dim, " {\n");
 
                 self.indent_level += 1;
 
                 try self.printIndent();
-                try self.writer.styled(term.Color.Cyan, "signature_types: [\n");
+                try self.writer.styled(term.Color.Cyan, "parameter_types: [\n");
 
                 self.indent_level += 1;
 
-                for (ftype.signature_types.items) |stype| {
+                for (ftype.parameter_types.items) |ptype| {
                     try self.printIndent();
-                    try self.printNode(stype);
+                    try self.printNode(ptype);
                 }
 
                 self.indent_level -= 1;
@@ -355,7 +355,7 @@ pub const AstPrinter = struct {
                 self.indent_level += 1;
 
                 try self.printIndent();
-                try self.writer.styled(term.Color.Cyan, "params: [");
+                try self.writer.styled(term.Color.Cyan, "parameters: [");
 
                 for (expr.param_names.items, 0..) |param, i| {
                     if (i > 0) {
@@ -376,8 +376,8 @@ pub const AstPrinter = struct {
                 try self.printIndent();
                 try self.writer.styled(term.Color.Dim, "}\n");
             },
-            .function_application => |expr| {
-                try self.writer.styled(term.Color.Bold, "FunctionApplication");
+            .function_call => |expr| {
+                try self.writer.styled(term.Color.Bold, "FuncCallNode");
                 try self.writer.styled(term.Color.Dim, " {\n");
 
                 self.indent_level += 1;
@@ -448,32 +448,6 @@ pub const AstPrinter = struct {
                 try self.printIndent();
                 try self.writer.styled(term.Color.Cyan, "right: ");
                 try self.printNode(expr.right);
-
-                self.indent_level -= 1;
-
-                try self.printIndent();
-                try self.writer.styled(term.Color.Dim, "}\n");
-            },
-            .composition_expr => |expr| {
-                try self.writer.styled(term.Color.Bold, "CompositionExpr");
-                try self.writer.styled(term.Color.Dim, " {\n");
-
-                self.indent_level += 1;
-
-                try self.printIndent();
-                try self.writer.styled(term.Color.Cyan, "operator: ");
-                try self.writer.styled(term.Color.Yellow, @tagName(expr.operator.kind));
-                try self.writer.plain(" (");
-                try self.writer.styled(term.Color.Yellow, expr.operator.lexeme);
-                try self.writer.plain(")\n");
-
-                try self.printIndent();
-                try self.writer.styled(term.Color.Cyan, "first: ");
-                try self.printNode(expr.first);
-
-                try self.printIndent();
-                try self.writer.styled(term.Color.Cyan, "second: ");
-                try self.printNode(expr.second);
 
                 self.indent_level -= 1;
 
@@ -578,7 +552,7 @@ pub const AstPrinter = struct {
 
                 try self.printIndent();
                 try self.writer.styled(term.Color.Cyan, "name: ");
-                try self.writer.styled(term.Color.Magenta, alias.name);
+                try self.writer.styled(term.Color.Magenta, alias.name.identifier);
                 try self.writer.plain("\n");
 
                 try self.printIndent();
@@ -611,7 +585,7 @@ pub const AstPrinter = struct {
 
                 try self.printIndent();
                 try self.writer.styled(term.Color.Cyan, "name: ");
-                try self.writer.styled(term.Color.Magenta, vtype.name);
+                try self.writer.styled(term.Color.Magenta, vtype.name.identifier);
                 try self.writer.plain("\n");
 
                 try self.printIndent();
@@ -641,7 +615,7 @@ pub const AstPrinter = struct {
 
                     try self.printIndent();
                     try self.writer.styled(term.Color.Cyan, "name: ");
-                    try self.writer.styled(term.Color.Magenta, constructor.name);
+                    try self.writer.styled(term.Color.Magenta, constructor.name.identifier);
                     try self.writer.plain("\n");
 
                     try self.printIndent();
@@ -683,7 +657,7 @@ pub const AstPrinter = struct {
 
                 try self.printIndent();
                 try self.writer.styled(term.Color.Cyan, "name: ");
-                try self.writer.styled(term.Color.Magenta, rtype.name);
+                try self.writer.styled(term.Color.Magenta, rtype.name.identifier);
                 try self.writer.plain("\n");
 
                 try self.printIndent();
@@ -752,7 +726,7 @@ pub const AstPrinter = struct {
                         try self.writer.plain(".");
                     }
 
-                    try self.writer.styled(term.Color.Magenta, segment);
+                    try self.writer.styled(term.Color.Magenta, segment.identifier);
                 }
 
                 try self.writer.plain("]\n");
@@ -832,7 +806,7 @@ pub const AstPrinter = struct {
                         try self.writer.plain(".");
                     }
 
-                    try self.writer.styled(term.Color.Magenta, segment);
+                    try self.writer.styled(term.Color.Magenta, segment.identifier);
                 }
 
                 try self.writer.plain("\n");
@@ -840,7 +814,7 @@ pub const AstPrinter = struct {
                 if (spec.alias) |alias| {
                     try self.printIndent();
                     try self.writer.styled(term.Color.Cyan, "alias: ");
-                    try self.writer.styled(term.Color.Magenta, alias);
+                    try self.writer.styled(term.Color.Magenta, alias.identifier);
                     try self.writer.plain("\n");
                 }
 
@@ -960,7 +934,7 @@ pub const AstPrinter = struct {
                         try self.writer.plain(".");
                     }
 
-                    try self.writer.styled(term.Color.Magenta, segment);
+                    try self.writer.styled(term.Color.Magenta, segment.identifier);
                     try self.writer.plain("\n");
                 }
 
@@ -984,7 +958,7 @@ pub const AstPrinter = struct {
 
                 try self.printIndent();
                 try self.writer.styled(term.Color.Cyan, "name: ");
-                try self.writer.styled(term.Color.Magenta, decl.name);
+                try self.writer.styled(term.Color.Magenta, decl.name.identifier);
                 try self.writer.plain("\n");
 
                 if (decl.type_annotation) |type_annot| {
@@ -1011,7 +985,7 @@ pub const AstPrinter = struct {
 
                 try self.printIndent();
                 try self.writer.styled(term.Color.Cyan, "name: ");
-                try self.writer.styled(term.Color.Magenta, decl.name);
+                try self.writer.styled(term.Color.Magenta, decl.name.identifier);
                 try self.writer.plain("\n");
 
                 try self.printIndent();

--- a/compiler/frontend/ast_printer.zig
+++ b/compiler/frontend/ast_printer.zig
@@ -959,25 +959,22 @@ pub const AstPrinter = struct {
                 self.indent_level += 1;
 
                 try self.printIndent();
-                try self.writer.styled(term.Color.Cyan, "path: [\n");
+
+                try self.writer.styled(term.Color.Cyan, "path: ");
 
                 self.indent_level += 1;
 
                 for (inc.path.segments.items, 0..) |segment, i| {
-                    try self.printIndent();
-
                     if (i > 0) {
                         try self.writer.plain(".");
                     }
 
                     try self.writer.styled(term.Color.Magenta, segment.identifier);
-                    try self.writer.plain("\n");
                 }
 
                 self.indent_level -= 1;
 
-                try self.printIndent();
-                try self.writer.plain("]\n");
+                try self.writer.plain("\n");
 
                 self.indent_level -= 1;
 

--- a/compiler/frontend/ast_printer.zig
+++ b/compiler/frontend/ast_printer.zig
@@ -343,6 +343,10 @@ pub const AstPrinter = struct {
                 try self.printIndent();
                 try self.writer.styled(term.Color.Cyan, "]\n");
 
+                try self.printIndent();
+                try self.writer.styled(term.Color.Cyan, "return_type: ");
+                try self.printNode(ftype.return_type);
+
                 self.indent_level -= 1;
 
                 try self.printIndent();
@@ -355,16 +359,37 @@ pub const AstPrinter = struct {
                 self.indent_level += 1;
 
                 try self.printIndent();
-                try self.writer.styled(term.Color.Cyan, "parameters: [");
+                try self.writer.styled(term.Color.Cyan, "parameters: [\n");
 
-                for (expr.param_names.items, 0..) |param, i| {
-                    if (i > 0) {
-                        try self.writer.plain(", ");
+                self.indent_level += 1;
+
+                for (expr.parameters.items) |param| {
+                    try self.printIndent();
+                    try self.writer.styled(term.Color.Bold, "Parameter");
+                    try self.writer.styled(term.Color.Dim, " {\n");
+
+                    self.indent_level += 1;
+
+                    try self.printIndent();
+                    try self.writer.styled(term.Color.Cyan, "name: ");
+                    try self.writer.styled(term.Color.Magenta, param.name.identifier);
+                    try self.writer.plain("\n");
+
+                    if (param.type_annotation) |type_ann| {
+                        try self.printIndent();
+                        try self.writer.styled(term.Color.Cyan, "type: ");
+                        try self.printNode(type_ann);
                     }
 
-                    try self.writer.styled(term.Color.Magenta, param);
+                    self.indent_level -= 1;
+
+                    try self.printIndent();
+                    try self.writer.styled(term.Color.Dim, "}\n");
                 }
 
+                self.indent_level -= 1;
+
+                try self.printIndent();
                 try self.writer.plain("]\n");
 
                 try self.printIndent();
@@ -387,8 +412,19 @@ pub const AstPrinter = struct {
                 try self.printNode(expr.function);
 
                 try self.printIndent();
-                try self.writer.styled(term.Color.Cyan, "argument: ");
-                try self.printNode(expr.argument);
+                try self.writer.styled(term.Color.Cyan, "arguments: [\n");
+
+                self.indent_level += 1;
+
+                for (expr.arguments.items) |argument| {
+                    try self.printIndent();
+                    try self.printNode(argument);
+                }
+
+                self.indent_level -= 1;
+
+                try self.printIndent();
+                try self.writer.plain("]\n");
 
                 self.indent_level -= 1;
 
@@ -687,7 +723,7 @@ pub const AstPrinter = struct {
 
                     try self.printIndent();
                     try self.writer.styled(term.Color.Cyan, "name: ");
-                    try self.writer.styled(term.Color.Magenta, field.name);
+                    try self.writer.styled(term.Color.Magenta, field.name.identifier);
                     try self.writer.plain("\n");
 
                     try self.printIndent();
@@ -961,11 +997,44 @@ pub const AstPrinter = struct {
                 try self.writer.styled(term.Color.Magenta, decl.name.identifier);
                 try self.writer.plain("\n");
 
-                if (decl.type_annotation) |type_annot| {
+                try self.printIndent();
+                try self.writer.styled(term.Color.Cyan, "parameters: [\n");
+
+                self.indent_level += 1;
+
+                for (decl.parameters.items) |param| {
                     try self.printIndent();
-                    try self.writer.styled(term.Color.Cyan, "type: ");
-                    const type_node = ast.Node{ .function_type = type_annot };
-                    try self.printNode(&type_node);
+                    try self.writer.styled(term.Color.Bold, "Parameter");
+                    try self.writer.styled(term.Color.Dim, " {\n");
+
+                    self.indent_level += 1;
+
+                    try self.printIndent();
+                    try self.writer.styled(term.Color.Cyan, "name: ");
+                    try self.writer.styled(term.Color.Magenta, param.name.identifier);
+                    try self.writer.plain("\n");
+
+                    if (param.type_annotation) |type_ann| {
+                        try self.printIndent();
+                        try self.writer.styled(term.Color.Cyan, "type: ");
+                        try self.printNode(type_ann);
+                    }
+
+                    self.indent_level -= 1;
+
+                    try self.printIndent();
+                    try self.writer.styled(term.Color.Dim, "}\n");
+                }
+
+                self.indent_level -= 1;
+
+                try self.printIndent();
+                try self.writer.plain("]\n");
+
+                if (decl.return_type) |ret_type| {
+                    try self.printIndent();
+                    try self.writer.styled(term.Color.Cyan, "return_type: ");
+                    try self.printNode(ret_type);
                 }
 
                 try self.printIndent();
@@ -989,14 +1058,47 @@ pub const AstPrinter = struct {
                 try self.writer.plain("\n");
 
                 try self.printIndent();
-                try self.writer.styled(term.Color.Cyan, "external_name: ");
-                try self.writer.styled(term.Color.Green, decl.external_name);
-                try self.writer.plain("\n");
+                try self.writer.styled(term.Color.Cyan, "parameters: [\n");
+
+                self.indent_level += 1;
+
+                for (decl.parameters.items) |param| {
+                    try self.printIndent();
+                    try self.writer.styled(term.Color.Bold, "Parameter");
+                    try self.writer.styled(term.Color.Dim, " {\n");
+
+                    self.indent_level += 1;
+
+                    try self.printIndent();
+                    try self.writer.styled(term.Color.Cyan, "name: ");
+                    try self.writer.styled(term.Color.Magenta, param.name.identifier);
+                    try self.writer.plain("\n");
+
+                    if (param.type_annotation) |type_ann| {
+                        try self.printIndent();
+                        try self.writer.styled(term.Color.Cyan, "type: ");
+                        try self.printNode(type_ann);
+                    }
+
+                    self.indent_level -= 1;
+
+                    try self.printIndent();
+                    try self.writer.styled(term.Color.Dim, "}\n");
+                }
+
+                self.indent_level -= 1;
 
                 try self.printIndent();
-                try self.writer.styled(term.Color.Cyan, "type: ");
-                const type_node = ast.Node{ .function_type = decl.type_annotation };
-                try self.printNode(&type_node);
+                try self.writer.plain("]\n");
+
+                try self.printIndent();
+                try self.writer.styled(term.Color.Cyan, "return_type: ");
+                try self.printNode(decl.return_type);
+
+                try self.printIndent();
+                try self.writer.styled(term.Color.Cyan, "external_name: ");
+                try self.writer.styled(term.Color.Green, decl.external_name.value);
+                try self.writer.plain("\n");
 
                 self.indent_level -= 1;
 
@@ -1017,7 +1119,7 @@ pub const AstPrinter = struct {
                         try self.writer.plain(".");
                     }
 
-                    try self.writer.styled(term.Color.Magenta, segment);
+                    try self.writer.styled(term.Color.Magenta, segment.identifier);
                 }
 
                 try self.writer.plain("]\n");
@@ -1134,7 +1236,7 @@ pub const AstPrinter = struct {
             .variable => |var_pattern| {
                 try self.writer.styled(term.Color.Bold, "VariablePattern");
                 try self.writer.plain("(");
-                try self.writer.styled(term.Color.Magenta, var_pattern.name);
+                try self.writer.styled(term.Color.Magenta, var_pattern.name.identifier);
                 try self.writer.plain(")\n");
             },
             .constructor => |con| {
@@ -1211,12 +1313,10 @@ test "example" {
     // Create a simple expression: 1 + 2 * 3
 
     const two = try allocator.create(ast.Node);
-    defer allocator.destroy(two);
-
     two.* = .{
         .int_literal = .{
             .value = 2,
-            .token = lexer.Token{
+            .token = .{
                 .kind = .{ .literal = .Int },
                 .lexeme = "2",
                 .loc = .{
@@ -1229,12 +1329,10 @@ test "example" {
     };
 
     const three = try allocator.create(ast.Node);
-    defer allocator.destroy(three);
-
     three.* = .{
         .int_literal = .{
             .value = 3,
-            .token = lexer.Token{
+            .token = .{
                 .kind = .{ .literal = .Int },
                 .lexeme = "3",
                 .loc = .{
@@ -1246,32 +1344,29 @@ test "example" {
         },
     };
 
-    const mul = try allocator.create(ast.Node);
-    defer allocator.destroy(mul);
-
+    const mul = try allocator.create(ast.ArithmeticExprNode);
     mul.* = .{
-        .arithmetic_expr = .{
-            .left = two,
-            .right = three,
-            .operator = lexer.Token{
-                .kind = .{ .operator = .IntMul },
-                .lexeme = "*",
-                .loc = .{
-                    .filename = TEST_FILE,
-                    .span = .{ .start = 6, .end = 7 },
-                    .src = .{ .line = 1, .col = 7 },
-                },
+        .left = two,
+        .right = three,
+        .operator = .{
+            .kind = .{ .operator = .IntMul },
+            .lexeme = "*",
+            .loc = .{
+                .filename = TEST_FILE,
+                .span = .{ .start = 6, .end = 7 },
+                .src = .{ .line = 1, .col = 7 },
             },
         },
     };
 
-    const one = try allocator.create(ast.Node);
-    defer allocator.destroy(one);
+    const mul_node = try allocator.create(ast.Node);
+    mul_node.* = .{ .arithmetic_expr = mul };
 
+    const one = try allocator.create(ast.Node);
     one.* = .{
         .int_literal = .{
             .value = 1,
-            .token = lexer.Token{
+            .token = .{
                 .kind = .{ .literal = .Int },
                 .lexeme = "1",
                 .loc = .{
@@ -1283,25 +1378,29 @@ test "example" {
         },
     };
 
-    const add = try allocator.create(ast.Node);
-    defer allocator.destroy(add);
-
+    const add = try allocator.create(ast.ArithmeticExprNode);
     add.* = .{
-        .arithmetic_expr = .{
-            .left = one,
-            .right = mul,
-            .operator = lexer.Token{
-                .kind = .{ .operator = .IntAdd },
-                .lexeme = "+",
-                .loc = .{
-                    .filename = TEST_FILE,
-                    .span = .{ .start = 2, .end = 3 },
-                    .src = .{ .line = 1, .col = 3 },
-                },
+        .left = one,
+        .right = mul_node,
+        .operator = .{
+            .kind = .{ .operator = .IntAdd },
+            .lexeme = "+",
+            .loc = .{
+                .filename = TEST_FILE,
+                .span = .{ .start = 2, .end = 3 },
+                .src = .{ .line = 1, .col = 3 },
             },
         },
     };
 
+    const add_node = try allocator.create(ast.Node);
+    defer {
+        add_node.deinit(allocator);
+        allocator.destroy(add_node);
+    }
+
+    add_node.* = .{ .arithmetic_expr = add };
+
     var printer = AstPrinter.init(allocator, std.io.getStdOut().writer());
-    try printer.printNode(add);
+    try printer.printNode(add_node);
 }

--- a/compiler/frontend/parser.zig
+++ b/compiler/frontend/parser.zig
@@ -1143,7 +1143,9 @@ pub const Parser = struct {
         if (try self.match(lexer.TokenKind{ .symbol = .ArrowRight })) {
             return_type = try self.parseTypeExpr();
 
-            assert(return_type.?.* == .lower_identifier or return_type.?.* == .upper_identifier);
+            assert((return_type.?.* == .lower_identifier) or
+                (return_type.?.* == .upper_identifier) or
+                (return_type.?.* == .type_application));
         }
 
         _ = try self.expect(lexer.TokenKind{ .operator = .Equal });
@@ -1226,7 +1228,9 @@ pub const Parser = struct {
             self.allocator.destroy(return_type);
         }
 
-        assert(return_type.* == .lower_identifier or return_type.* == .upper_identifier);
+        assert((return_type.* == .lower_identifier) or
+            (return_type.* == .upper_identifier) or
+            (return_type.* == .type_application));
 
         _ = try self.expect(lexer.TokenKind{ .operator = .Equal });
 

--- a/compiler/frontend/parser.zig
+++ b/compiler/frontend/parser.zig
@@ -2302,31 +2302,31 @@ test "[comment]" {
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 
-    const source = "# This is a regular comment";
-    const text = "This is a regular comment";
+    {
+        const source = "# This is a regular comment";
+        var l = lexer.Lexer.init(source, TEST_FILE);
+        var parser = try Parser.init(allocator, &l);
+        defer parser.deinit();
 
-    var l = lexer.Lexer.init(source, TEST_FILE);
-    var parser = try Parser.init(allocator, &l);
-    defer parser.deinit();
+        // Action
+        const node = try parser.parseComment();
+        defer {
+            node.deinit(allocator);
+            allocator.destroy(node);
+        }
 
-    // Action
-    const node = try parser.parseComment();
-    defer {
-        node.deinit(allocator);
-        allocator.destroy(node);
+        // Assertions
+        // Verify the node is a regular comment
+        try testing.expect(node.* == .comment);
+
+        const comment = node.comment;
+
+        // Validate the comment token and its properties
+        try testing.expectEqual(lexer.TokenKind{ .comment = .Regular }, comment.token.kind);
+
+        // Ensure the content of the comment matches the source
+        try testing.expectEqualStrings("This is a regular comment", comment.text);
     }
-
-    // Assertions
-    // Verify the node is a regular comment
-    try testing.expect(node.* == .comment);
-
-    const comment = node.comment;
-
-    // Validate the comment token and its properties
-    try testing.expectEqual(lexer.TokenKind{ .comment = .Regular }, comment.token.kind);
-
-    // Ensure the content of the comment matches the source
-    try testing.expectEqualStrings(text, comment.text);
 }
 
 test "[doc_comment]" {
@@ -2335,31 +2335,31 @@ test "[doc_comment]" {
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 
-    const source = "## This is a doc comment";
-    const text = "This is a doc comment";
+    {
+        const source = "## This is a doc comment";
+        var l = lexer.Lexer.init(source, TEST_FILE);
+        var parser = try Parser.init(allocator, &l);
+        defer parser.deinit();
 
-    var l = lexer.Lexer.init(source, TEST_FILE);
-    var parser = try Parser.init(allocator, &l);
-    defer parser.deinit();
+        // Action
+        const node = try parser.parseDocComment();
+        defer {
+            node.deinit(allocator);
+            allocator.destroy(node);
+        }
 
-    // Action
-    const node = try parser.parseDocComment();
-    defer {
-        node.deinit(allocator);
-        allocator.destroy(node);
+        // Assertions
+        // Verify the node is a doc comment
+        try testing.expect(node.* == .doc_comment);
+
+        const comment = node.doc_comment;
+
+        // Validate the comment token and its properties
+        try testing.expectEqual(lexer.TokenKind{ .comment = .Doc }, comment.token.kind);
+
+        // Ensure the content of the comment matches the source
+        try testing.expectEqualStrings("This is a doc comment", comment.text);
     }
-
-    // Assertions
-    // Verify the node is a doc comment
-    try testing.expect(node.* == .doc_comment);
-
-    const comment = node.doc_comment;
-
-    // Validate the comment token and its properties
-    try testing.expectEqual(lexer.TokenKind{ .comment = .Doc }, comment.token.kind);
-
-    // Ensure the content of the comment matches the source
-    try testing.expectEqualStrings(text, comment.text);
 }
 
 test "[int_literal]" {
@@ -2664,33 +2664,35 @@ test "[unary_expr]" {
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 
-    const source = "-42";
-    var l = lexer.Lexer.init(source, TEST_FILE);
-    var parser = try Parser.init(allocator, &l);
-    defer parser.deinit();
+    {
+        const source = "-42";
+        var l = lexer.Lexer.init(source, TEST_FILE);
+        var parser = try Parser.init(allocator, &l);
+        defer parser.deinit();
 
-    // Action
-    const expr = try parser.parseSimpleExpr();
-    defer {
-        expr.deinit(allocator);
-        allocator.destroy(expr);
+        // Action
+        const expr = try parser.parseSimpleExpr();
+        defer {
+            expr.deinit(allocator);
+            allocator.destroy(expr);
+        }
+
+        // Assertions
+        // Ensure the expression is identified as a unary expression
+        try testing.expect(expr.* == .unary_expr);
+
+        // Validate the operator in the unary expression
+        try testing.expectEqual(lexer.TokenKind{ .operator = .IntSub }, expr.unary_expr.operator.kind);
+        try testing.expectEqualStrings("-", expr.unary_expr.operator.lexeme);
+
+        const operand = expr.unary_expr.operand;
+
+        // Ensure the operand is an integer literal
+        try testing.expect(operand.* == .int_literal);
+
+        // Verify the integer value of the operand is correct
+        try testing.expect(operand.int_literal.value == 42);
     }
-
-    // Assertions
-    // Ensure the expression is identified as a unary expression
-    try testing.expect(expr.* == .unary_expr);
-
-    // Validate the operator in the unary expression
-    try testing.expectEqual(lexer.TokenKind{ .operator = .IntSub }, expr.unary_expr.operator.kind);
-    try testing.expectEqualStrings("-", expr.unary_expr.operator.lexeme);
-
-    const operand = expr.unary_expr.operand;
-
-    // Ensure the operand is an integer literal
-    try testing.expect(operand.* == .int_literal);
-
-    // Verify the integer value of the operand is correct
-    try testing.expect(operand.int_literal.value == 42);
 }
 
 test "[arithmetic_expr]" {
@@ -2699,40 +2701,42 @@ test "[arithmetic_expr]" {
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 
-    const source = "42 + 24";
-    var l = lexer.Lexer.init(source, TEST_FILE);
-    var parser = try Parser.init(allocator, &l);
-    defer parser.deinit();
+    {
+        const source = "42 + 24";
+        var l = lexer.Lexer.init(source, TEST_FILE);
+        var parser = try Parser.init(allocator, &l);
+        defer parser.deinit();
 
-    // Action
-    const expr = try parser.parseExpression();
-    defer {
-        expr.deinit(allocator);
-        allocator.destroy(expr);
+        // Action
+        const expr = try parser.parseExpression();
+        defer {
+            expr.deinit(allocator);
+            allocator.destroy(expr);
+        }
+
+        // Assertions
+        // Ensure the expression is identified as an arithmetic expression
+        try testing.expect(expr.* == .arithmetic_expr);
+
+        // Validate the operator in the arithmetic expression
+        try testing.expectEqual(lexer.TokenKind{ .operator = .IntAdd }, expr.arithmetic_expr.operator.kind);
+
+        const left = expr.arithmetic_expr.left;
+
+        // Ensure the left operand is an integer literal
+        try testing.expect(left.* == .int_literal);
+
+        // Verify the integer value of the left operand is correct
+        try testing.expect(left.int_literal.value == 42);
+
+        const right = expr.arithmetic_expr.right;
+
+        // Ensure the right operand is an integer literal
+        try testing.expect(right.* == .int_literal);
+
+        // Verify the integer value of the right operand is correct
+        try testing.expect(right.int_literal.value == 24);
     }
-
-    // Assertions
-    // Ensure the expression is identified as an arithmetic expression
-    try testing.expect(expr.* == .arithmetic_expr);
-
-    // Validate the operator in the arithmetic expression
-    try testing.expectEqual(lexer.TokenKind{ .operator = .IntAdd }, expr.arithmetic_expr.operator.kind);
-
-    const left = expr.arithmetic_expr.left;
-
-    // Ensure the left operand is an integer literal
-    try testing.expect(left.* == .int_literal);
-
-    // Verify the integer value of the left operand is correct
-    try testing.expect(left.int_literal.value == 42);
-
-    const right = expr.arithmetic_expr.right;
-
-    // Ensure the right operand is an integer literal
-    try testing.expect(right.* == .int_literal);
-
-    // Verify the integer value of the right operand is correct
-    try testing.expect(right.int_literal.value == 24);
 }
 
 test "[comparison_expr]" {
@@ -3016,7 +3020,8 @@ test "[operator precedence] (structural)" {
     const allocator = gpa.allocator();
 
     {
-        var l = lexer.Lexer.init("1 + 2 * 3", TEST_FILE);
+        const source = "1 + 2 * 3";
+        var l = lexer.Lexer.init(source, TEST_FILE);
         var parser = try Parser.init(allocator, &l);
         defer parser.deinit();
 
@@ -3060,7 +3065,8 @@ test "[operator precedence] (structural)" {
     }
 
     {
-        var l = lexer.Lexer.init("1 * 2 + 3 == 4", TEST_FILE);
+        const source = "1 * 2 + 3 == 4";
+        var l = lexer.Lexer.init(source, TEST_FILE);
         var parser = try Parser.init(allocator, &l);
         defer parser.deinit();
 
@@ -3247,55 +3253,57 @@ test "[if_then_else_stmt]" {
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 
-    const source = "if x > 0 then 1 else -1";
-    var l = lexer.Lexer.init(source, TEST_FILE);
-    var parser = try Parser.init(allocator, &l);
-    defer parser.deinit();
+    {
+        const source = "if x > 0 then 1 else -1";
+        var l = lexer.Lexer.init(source, TEST_FILE);
+        var parser = try Parser.init(allocator, &l);
+        defer parser.deinit();
 
-    // Action
-    const node = try parser.parseIfThenElse();
-    defer {
-        node.deinit(allocator);
-        allocator.destroy(node);
+        // Action
+        const node = try parser.parseIfThenElse();
+        defer {
+            node.deinit(allocator);
+            allocator.destroy(node);
+        }
+
+        // Assertions
+        // Ensure the node is identified as an if-then-else statement
+        try testing.expect(node.* == .if_then_else_stmt);
+
+        const stmt = node.if_then_else_stmt;
+
+        // Validate the condition of the if-then-else statement
+        try testing.expect(stmt.condition.* == .comparison_expr);
+
+        const condition = stmt.condition.comparison_expr;
+
+        // Ensure the condition's operator is a "greater than" comparison
+        try testing.expectEqual(lexer.TokenKind{ .operator = .GreaterThan }, condition.operator.kind);
+
+        // Check the left-hand side of the condition (should be the identifier "x")
+        try testing.expect(condition.left.* == .lower_identifier);
+        try testing.expectEqualStrings("x", condition.left.lower_identifier.identifier);
+
+        // Check the right-hand side of the condition (should be the integer literal 0)
+        try testing.expect(condition.right.* == .int_literal);
+        try testing.expectEqual(@as(i64, 0), condition.right.int_literal.value);
+
+        // Validate the "then" branch (should evaluate to integer literal 1)
+        try testing.expect(stmt.then_branch.* == .int_literal);
+        try testing.expectEqual(@as(i64, 1), stmt.then_branch.int_literal.value);
+
+        // Validate the "else" branch (should evaluate to the unary expression -1)
+        try testing.expect(stmt.else_branch.* == .unary_expr);
+
+        const else_expr = stmt.else_branch.unary_expr;
+
+        // Ensure the unary operator in the else branch is subtraction
+        try testing.expectEqual(lexer.TokenKind{ .operator = .IntSub }, else_expr.operator.kind);
+
+        // Ensure the operand of the unary expression is an integer literal 1
+        try testing.expect(else_expr.operand.* == .int_literal);
+        try testing.expectEqual(@as(i64, 1), else_expr.operand.int_literal.value);
     }
-
-    // Assertions
-    // Ensure the node is identified as an if-then-else statement
-    try testing.expect(node.* == .if_then_else_stmt);
-
-    const stmt = node.if_then_else_stmt;
-
-    // Validate the condition of the if-then-else statement
-    try testing.expect(stmt.condition.* == .comparison_expr);
-
-    const condition = stmt.condition.comparison_expr;
-
-    // Ensure the condition's operator is a "greater than" comparison
-    try testing.expectEqual(lexer.TokenKind{ .operator = .GreaterThan }, condition.operator.kind);
-
-    // Check the left-hand side of the condition (should be the identifier "x")
-    try testing.expect(condition.left.* == .lower_identifier);
-    try testing.expectEqualStrings("x", condition.left.lower_identifier.identifier);
-
-    // Check the right-hand side of the condition (should be the integer literal 0)
-    try testing.expect(condition.right.* == .int_literal);
-    try testing.expectEqual(@as(i64, 0), condition.right.int_literal.value);
-
-    // Validate the "then" branch (should evaluate to integer literal 1)
-    try testing.expect(stmt.then_branch.* == .int_literal);
-    try testing.expectEqual(@as(i64, 1), stmt.then_branch.int_literal.value);
-
-    // Validate the "else" branch (should evaluate to the unary expression -1)
-    try testing.expect(stmt.else_branch.* == .unary_expr);
-
-    const else_expr = stmt.else_branch.unary_expr;
-
-    // Ensure the unary operator in the else branch is subtraction
-    try testing.expectEqual(lexer.TokenKind{ .operator = .IntSub }, else_expr.operator.kind);
-
-    // Ensure the operand of the unary expression is an integer literal 1
-    try testing.expect(else_expr.operand.* == .int_literal);
-    try testing.expectEqual(@as(i64, 1), else_expr.operand.int_literal.value);
 }
 
 test "[function_decl]" {
@@ -3471,8 +3479,6 @@ test "[function_call]" {
     const allocator = gpa.allocator();
 
     {
-        // Test input: bitwise_and(x, y)
-
         const source = "bitwise_and(x, y)";
         var l = lexer.Lexer.init(source, TEST_FILE);
         var parser = try Parser.init(allocator, &l);
@@ -3511,45 +3517,45 @@ test "[foreign_function_decl]" {
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 
-    // foreign sqrt(x : Float) -> Float = "c_sqrt"
+    {
+        const source = "foreign sqrt(x : Float) -> Float = \"c_sqrt\"";
+        var l = lexer.Lexer.init(source, TEST_FILE);
+        var parser = try Parser.init(allocator, &l);
+        defer parser.deinit();
 
-    const source = "foreign sqrt(x : Float) -> Float = \"c_sqrt\"";
-    var l = lexer.Lexer.init(source, TEST_FILE);
-    var parser = try Parser.init(allocator, &l);
-    defer parser.deinit();
+        // Action
+        const node = try parser.parseForeignFunctionDecl();
+        defer {
+            node.deinit(allocator);
+            allocator.destroy(node);
+        }
 
-    // Action
-    const node = try parser.parseForeignFunctionDecl();
-    defer {
-        node.deinit(allocator);
-        allocator.destroy(node);
+        // Assertions
+        // Verify the node is a foreign function declaration
+        try testing.expect(node.* == .foreign_function_decl);
+
+        const decl = node.foreign_function_decl;
+
+        // Verify the function name matches
+        try testing.expectEqualStrings("sqrt", decl.name.identifier);
+
+        // Verify the function type has exactly one parameter
+        try testing.expectEqual(@as(usize, 1), decl.parameters.items.len);
+
+        const param1 = decl.parameters.items[0];
+
+        // Verify the parameter name is "x"
+        try testing.expectEqualStrings("x", param1.name.identifier);
+
+        // Verify paramater type is "Flaot"
+        try testing.expectEqualStrings("Float", param1.type_annotation.?.upper_identifier.identifier);
+
+        // Verify return type is "Float"
+        try testing.expectEqualStrings("Float", decl.return_type.upper_identifier.identifier);
+
+        // Verify the external name matches
+        try testing.expectEqualStrings("c_sqrt", decl.external_name.value);
     }
-
-    // Assertions
-    // Verify the node is a foreign function declaration
-    try testing.expect(node.* == .foreign_function_decl);
-
-    const decl = node.foreign_function_decl;
-
-    // Verify the function name matches
-    try testing.expectEqualStrings("sqrt", decl.name.identifier);
-
-    // Verify the function type has exactly one parameter
-    try testing.expectEqual(@as(usize, 1), decl.parameters.items.len);
-
-    const param1 = decl.parameters.items[0];
-
-    // Verify the parameter name is "x"
-    try testing.expectEqualStrings("x", param1.name.identifier);
-
-    // Verify paramater type is "Flaot"
-    try testing.expectEqualStrings("Float", param1.type_annotation.?.upper_identifier.identifier);
-
-    // Verify return type is "Float"
-    try testing.expectEqualStrings("Float", decl.return_type.upper_identifier.identifier);
-
-    // Verify the external name matches
-    try testing.expectEqualStrings("c_sqrt", decl.external_name.value);
 }
 
 test "[module_path]" {
@@ -3558,31 +3564,33 @@ test "[module_path]" {
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 
-    const source = "Std.List";
-    var l = lexer.Lexer.init(source, TEST_FILE);
-    var parser = try Parser.init(allocator, &l);
-    defer parser.deinit();
+    {
+        const source = "Std.List";
+        var l = lexer.Lexer.init(source, TEST_FILE);
+        var parser = try Parser.init(allocator, &l);
+        defer parser.deinit();
 
-    // Action
-    const node = try parser.parseModulePath();
-    defer {
-        node.deinit(allocator);
-        allocator.destroy(node.module_path);
-        allocator.destroy(node);
+        // Action
+        const node = try parser.parseModulePath();
+        defer {
+            node.deinit(allocator);
+            allocator.destroy(node.module_path);
+            allocator.destroy(node);
+        }
+
+        // Assertions
+        // Verify the node is a path to a module
+        try testing.expect(node.* == .module_path);
+
+        const module_path = node.module_path;
+
+        // Check the module path has exactly two segments
+        try testing.expectEqual(@as(usize, 2), module_path.segments.items.len);
+
+        // Verify the segments
+        try testing.expectEqualStrings("Std", module_path.segments.items[0].identifier);
+        try testing.expectEqualStrings("List", module_path.segments.items[1].identifier);
     }
-
-    // Assertions
-    // Verify the node is a path to a module
-    try testing.expect(node.* == .module_path);
-
-    const module_path = node.module_path;
-
-    // Check the module path has exactly two segments
-    try testing.expectEqual(@as(usize, 2), module_path.segments.items.len);
-
-    // Verify the segments
-    try testing.expectEqualStrings("Std", module_path.segments.items[0].identifier);
-    try testing.expectEqualStrings("List", module_path.segments.items[1].identifier);
 }
 
 test "[include]" {
@@ -3591,30 +3599,32 @@ test "[include]" {
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 
-    const source = "include Std.List";
-    var l = lexer.Lexer.init(source, TEST_FILE);
-    var parser = try Parser.init(allocator, &l);
-    defer parser.deinit();
+    {
+        const source = "include Std.List";
+        var l = lexer.Lexer.init(source, TEST_FILE);
+        var parser = try Parser.init(allocator, &l);
+        defer parser.deinit();
 
-    // Action
-    const node = try parser.parseInclude();
-    defer {
-        node.deinit(allocator);
-        allocator.destroy(node);
+        // Action
+        const node = try parser.parseInclude();
+        defer {
+            node.deinit(allocator);
+            allocator.destroy(node);
+        }
+
+        // Assertions
+        // Verify the node is an include statement
+        try testing.expect(node.* == .include);
+
+        const include = node.include;
+
+        // Check the include path has exactly two segments
+        try testing.expectEqual(@as(usize, 2), include.path.segments.items.len);
+
+        // Verify the segments
+        try testing.expectEqualStrings("Std", include.path.segments.items[0].identifier);
+        try testing.expectEqualStrings("List", include.path.segments.items[1].identifier);
     }
-
-    // Assertions
-    // Verify the node is an include statement
-    try testing.expect(node.* == .include);
-
-    const include = node.include;
-
-    // Check the include path has exactly two segments
-    try testing.expectEqual(@as(usize, 2), include.path.segments.items.len);
-
-    // Verify the segments
-    try testing.expectEqualStrings("Std", include.path.segments.items[0].identifier);
-    try testing.expectEqualStrings("List", include.path.segments.items[1].identifier);
 }
 
 test "[import_spec]" {
@@ -4613,9 +4623,8 @@ test "[list]" {
     const allocator = gpa.allocator();
 
     {
-        // Test input: []
-
-        var l = lexer.Lexer.init("[]", TEST_FILE);
+        const source = "[]";
+        var l = lexer.Lexer.init(source, TEST_FILE);
         var parser = try Parser.init(allocator, &l);
         defer parser.deinit();
 
@@ -4637,9 +4646,8 @@ test "[list]" {
     }
 
     {
-        // Test input: [1, 2, 3]
-
-        var l = lexer.Lexer.init("[1, 2, 3]", TEST_FILE);
+        const source = "[1, 2, 3]";
+        var l = lexer.Lexer.init(source, TEST_FILE);
         var parser = try Parser.init(allocator, &l);
         defer parser.deinit();
 
@@ -4680,9 +4688,8 @@ test "[tuple]" {
     const allocator = gpa.allocator();
 
     {
-        // Test input: (1, "hello")
-
-        var l = lexer.Lexer.init("(1, \"hello\")", TEST_FILE);
+        const source = "(1, \"hello\")";
+        var l = lexer.Lexer.init(source, TEST_FILE);
         var parser = try Parser.init(allocator, &l);
         defer parser.deinit();
 
@@ -4706,9 +4713,8 @@ test "[tuple]" {
     }
 
     {
-        // Test input: (x, True)
-
-        var l = lexer.Lexer.init("(x, True)", TEST_FILE);
+        const source = "(x, True)";
+        var l = lexer.Lexer.init(source, TEST_FILE);
         var parser = try Parser.init(allocator, &l);
         defer parser.deinit();
 

--- a/compiler/frontend/parser.zig
+++ b/compiler/frontend/parser.zig
@@ -210,30 +210,36 @@ pub const Parser = struct {
     fn parseLowerIdentifier(self: *Parser) ParserError!*ast.LowerIdentifierNode {
         const start_token = try self.expect(lexer.TokenKind{ .identifier = .Lower });
 
-        const ident = try self.allocator.create(ast.LowerIdentifierNode);
-        errdefer ident.deinit(self.allocator);
+        const node = try self.allocator.create(ast.LowerIdentifierNode);
+        errdefer {
+            node.deinit(self.allocator);
+            self.allocator.destroy(node);
+        }
 
-        ident.* = .{
+        node.* = .{
             .identifier = try self.allocator.dupe(u8, start_token.lexeme),
             .token = start_token,
         };
 
-        return ident;
+        return node;
     }
 
     /// Parses a upper-case identifier into a structured node.
     fn parseUpperIdentifier(self: *Parser) ParserError!*ast.UpperIdentifierNode {
         const start_token = try self.expect(lexer.TokenKind{ .identifier = .Upper });
 
-        const ident = try self.allocator.create(ast.UpperIdentifierNode);
-        errdefer ident.deinit(self.allocator);
+        const node = try self.allocator.create(ast.UpperIdentifierNode);
+        errdefer {
+            node.deinit(self.allocator);
+            self.allocator.destroy(node);
+        }
 
-        ident.* = .{
+        node.* = .{
             .identifier = try self.allocator.dupe(u8, start_token.lexeme),
             .token = start_token,
         };
 
-        return ident;
+        return node;
     }
 
     /// Parses an integer literal value into a structured node.
@@ -403,6 +409,14 @@ pub const Parser = struct {
     /// Parses a complete program, which consists of a sequence of top-level declarations.
     pub fn parseProgram(self: *Parser) ParserError!*ast.Node {
         var statements = std.ArrayList(*ast.Node).init(self.allocator);
+        errdefer {
+            for (statements.items) |item| {
+                item.deinit(self.allocator);
+                self.allocator.destroy(item);
+            }
+
+            statements.deinit();
+        }
 
         while (!self.check(lexer.TokenKind{ .special = .Eof })) {
             const stmt = try self.parseTopLevel();
@@ -410,7 +424,10 @@ pub const Parser = struct {
         }
 
         const program_node = try self.allocator.create(ast.ProgramNode);
-        errdefer program_node.deinit(self.allocator);
+        errdefer {
+            program_node.deinit(self.allocator);
+            self.allocator.destroy(program_node);
+        }
 
         program_node.* = .{
             .statements = statements,
@@ -418,7 +435,10 @@ pub const Parser = struct {
         };
 
         const node = try self.allocator.create(ast.Node);
-        errdefer node.deinit(self.allocator);
+        errdefer {
+            node.deinit(self.allocator);
+            self.allocator.destroy(node);
+        }
 
         node.* = .{ .program = program_node };
 
@@ -507,8 +527,6 @@ pub const Parser = struct {
                             }
 
                             import_list.deinit();
-
-                            self.allocator.destroy(import_list);
                         }
                     }
 
@@ -534,7 +552,10 @@ pub const Parser = struct {
                                     }
 
                                     const import_item = try self.allocator.create(ast.ImportItem);
-                                    errdefer import_item.deinit(self.allocator);
+                                    errdefer {
+                                        import_item.deinit(self.allocator);
+                                        self.allocator.destroy(import_item);
+                                    }
 
                                     import_item.* = .{
                                         .function = .{
@@ -572,7 +593,10 @@ pub const Parser = struct {
                                     }
 
                                     const import_item = try self.allocator.create(ast.ImportItem);
-                                    errdefer import_item.deinit(self.allocator);
+                                    errdefer {
+                                        import_item.deinit(self.allocator);
+                                        self.allocator.destroy(import_item);
+                                    }
 
                                     import_item.* = .{
                                         .type = .{
@@ -609,7 +633,10 @@ pub const Parser = struct {
                                     }
 
                                     const import_item = try self.allocator.create(ast.ImportItem);
-                                    errdefer import_item.deinit(self.allocator);
+                                    errdefer {
+                                        import_item.deinit(self.allocator);
+                                        self.allocator.destroy(import_item);
+                                    }
 
                                     import_item.* = .{
                                         .operator = .{
@@ -668,7 +695,10 @@ pub const Parser = struct {
                                     defer func.deinit(self.allocator);
 
                                     const import_item = try self.allocator.create(ast.ImportItem);
-                                    errdefer import_item.deinit(self.allocator);
+                                    errdefer {
+                                        import_item.deinit(self.allocator);
+                                        self.allocator.destroy(import_item);
+                                    }
 
                                     import_item.* = .{
                                         .function = .{
@@ -692,7 +722,10 @@ pub const Parser = struct {
                                     }
 
                                     const import_item = try self.allocator.create(ast.ImportItem);
-                                    errdefer import_item.deinit(self.allocator);
+                                    errdefer {
+                                        import_item.deinit(self.allocator);
+                                        self.allocator.destroy(import_item);
+                                    }
 
                                     import_item.* = .{
                                         .type = .{
@@ -716,7 +749,10 @@ pub const Parser = struct {
                                     _ = try self.expect(lexer.TokenKind{ .delimiter = .RightParen });
 
                                     const import_item = try self.allocator.create(ast.ImportItem);
-                                    errdefer import_item.deinit(self.allocator);
+                                    errdefer {
+                                        import_item.deinit(self.allocator);
+                                        self.allocator.destroy(import_item);
+                                    }
 
                                     import_item.* = .{
                                         .operator = .{
@@ -752,7 +788,10 @@ pub const Parser = struct {
         }
 
         const import_node = try self.allocator.create(ast.ImportSpecNode);
-        errdefer import_node.deinit(self.allocator);
+        errdefer {
+            import_node.deinit(self.allocator);
+            self.allocator.destroy(import_node);
+        }
 
         import_node.* = .{
             .path = path_node.module_path,
@@ -763,7 +802,10 @@ pub const Parser = struct {
         };
 
         const node = try self.allocator.create(ast.Node);
-        errdefer node.deinit(self.allocator);
+        errdefer {
+            node.deinit(self.allocator);
+            self.allocator.destroy(node);
+        }
 
         node.* = .{ .import_spec = import_node };
 
@@ -799,18 +841,37 @@ pub const Parser = struct {
                 type_params.deinit();
             }
 
-            while (self.check(lexer.TokenKind{ .identifier = .Lower })) {
+            if (try self.match(lexer.TokenKind{ .delimiter = .LeftParen })) {
                 const param = try self.parseLowerIdentifier();
+                errdefer param.deinit(self.allocator);
+                defer param.deinit(self.allocator);
 
                 try type_params.append(try self.allocator.dupe(u8, param.identifier));
+
+                while (try self.match(lexer.TokenKind{ .delimiter = .Comma })) {
+                    const next_param = try self.parseLowerIdentifier();
+                    errdefer next_param.deinit(self.allocator);
+                    defer next_param.deinit(self.allocator);
+
+                    try type_params.append(try self.allocator.dupe(u8, next_param.identifier));
+                }
+
+                _ = try self.expect(lexer.TokenKind{ .delimiter = .RightParen });
             }
 
             _ = try self.expect(lexer.TokenKind{ .operator = .Equal });
 
             const value = try self.parseTypeExpr();
+            errdefer {
+                value.deinit(self.allocator);
+                self.allocator.destroy(value);
+            }
 
             const alias_node = try self.allocator.create(ast.TypeAliasNode);
-            errdefer alias_node.deinit(self.allocator);
+            errdefer {
+                alias_node.deinit(self.allocator);
+                self.allocator.destroy(alias_node);
+            }
 
             alias_node.* = .{
                 .name = type_ident,
@@ -820,7 +881,10 @@ pub const Parser = struct {
             };
 
             const node = try self.allocator.create(ast.Node);
-            errdefer node.deinit(self.allocator);
+            errdefer {
+                node.deinit(self.allocator);
+                self.allocator.destroy(node);
+            }
 
             node.* = .{ .type_alias = alias_node };
 
@@ -866,7 +930,10 @@ pub const Parser = struct {
                 const field_type = try self.parseTypeExpr();
 
                 const field_node = try self.allocator.create(ast.RecordFieldNode);
-                errdefer field_node.deinit(self.allocator);
+                errdefer {
+                    field_node.deinit(self.allocator);
+                    self.allocator.destroy(field_node);
+                }
 
                 field_node.* = .{
                     .name = field_name,
@@ -884,7 +951,10 @@ pub const Parser = struct {
             _ = try self.expect(lexer.TokenKind{ .delimiter = .RightBrace });
 
             const rtype_node = try self.allocator.create(ast.RecordTypeNode);
-            errdefer rtype_node.deinit(self.allocator);
+            errdefer {
+                rtype_node.deinit(self.allocator);
+                self.allocator.destroy(rtype_node);
+            }
 
             rtype_node.* = .{
                 .name = type_ident,
@@ -894,7 +964,10 @@ pub const Parser = struct {
             };
 
             const node = try self.allocator.create(ast.Node);
-            errdefer node.deinit(self.allocator);
+            errdefer {
+                node.deinit(self.allocator);
+                self.allocator.destroy(node);
+            }
 
             node.* = .{ .record_type = rtype_node };
 
@@ -934,7 +1007,10 @@ pub const Parser = struct {
             }
 
             const constructor_node = try self.allocator.create(ast.VariantConstructorNode);
-            errdefer constructor_node.deinit(self.allocator);
+            errdefer {
+                constructor_node.deinit(self.allocator);
+                self.allocator.destroy(constructor_node);
+            }
 
             constructor_node.* = .{
                 .name = constructor,
@@ -978,7 +1054,10 @@ pub const Parser = struct {
                 }
 
                 const next_constructor_node = try self.allocator.create(ast.VariantConstructorNode);
-                errdefer next_constructor_node.deinit(self.allocator);
+                errdefer {
+                    next_constructor_node.deinit(self.allocator);
+                    self.allocator.destroy(next_constructor_node);
+                }
 
                 next_constructor_node.* = .{
                     .name = next_constructor,
@@ -990,7 +1069,10 @@ pub const Parser = struct {
             }
 
             const vtype_node = try self.allocator.create(ast.VariantTypeNode);
-            errdefer vtype_node.deinit(self.allocator);
+            errdefer {
+                vtype_node.deinit(self.allocator);
+                self.allocator.destroy(vtype_node);
+            }
 
             vtype_node.* = .{
                 .name = type_ident,
@@ -1000,7 +1082,10 @@ pub const Parser = struct {
             };
 
             const node = try self.allocator.create(ast.Node);
-            errdefer node.deinit(self.allocator);
+            errdefer {
+                node.deinit(self.allocator);
+                self.allocator.destroy(node);
+            }
 
             node.* = .{ .variant_type = vtype_node };
 
@@ -1060,7 +1145,10 @@ pub const Parser = struct {
         const value = try self.parseExpression();
 
         const func_decl_node = try self.allocator.create(ast.FunctionDeclNode);
-        errdefer func_decl_node.deinit(self.allocator);
+        errdefer {
+            func_decl_node.deinit(self.allocator);
+            self.allocator.destroy(func_decl_node);
+        }
 
         func_decl_node.* = .{
             .name = fn_name,
@@ -1071,7 +1159,10 @@ pub const Parser = struct {
         };
 
         const node = try self.allocator.create(ast.Node);
-        errdefer node.deinit(self.allocator);
+        errdefer {
+            node.deinit(self.allocator);
+            self.allocator.destroy(node);
+        }
 
         node.* = .{ .function_decl = func_decl_node };
 
@@ -1126,7 +1217,10 @@ pub const Parser = struct {
         }
 
         const foreign_node = try self.allocator.create(ast.ForeignFunctionDeclNode);
-        errdefer foreign_node.deinit(self.allocator);
+        errdefer {
+            foreign_node.deinit(self.allocator);
+            self.allocator.destroy(foreign_node);
+        }
 
         foreign_node.* = .{
             .name = fn_name,
@@ -1137,7 +1231,10 @@ pub const Parser = struct {
         };
 
         const node = try self.allocator.create(ast.Node);
-        errdefer node.deinit(self.allocator);
+        errdefer {
+            node.deinit(self.allocator);
+            self.allocator.destroy(node);
+        }
 
         node.* = .{ .foreign_function_decl = foreign_node };
 
@@ -1160,7 +1257,10 @@ pub const Parser = struct {
         defer self.allocator.destroy(path_node);
 
         const include_node = try self.allocator.create(ast.IncludeNode);
-        errdefer include_node.deinit(self.allocator);
+        errdefer {
+            include_node.deinit(self.allocator);
+            self.allocator.destroy(include_node);
+        }
 
         include_node.* = .{
             .path = path_node.module_path,
@@ -1168,7 +1268,10 @@ pub const Parser = struct {
         };
 
         const node = try self.allocator.create(ast.Node);
-        errdefer node.deinit(self.allocator);
+        errdefer {
+            node.deinit(self.allocator);
+            self.allocator.destroy(node);
+        }
 
         node.* = .{ .include = include_node };
 
@@ -1205,10 +1308,12 @@ pub const Parser = struct {
             };
 
             const right = try self.parseBinaryExpr(next_min);
-            errdefer right.deinit(self.allocator);
 
             const node = try self.allocator.create(ast.Node);
-            errdefer node.deinit(self.allocator);
+            errdefer {
+                node.deinit(self.allocator);
+                self.allocator.destroy(node);
+            }
 
             switch (operator.kind) {
                 .operator => |op| {
@@ -1217,7 +1322,10 @@ pub const Parser = struct {
                         op == .IntDiv or op == .IntMul or op == .IntSub)
                     {
                         const arithmetic_node = try self.allocator.create(ast.ArithmeticExprNode);
-                        errdefer arithmetic_node.deinit(self.allocator);
+                        errdefer {
+                            arithmetic_node.deinit(self.allocator);
+                            self.allocator.destroy(arithmetic_node);
+                        }
 
                         arithmetic_node.* = .{
                             .left = left,
@@ -1228,7 +1336,10 @@ pub const Parser = struct {
                         node.* = .{ .arithmetic_expr = arithmetic_node };
                     } else if (op == .LogicalAnd or op == .LogicalOr) {
                         const logical_node = try self.allocator.create(ast.LogicalExprNode);
-                        errdefer logical_node.deinit(self.allocator);
+                        errdefer {
+                            logical_node.deinit(self.allocator);
+                            self.allocator.destroy(logical_node);
+                        }
 
                         logical_node.* = .{
                             .left = left,
@@ -1241,7 +1352,10 @@ pub const Parser = struct {
                         op == .LessThan or op == .LessThanEqual or op == .NotEqual)
                     {
                         const comparison_node = try self.allocator.create(ast.ComparisonExprNode);
-                        errdefer comparison_node.deinit(self.allocator);
+                        errdefer {
+                            comparison_node.deinit(self.allocator);
+                            self.allocator.destroy(comparison_node);
+                        }
 
                         comparison_node.* = .{
                             .left = left,
@@ -1252,7 +1366,10 @@ pub const Parser = struct {
                         node.* = .{ .comparison_expr = comparison_node };
                     } else if (op == .StrConcat) {
                         const str_concat_node = try self.allocator.create(ast.StrConcatExprNode);
-                        errdefer str_concat_node.deinit(self.allocator);
+                        errdefer {
+                            str_concat_node.deinit(self.allocator);
+                            self.allocator.destroy(str_concat_node);
+                        }
 
                         str_concat_node.* = .{
                             .left = left,
@@ -1263,7 +1380,10 @@ pub const Parser = struct {
                         node.* = .{ .str_concat_expr = str_concat_node };
                     } else if (op == .ListConcat) {
                         const list_concat_node = try self.allocator.create(ast.ListConcatExprNode);
-                        errdefer list_concat_node.deinit(self.allocator);
+                        errdefer {
+                            list_concat_node.deinit(self.allocator);
+                            self.allocator.destroy(list_concat_node);
+                        }
 
                         list_concat_node.* = .{
                             .left = left,
@@ -1301,7 +1421,10 @@ pub const Parser = struct {
             const operand = try self.parseSimpleExpr();
 
             const unary_node = try self.allocator.create(ast.UnaryExprNode);
-            errdefer unary_node.deinit(self.allocator);
+            errdefer {
+                unary_node.deinit(self.allocator);
+                self.allocator.destroy(unary_node);
+            }
 
             unary_node.* = .{
                 .operand = operand,
@@ -1309,7 +1432,10 @@ pub const Parser = struct {
             };
 
             const node = try self.allocator.create(ast.Node);
-            errdefer node.deinit(self.allocator);
+            errdefer {
+                node.deinit(self.allocator);
+                self.allocator.destroy(node);
+            }
 
             node.* = .{ .unary_expr = unary_node };
 
@@ -1341,7 +1467,10 @@ pub const Parser = struct {
             },
             .identifier => |ident| {
                 const node = try self.allocator.create(ast.Node);
-                errdefer node.deinit(self.allocator);
+                errdefer {
+                    node.deinit(self.allocator);
+                    self.allocator.destroy(node);
+                }
 
                 switch (ident) {
                     .Lower => {
@@ -1436,6 +1565,7 @@ pub const Parser = struct {
         errdefer {
             if (return_type) |rt| {
                 rt.deinit(self.allocator);
+                self.allocator.destroy(rt);
             }
         }
 
@@ -1448,7 +1578,10 @@ pub const Parser = struct {
         const body = try self.parseExpression();
 
         const lambda_node = try self.allocator.create(ast.LambdaExprNode);
-        errdefer lambda_node.deinit(self.allocator);
+        errdefer {
+            lambda_node.deinit(self.allocator);
+            self.allocator.destroy(lambda_node);
+        }
 
         lambda_node.* = .{
             .parameters = parameters,
@@ -1458,7 +1591,10 @@ pub const Parser = struct {
         };
 
         const node = try self.allocator.create(ast.Node);
-        errdefer node.deinit(self.allocator);
+        errdefer {
+            node.deinit(self.allocator);
+            self.allocator.destroy(node);
+        }
 
         node.* = .{ .lambda_expr = lambda_node };
 
@@ -1470,12 +1606,12 @@ pub const Parser = struct {
         const param_token = self.current_token;
 
         const name = try self.parseLowerIdentifier();
-        errdefer name.deinit(self.allocator);
 
         var type_annotation: ?*ast.Node = null;
         errdefer {
             if (type_annotation) |t| {
                 t.deinit(self.allocator);
+                self.allocator.destroy(t);
             }
         }
 
@@ -1483,16 +1619,19 @@ pub const Parser = struct {
             type_annotation = try self.parseTypeExpr();
         }
 
-        const param = try self.allocator.create(ast.ParamDeclNode);
-        errdefer param.deinit(self.allocator);
+        const node = try self.allocator.create(ast.ParamDeclNode);
+        errdefer {
+            node.deinit(self.allocator);
+            self.allocator.destroy(node);
+        }
 
-        param.* = .{
+        node.* = .{
             .name = name,
             .type_annotation = type_annotation,
             .token = param_token,
         };
 
-        return param;
+        return node;
     }
 
     /// Parses a list expression surrounded by square brackets with comma-separated elements.
@@ -1519,9 +1658,13 @@ pub const Parser = struct {
             elements.deinit();
         }
 
-        // Handle empty list case
         if (try self.match(lexer.TokenKind{ .delimiter = .RightBracket })) {
             const empty_list = try self.allocator.create(ast.ListNode);
+            errdefer {
+                empty_list.deinit(self.allocator);
+                self.allocator.destroy(empty_list);
+            }
+
             empty_list.* = .{
                 .elements = elements,
                 .token = start_token,
@@ -1538,7 +1681,6 @@ pub const Parser = struct {
             return node;
         }
 
-        // Parse first element (required)
         const first_element = try self.parseExpression();
         try elements.append(first_element);
 
@@ -1550,6 +1692,11 @@ pub const Parser = struct {
         _ = try self.expect(lexer.TokenKind{ .delimiter = .RightBracket });
 
         const list_node = try self.allocator.create(ast.ListNode);
+        errdefer {
+            list_node.deinit(self.allocator);
+            self.allocator.destroy(list_node);
+        }
+
         list_node.* = .{
             .elements = elements,
             .token = start_token,
@@ -1574,34 +1721,113 @@ pub const Parser = struct {
     /// Examples:
     /// - `(1, "hello")`
     /// - `(x, True)`
-    /// - `(42, some_func x)`
-    // fn parseTuple(self: *Parser) ParserError!*ast.Node {}
+    /// - `(42, some_func(x))`
+    fn parseTuple(self: *Parser) ParserError!*ast.Node {
+        const start_token = try self.expect(lexer.TokenKind{ .delimiter = .LeftParen });
+
+        var elements = std.ArrayList(*ast.Node).init(self.allocator);
+        errdefer {
+            for (elements.items) |elem| {
+                elem.deinit(self.allocator);
+                self.allocator.destroy(elem);
+            }
+
+            elements.deinit();
+        }
+
+        const first = try self.parseSimpleExpr();
+        errdefer {
+            first.deinit(self.allocator);
+            self.allocator.destroy(first);
+        }
+
+        try elements.append(first);
+
+        _ = try self.match(lexer.TokenKind{ .delimiter = .Comma });
+
+        const second = try self.parseSimpleExpr();
+        errdefer {
+            second.deinit(self.allocator);
+            self.allocator.destroy(second);
+        }
+
+        try elements.append(second);
+
+        _ = try self.match(lexer.TokenKind{ .delimiter = .RightParen });
+
+        assert(elements.items.len == 2);
+
+        const tuple_node = try self.allocator.create(ast.TupleNode);
+        errdefer {
+            tuple_node.deinit(self.allocator);
+            self.allocator.destroy(tuple_node);
+        }
+
+        tuple_node.* = .{
+            .elements = elements,
+            .token = start_token,
+        };
+
+        const node = try self.allocator.create(ast.Node);
+        errdefer {
+            node.deinit(self.allocator);
+            self.allocator.destroy(node);
+        }
+
+        node.* = .{ .tuple = tuple_node };
+
+        return node;
+    }
 
     /// Parses a conditional expression with a required 'then' and 'else' branch.
     /// The condition must evaluate to a boolean value. If true, the 'then' branch
     /// is evaluated; otherwise, the 'else' branch is evaluated.
     ///
     /// Examples:
-    /// - `if x > 0 then "positive" else "non-positive"`
-    /// - `if empty? list then None else head list`
+    /// - `if x > 0 then
+    ///    "positive"
+    ///else
+    ///    "non-positive"`
+    /// - `if empty?(list) then
+    ///    None
+    ///else
+    ///    head(list)`
     /// - `if x == 0 then
-    ///      "zero"
-    ///    else if x < 0 then
-    ///      "negative"
-    ///    else
-    ///      "positive"`
+    ///    "zero"
+    ///else if x < 0 then
+    ///    "negative"
+    ///else
+    ///    "positive"`
     fn parseIfThenElse(self: *Parser) ParserError!*ast.Node {
         const start_token = try self.expect(lexer.TokenKind{ .keyword = .If });
+
         const condition = try self.parseExpression();
+        errdefer {
+            condition.deinit(self.allocator);
+            self.allocator.destroy(condition);
+        }
 
         _ = try self.expect(lexer.TokenKind{ .keyword = .Then });
+
         const then_branch = try self.parseExpression();
+        errdefer {
+            then_branch.deinit(self.allocator);
+            self.allocator.destroy(then_branch);
+        }
 
         _ = try self.expect(lexer.TokenKind{ .keyword = .Else });
+
         const else_branch = try self.parseExpression();
+        errdefer {
+            else_branch.deinit(self.allocator);
+            self.allocator.destroy(else_branch);
+        }
 
         const if_node = try self.allocator.create(ast.IfThenElseStmtNode);
-        errdefer if_node.deinit(self.allocator);
+        errdefer {
+            if_node.deinit(self.allocator);
+            self.allocator.destroy(if_node);
+        }
 
         if_node.* = .{
             .condition = condition,
@@ -1611,7 +1837,10 @@ pub const Parser = struct {
         };
 
         const node = try self.allocator.create(ast.Node);
-        errdefer node.deinit(self.allocator);
+        errdefer {
+            node.deinit(self.allocator);
+            self.allocator.destroy(node);
+        }
 
         node.* = .{ .if_then_else_stmt = if_node };
 
@@ -1629,6 +1858,10 @@ pub const Parser = struct {
         const start_token = self.current_token;
 
         const first_type = try self.parseSimpleType();
+        errdefer {
+            first_type.deinit(self.allocator);
+            self.allocator.destroy(first_type);
+        }
 
         if (!try self.match(lexer.TokenKind{ .symbol = .ArrowRight })) {
             return first_type;
@@ -1638,6 +1871,7 @@ pub const Parser = struct {
         errdefer {
             for (parameter_types.items) |param_type| {
                 param_type.deinit(self.allocator);
+                self.allocator.destroy(param_type);
             }
 
             parameter_types.deinit();
@@ -1646,9 +1880,16 @@ pub const Parser = struct {
         try parameter_types.append(first_type);
 
         const return_type = try self.parseTypeExpr();
+        errdefer {
+            return_type.deinit(self.allocator);
+            self.allocator.destroy(return_type);
+        }
 
         const function_sig_node = try self.allocator.create(ast.FunctionSignatureNode);
-        errdefer function_sig_node.deinit(self.allocator);
+        errdefer {
+            function_sig_node.deinit(self.allocator);
+            self.allocator.destroy(function_sig_node);
+        }
 
         function_sig_node.* = .{
             .parameter_types = parameter_types,
@@ -1657,7 +1898,10 @@ pub const Parser = struct {
         };
 
         const node = try self.allocator.create(ast.Node);
-        errdefer node.deinit(self.allocator);
+        errdefer {
+            node.deinit(self.allocator);
+            self.allocator.destroy(node);
+        }
 
         node.* = .{ .function_signature = function_sig_node };
 
@@ -1670,37 +1914,59 @@ pub const Parser = struct {
             const start_token = self.current_token;
 
             const type_name = try self.parseUpperIdentifier();
-
-            // Check for type arguments
-            var args = std.ArrayList(*ast.Node).init(self.allocator);
             errdefer {
-                for (args.items) |t| {
+                type_name.deinit(self.allocator);
+                self.allocator.destroy(type_name);
+            }
+
+            var type_args = std.ArrayList(*ast.Node).init(self.allocator);
+            errdefer {
+                for (type_args.items) |t| {
                     t.deinit(self.allocator);
+                    self.allocator.destroy(t);
                 }
 
-                args.deinit();
+                type_args.deinit();
             }
 
             if (try self.match(lexer.TokenKind{ .delimiter = .LeftParen })) {
-                try args.append(try self.parseTypeExpr());
+                const first_arg = try self.parseTypeExpr();
+                errdefer {
+                    first_arg.deinit(self.allocator);
+                    self.allocator.destroy(first_arg);
+                }
+
+                try type_args.append(first_arg);
 
                 while (try self.match(lexer.TokenKind{ .delimiter = .Comma })) {
-                    try args.append(try self.parseTypeExpr());
+                    const next_arg = try self.parseTypeExpr();
+                    errdefer {
+                        next_arg.deinit(self.allocator);
+                        self.allocator.destroy(next_arg);
+                    }
+
+                    try type_args.append(next_arg);
                 }
 
                 _ = try self.expect(lexer.TokenKind{ .delimiter = .RightParen });
 
                 const type_app_node = try self.allocator.create(ast.TypeApplicationNode);
-                errdefer type_app_node.deinit(self.allocator);
+                errdefer {
+                    type_app_node.deinit(self.allocator);
+                    self.allocator.destroy(type_app_node);
+                }
 
                 type_app_node.* = .{
                     .constructor = type_name,
-                    .args = args,
+                    .args = type_args,
                     .token = start_token,
                 };
 
                 const node = try self.allocator.create(ast.Node);
-                errdefer node.deinit(self.allocator);
+                errdefer {
+                    node.deinit(self.allocator);
+                    self.allocator.destroy(node);
+                }
 
                 node.* = .{ .type_application = type_app_node };
 
@@ -1708,7 +1974,10 @@ pub const Parser = struct {
             }
 
             const node = try self.allocator.create(ast.Node);
-            errdefer self.allocator.destroy(node);
+            errdefer {
+                node.deinit(self.allocator);
+                self.allocator.destroy(node);
+            }
 
             node.* = .{ .upper_identifier = type_name };
 
@@ -1717,9 +1986,16 @@ pub const Parser = struct {
 
         if (self.check(lexer.TokenKind{ .identifier = .Lower })) {
             const type_var = try self.parseLowerIdentifier();
+            errdefer {
+                type_var.deinit(self.allocator);
+                self.allocator.destroy(type_var);
+            }
 
             const node = try self.allocator.create(ast.Node);
-            errdefer node.deinit(self.allocator);
+            errdefer {
+                node.deinit(self.allocator);
+                self.allocator.destroy(node);
+            }
 
             node.* = .{ .lower_identifier = type_var };
 
@@ -1736,11 +2012,23 @@ pub const Parser = struct {
                 types.deinit();
             }
 
-            try types.append(try self.parseTypeExpr());
+            const first_type = try self.parseTypeExpr();
+            errdefer {
+                first_type.deinit(self.allocator);
+                self.allocator.destroy(first_type);
+            }
+
+            try types.append(first_type);
 
             if (try self.match(lexer.TokenKind{ .delimiter = .Comma })) {
                 while (true) {
-                    try types.append(try self.parseTypeExpr());
+                    const next_type = try self.parseTypeExpr();
+                    errdefer {
+                        next_type.deinit(self.allocator);
+                        self.allocator.destroy(next_type);
+                    }
+
+                    try types.append(next_type);
 
                     if (!try self.match(lexer.TokenKind{ .delimiter = .Comma })) {
                         break;
@@ -1750,6 +2038,20 @@ pub const Parser = struct {
 
             _ = try self.expect(lexer.TokenKind{ .delimiter = .RightParen });
 
+        if (try self.match(lexer.TokenKind{ .special = .Hole })) {
+            const node = try self.allocator.create(ast.Node);
+            errdefer {
+                node.deinit(self.allocator);
+                self.allocator.destroy(node);
+            }
+
+            node.* = .{
+                .typed_hole = .{
+                    .token = self.current_token,
+                },
+            };
+
+            return node;
         }
 
         return error.UnexpectedToken;
@@ -1767,6 +2069,13 @@ pub const Parser = struct {
     /// - `Parser.Internal.Utils`
     fn parseModulePath(self: *Parser) ParserError!*ast.Node {
         var segments = std.ArrayList(*ast.UpperIdentifierNode).init(self.allocator);
+        errdefer {
+            for (segments.items) |segment| {
+                segment.deinit(self.allocator);
+            }
+
+            segments.deinit();
+        }
 
         const first_segment = try self.parseUpperIdentifier();
         try segments.append(first_segment);
@@ -1777,6 +2086,11 @@ pub const Parser = struct {
         }
 
         const path_node = try self.allocator.create(ast.ModulePathNode);
+        errdefer {
+            path_node.deinit(self.allocator);
+            self.allocator.destroy(path_node);
+        }
+
         path_node.* = .{
             .segments = segments,
             .token = first_segment.token,
@@ -1785,7 +2099,6 @@ pub const Parser = struct {
         const node = try self.allocator.create(ast.Node);
         errdefer {
             node.deinit(self.allocator);
-            self.allocator.destroy(path_node.module_path);
             self.allocator.destroy(node);
         }
 
@@ -1807,7 +2120,10 @@ pub const Parser = struct {
         const trimmed = std.mem.trimRight(u8, start_token.lexeme[i..], &std.ascii.whitespace);
 
         const comment_node = try self.allocator.create(ast.CommentNode);
-        errdefer comment_node.deinit(self.allocator);
+        errdefer {
+            comment_node.deinit(self.allocator);
+            self.allocator.destroy(comment_node);
+        }
 
         comment_node.* = .{
             .text = try self.allocator.dupe(u8, trimmed),
@@ -1815,7 +2131,10 @@ pub const Parser = struct {
         };
 
         const node = try self.allocator.create(ast.Node);
-        errdefer node.deinit(self.allocator);
+        errdefer {
+            node.deinit(self.allocator);
+            self.allocator.destroy(node);
+        }
 
         node.* = .{ .comment = comment_node };
 
@@ -1835,7 +2154,10 @@ pub const Parser = struct {
         const trimmed = std.mem.trimRight(u8, start_token.lexeme[i..], &std.ascii.whitespace);
 
         const comment_node = try self.allocator.create(ast.DocCommentNode);
-        errdefer comment_node.deinit(self.allocator);
+        errdefer {
+            comment_node.deinit(self.allocator);
+            self.allocator.destroy(comment_node);
+        }
 
         comment_node.* = .{
             .text = try self.allocator.dupe(u8, trimmed),
@@ -1843,7 +2165,10 @@ pub const Parser = struct {
         };
 
         const node = try self.allocator.create(ast.Node);
-        errdefer node.deinit(self.allocator);
+        errdefer {
+            node.deinit(self.allocator);
+            self.allocator.destroy(node);
+        }
 
         node.* = .{ .doc_comment = comment_node };
 
@@ -3478,7 +3803,7 @@ test "[type_alias]" {
 
     {
         // Function type
-        const source = "type alias Reducer a b = a -> b -> b";
+        const source = "type alias Reducer(a, b) = (a, b) -> b";
         var l = lexer.Lexer.init(source, TEST_FILE);
         var parser = try Parser.init(allocator, &l);
         defer parser.deinit();
@@ -3547,7 +3872,7 @@ test "[type_alias]" {
         const type_alias = node.type_alias;
 
         // Verify the name and type parameters of the alias
-        try testing.expectEqualStrings("TreeMap", type_alias.name);
+        try testing.expectEqualStrings("TreeMap", type_alias.name.identifier);
         try testing.expectEqual(@as(usize, 2), type_alias.type_params.items.len);
         try testing.expectEqualStrings("k", type_alias.type_params.items[0]);
         try testing.expectEqualStrings("v", type_alias.type_params.items[1]);
@@ -3557,14 +3882,14 @@ test "[type_alias]" {
 
         const tree_app = type_alias.value.type_application;
 
-        // Validate that the base type is 'Tree'
+        // Validate that the base type is "Tree"
         try testing.expectEqual(lexer.TokenKind{ .identifier = .Upper }, tree_app.constructor.token.kind);
         try testing.expectEqualStrings("Tree", tree_app.constructor.identifier);
 
-        // Ensure 'Tree' has exactly two type arguments: (Pair k v) and (Compare k)
+        // Ensure 'Tree' has exactly two type arguments: Pair(k, v) and Compare(k)
         try testing.expectEqual(@as(usize, 2), tree_app.args.items.len);
 
-        // Check first argument (Pair k v)
+        // Check first argument "Pair(k, v)"
         {
             const pair_arg = tree_app.args.items[0];
 
@@ -3589,7 +3914,7 @@ test "[type_alias]" {
             try testing.expectEqualStrings("v", pair_app.args.items[1].lower_identifier.identifier);
         }
 
-        // Check second argument (Compare k)
+        // Check second argument "Compare(k)"
         {
             const compare_arg = tree_app.args.items[1];
 
@@ -3598,11 +3923,11 @@ test "[type_alias]" {
 
             const compare_app = compare_arg.type_application;
 
-            // Verify 'Compare' as the base type
+            // Verify "Compare" as the base type
             try testing.expectEqual(lexer.TokenKind{ .identifier = .Upper }, compare_app.constructor.token.kind);
             try testing.expectEqualStrings("Compare", compare_app.constructor.identifier);
 
-            // Ensure 'Compare' takes exactly one argument: 'k'
+            // Ensure "Compare" takes exactly one argument: 'k'
             try testing.expectEqual(@as(usize, 1), compare_app.args.items.len);
 
             // Validate argument of Compare: 'k'
@@ -3638,7 +3963,7 @@ test "[record_type]" {
         const record = node.record_type;
 
         // Validate the name of the record type
-        try testing.expectEqualStrings("User", record.name);
+        try testing.expectEqualStrings("User", record.name.identifier);
 
         // Ensure the record has no type parameters
         try testing.expectEqual(@as(usize, 0), record.type_params.items.len);
@@ -3651,7 +3976,7 @@ test "[record_type]" {
             const name_field = record.fields.items[0];
 
             // Ensure the field name is 'name'
-            try testing.expectEqualStrings("name", name_field.name);
+            try testing.expectEqualStrings("name", name_field.name.identifier);
 
             // Ensure the field type is 'String'
             try testing.expect(name_field.type.* == .upper_identifier);
@@ -3663,7 +3988,7 @@ test "[record_type]" {
             const age_field = record.fields.items[1];
 
             // Ensure the field name is 'age'
-            try testing.expectEqualStrings("age", age_field.name);
+            try testing.expectEqualStrings("age", age_field.name.identifier);
 
             // Ensure the field type is 'Int'
             try testing.expect(age_field.type.* == .upper_identifier);
@@ -3691,7 +4016,7 @@ test "[record_type]" {
         const record = node.record_type;
 
         // Validate the name of the record type
-        try testing.expectEqualStrings("Point", record.name);
+        try testing.expectEqualStrings("Point", record.name.identifier);
 
         // Ensure the record has exactly one type parameter
         try testing.expectEqual(@as(usize, 1), record.type_params.items.len);
@@ -3705,7 +4030,7 @@ test "[record_type]" {
             const x_field = record.fields.items[0];
 
             // Ensure the field name is 'x'
-            try testing.expectEqualStrings("x", x_field.name);
+            try testing.expectEqualStrings("x", x_field.name.identifier);
 
             // Ensure the field type is the generic type parameter 'a'
             try testing.expect(x_field.type.* == .lower_identifier);
@@ -3717,7 +4042,7 @@ test "[record_type]" {
             const y_field = record.fields.items[1];
 
             // Ensure the field name is 'y'
-            try testing.expectEqualStrings("y", y_field.name);
+            try testing.expectEqualStrings("y", y_field.name.identifier);
 
             // Ensure the field type is the generic type parameter 'a'
             try testing.expect(y_field.type.* == .lower_identifier);
@@ -3726,7 +4051,7 @@ test "[record_type]" {
     }
 
     {
-        const source = "type Dict k v = { keys: List k, values: List v }";
+        const source = "type Dict(k, v) = { keys : List(k), values : List(v) }";
         var l = lexer.Lexer.init(source, TEST_FILE);
         var parser = try Parser.init(allocator, &l);
         defer parser.deinit();
@@ -3745,7 +4070,7 @@ test "[record_type]" {
         const record = node.record_type;
 
         // Validate the name of the record type
-        try testing.expectEqualStrings("Dict", record.name);
+        try testing.expectEqualStrings("Dict", record.name.identifier);
 
         // Ensure the record has exactly two type parameters
         try testing.expectEqual(@as(usize, 2), record.type_params.items.len);
@@ -3760,7 +4085,7 @@ test "[record_type]" {
             const keys_field = record.fields.items[0];
 
             // Ensure the field name is 'keys'
-            try testing.expectEqualStrings("keys", keys_field.name);
+            try testing.expectEqualStrings("keys", keys_field.name.identifier);
 
             // Ensure the field type is a type application (List k)
             try testing.expect(keys_field.type.* == .type_application);
@@ -3782,7 +4107,7 @@ test "[record_type]" {
             const values_field = record.fields.items[1];
 
             // Ensure the field name is 'values'
-            try testing.expectEqualStrings("values", values_field.name);
+            try testing.expectEqualStrings("values", values_field.name.identifier);
 
             // Ensure the field type is a type application (List v)
             try testing.expect(values_field.type.* == .type_application);
@@ -3801,7 +4126,7 @@ test "[record_type]" {
     }
 
     {
-        const source = "type Storage a = { items: List (Maybe a), count: Maybe Int, names: List String }";
+        const source = "type Storage(a) = { items : List(Maybe(a)), count : Maybe(Int), names : List(String) }";
         var l = lexer.Lexer.init(source, TEST_FILE);
         var parser = try Parser.init(allocator, &l);
         defer parser.deinit();
@@ -3820,7 +4145,7 @@ test "[record_type]" {
         const record = node.record_type;
 
         // Validate the name of the record type
-        try testing.expectEqualStrings("Storage", record.name);
+        try testing.expectEqualStrings("Storage", record.name.identifier);
 
         // Ensure 'Storage' has one type parameter: 'a'
         try testing.expectEqual(@as(usize, 1), record.type_params.items.len);
@@ -3829,12 +4154,12 @@ test "[record_type]" {
         // Ensure the record has exactly three fields
         try testing.expectEqual(@as(usize, 3), record.fields.items.len);
 
-        // Check first field (items: List (Maybe a))
+        // Check first field (items: List(Maybe(a))
         {
             const items_field = record.fields.items[0];
 
             // Ensure the field name is 'items'
-            try testing.expectEqualStrings("items", items_field.name);
+            try testing.expectEqualStrings("items", items_field.name.identifier);
 
             // Ensure the field type is a type application (List (Maybe a))
             try testing.expect(items_field.type.* == .type_application);
@@ -3861,12 +4186,12 @@ test "[record_type]" {
             try testing.expectEqualStrings("a", maybe_app.args.items[0].lower_identifier.identifier);
         }
 
-        // Check second field (count: Maybe Int)
+        // Check second field (count: Maybe(Int))
         {
             const count_field = record.fields.items[1];
 
             // Ensure the field name is 'count'
-            try testing.expectEqualStrings("count", count_field.name);
+            try testing.expectEqualStrings("count", count_field.name.identifier);
 
             // Ensure the field type is a type application (Maybe Int)
             try testing.expect(count_field.type.* == .type_application);
@@ -3883,12 +4208,12 @@ test "[record_type]" {
             try testing.expectEqualStrings("Int", maybe_app.args.items[0].upper_identifier.identifier);
         }
 
-        // Check third field (names: List String)
+        // Check third field (names: List(String))
         {
             const names_field = record.fields.items[2];
 
             // Ensure the field name is 'names'
-            try testing.expectEqualStrings("names", names_field.name);
+            try testing.expectEqualStrings("names", names_field.name.identifier);
 
             // Ensure the field type is a type application (List String)
             try testing.expect(names_field.type.* == .type_application);
@@ -3933,7 +4258,7 @@ test "[variant_type]" {
         const variant = node.variant_type;
 
         // Validate the name of the variant type
-        try testing.expectEqualStrings("Boolean", variant.name);
+        try testing.expectEqualStrings("Boolean", variant.name.identifier);
 
         // Ensure 'Boolean' has no type parameters
         try testing.expectEqual(@as(usize, 0), variant.type_params.items.len);
@@ -3946,7 +4271,7 @@ test "[variant_type]" {
             const true_constructor = variant.constructors.items[0];
 
             // Ensure the constructor is named 'True'
-            try testing.expectEqualStrings("True", true_constructor.name);
+            try testing.expectEqualStrings("True", true_constructor.name.identifier);
 
             // Ensure 'True' has no associated parameters
             try testing.expectEqual(@as(usize, 0), true_constructor.parameters.items.len);
@@ -3957,7 +4282,7 @@ test "[variant_type]" {
             const false_constructor = variant.constructors.items[1];
 
             // Ensure the constructor is named 'False'
-            try testing.expectEqualStrings("False", false_constructor.name);
+            try testing.expectEqualStrings("False", false_constructor.name.identifier);
 
             // Ensure 'False' has no associated parameters
             try testing.expectEqual(@as(usize, 0), false_constructor.parameters.items.len);
@@ -3984,7 +4309,7 @@ test "[variant_type]" {
         const variant = node.variant_type;
 
         // Validate the name of the variant type
-        try testing.expectEqualStrings("Maybe", variant.name);
+        try testing.expectEqualStrings("Maybe", variant.name.identifier);
 
         // Ensure 'Maybe' has a single type parameter 'a'
         try testing.expectEqual(@as(usize, 1), variant.type_params.items.len);
@@ -3998,7 +4323,7 @@ test "[variant_type]" {
             const none_constructor = variant.constructors.items[0];
 
             // Ensure the constructor is named 'None'
-            try testing.expectEqualStrings("None", none_constructor.name);
+            try testing.expectEqualStrings("None", none_constructor.name.identifier);
 
             // Ensure 'None' has no associated parameters
             try testing.expectEqual(@as(usize, 0), none_constructor.parameters.items.len);
@@ -4009,7 +4334,7 @@ test "[variant_type]" {
             const some_constructor = variant.constructors.items[1];
 
             // Ensure the constructor is named 'Some'
-            try testing.expectEqualStrings("Some", some_constructor.name);
+            try testing.expectEqualStrings("Some", some_constructor.name.identifier);
 
             // Ensure 'Some' has exactly one associated parameter
             try testing.expectEqual(@as(usize, 1), some_constructor.parameters.items.len);
@@ -4042,7 +4367,7 @@ test "[variant_type]" {
         const variant = node.variant_type;
 
         // Validate the name of the variant type
-        try testing.expectEqualStrings("Tree", variant.name);
+        try testing.expectEqualStrings("Tree", variant.name.identifier);
 
         // Ensure 'Tree' has a single type parameter 'a'
         try testing.expectEqual(@as(usize, 1), variant.type_params.items.len);
@@ -4056,7 +4381,7 @@ test "[variant_type]" {
             const leaf_constructor = variant.constructors.items[0];
 
             // Ensure the constructor is named 'Leaf'
-            try testing.expectEqualStrings("Leaf", leaf_constructor.name);
+            try testing.expectEqualStrings("Leaf", leaf_constructor.name.identifier);
 
             // Ensure 'Leaf' has no associated parameters
             try testing.expectEqual(@as(usize, 0), leaf_constructor.parameters.items.len);
@@ -4067,7 +4392,7 @@ test "[variant_type]" {
             const branch_constructor = variant.constructors.items[1];
 
             // Ensure the constructor is named 'Branch'
-            try testing.expectEqualStrings("Branch", branch_constructor.name);
+            try testing.expectEqualStrings("Branch", branch_constructor.name.identifier);
 
             // Ensure 'Branch' has exactly three parameters
             try testing.expectEqual(@as(usize, 3), branch_constructor.parameters.items.len);
@@ -4186,5 +4511,64 @@ test "[list]" {
         // Test third element (3)
         try testing.expect(list.elements.items[2].* == .int_literal);
         try testing.expectEqual(@as(i64, 3), list.elements.items[2].int_literal.value);
+    }
+}
+
+test "[tuple]" {
+    // Setup
+    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    defer _ = gpa.deinit();
+    const allocator = gpa.allocator();
+
+    {
+        // Test input: (1, "hello")
+
+        var l = lexer.Lexer.init("(1, \"hello\")", TEST_FILE);
+        var parser = try Parser.init(allocator, &l);
+        defer parser.deinit();
+
+        // Action
+        const node = try parser.parseTuple();
+        defer {
+            node.deinit(allocator);
+            allocator.destroy(node);
+        }
+
+        // Assertions
+        // Verify that the node type is a tuple.
+        try testing.expect(node.* == .tuple);
+
+        const tuple = node.tuple;
+
+        // Ensure the list has exactly two elements.
+        try testing.expectEqual(@as(usize, 2), tuple.elements.items.len);
+        try testing.expect(tuple.elements.items[0].int_literal.value == 1);
+        try testing.expectEqualStrings("hello", tuple.elements.items[1].str_literal.value);
+    }
+
+    {
+        // Test input: (x, True)
+
+        var l = lexer.Lexer.init("(x, True)", TEST_FILE);
+        var parser = try Parser.init(allocator, &l);
+        defer parser.deinit();
+
+        // Action
+        const node = try parser.parseTuple();
+        defer {
+            node.deinit(allocator);
+            allocator.destroy(node);
+        }
+
+        // Assertions
+        // Verify that the node type is a tuple.
+        try testing.expect(node.* == .tuple);
+
+        const tuple = node.tuple;
+
+        // Ensure the list has exactly two elements.
+        try testing.expectEqual(@as(usize, 2), tuple.elements.items.len);
+        try testing.expectEqualStrings("x", tuple.elements.items[0].lower_identifier.identifier);
+        try testing.expectEqualStrings("True", tuple.elements.items[1].upper_identifier.identifier);
     }
 }

--- a/compiler/root.zig
+++ b/compiler/root.zig
@@ -27,7 +27,7 @@ pub fn compile(allocator: std.mem.Allocator, writer: anytype, filepath: []const 
 
             if (std.meta.eql(token.kind, .{ .special = .Eof })) break;
 
-            try writer.print("Token: {s} ({any})\n", .{ token.lexeme, token.kind });
+            try writer.print("{any}\n", .{token});
         }
     }
 

--- a/formatter/formatter.zig
+++ b/formatter/formatter.zig
@@ -281,7 +281,7 @@ pub const Formatter = struct {
                 }
             },
             .lambda_expr => |expr| {
-                try self.write("\\");
+                try self.write("fn");
 
                 for (expr.param_names.items, 0..) |param, i| {
                     try self.write(param);
@@ -328,33 +328,9 @@ pub const Formatter = struct {
                 try self.write(" ++ ");
                 try self.formatNode(expr.right);
             },
-            .composition_expr => |expr| {
-                try self.formatNode(expr.first);
-
-                switch (expr.operator.kind) {
-                    .operator => |op| {
-                        if (op == .ComposeLeft) {
-                            try self.write(" << ");
-                        }
-
-                        if (op == .ComposeRight) {
-                            try self.write(" >> ");
-                        }
-                    },
-                    else => {},
-                }
-
-                try self.formatNode(expr.second);
-            },
             .pipe_expr => |expr| {
                 switch (expr.operator.kind) {
                     .operator => |op| {
-                        if (op == .PipeLeft) {
-                            try self.formatNode(expr.func);
-                            try self.write(" <| ");
-                            try self.formatNode(expr.value);
-                        }
-
                         if (op == .PipeRight) {
                             try self.formatNode(expr.value);
                             try self.write(" |> ");

--- a/formatter/formatter.zig
+++ b/formatter/formatter.zig
@@ -388,25 +388,30 @@ pub const Formatter = struct {
             .typed_hole => {
                 try self.write(" ? ");
             },
-            .type_application => |app| {
-                try self.formatNode(&ast.Node{ .upper_identifier = app.constructor });
-                try self.write(" ");
+            .type_application => |tapp| {
+                try self.formatNode(&ast.Node{ .upper_identifier = tapp.constructor });
 
-                for (app.args.items, 0..) |arg, i| {
-                    const needs_parens = (arg.* == .type_application);
-                    if (needs_parens) {
-                        try self.write("(");
+                if (tapp.args.items.len > 0) {
+                    try self.write("(");
+
+                    for (tapp.args.items, 0..) |arg, i| {
+                        const needs_parens = (arg.* == .type_application);
+                        if (needs_parens) {
+                            try self.write("(");
+                        }
+
+                        try self.formatNode(arg);
+
+                        if (needs_parens) {
+                            try self.write(")");
+                        }
+
+                        if (i < tapp.args.items.len - 1) {
+                            try self.write(", ");
+                        }
                     }
 
-                    try self.formatNode(arg);
-
-                    if (needs_parens) {
-                        try self.write(")");
-                    }
-
-                    if (i < app.args.items.len - 1) {
-                        try self.write(" ");
-                    }
+                    try self.write(")");
                 }
             },
             .type_alias => |atype| {

--- a/formatter/formatter.zig
+++ b/formatter/formatter.zig
@@ -365,7 +365,6 @@ pub const Formatter = struct {
                 try self.formatNode(stmt.condition);
 
                 try self.write(" then\n");
-
                 self.indent_level += 1;
 
                 try self.writeIndent();
@@ -373,9 +372,9 @@ pub const Formatter = struct {
                 try self.write("\n");
 
                 self.indent_level -= 1;
+                try self.writeIndent();
 
                 try self.write("else\n");
-
                 self.indent_level += 1;
 
                 try self.writeIndent();
@@ -723,9 +722,14 @@ pub const Formatter = struct {
                     try self.formatNode(ret_type);
                 }
 
-                try self.write(" = ");
+                try self.write(" =");
+
+                self.indent_level += 1;
+                try self.writeNewlineAndIndent();
 
                 try self.formatNode(decl.value);
+
+                self.indent_level -= 1;
 
                 try self.write("\n");
             },
@@ -755,9 +759,14 @@ pub const Formatter = struct {
 
                 try self.formatNode(decl.return_type);
 
-                try self.write(" = ");
+                try self.write(" =");
+
+                self.indent_level += 1;
+                try self.writeNewlineAndIndent();
 
                 try self.formatNode(&.{ .str_literal = decl.external_name });
+
+                self.indent_level -= 1;
 
                 try self.write("\n");
             },

--- a/stdlib/comparable.mn
+++ b/stdlib/comparable.mn
@@ -17,7 +17,7 @@ module Comparable exposing
         | GT
 
     let eq(x : Bool, y : Bool) -> Bool =
-        if (x == True) and (y == True) then
+        if (x == True) && (y == True) then
             True
         else
             False


### PR DESCRIPTION
⚠️ Types alias and and variant types aren't fully refactored to pass all previous tests. But memory management is becoming a serious issue, so I'm going to look into reference counting rather than pure manual memory management. 

test.mn
```
## some doc comment
## ```
## test
## ```

include Foo.Bar

open MyModule as M

type alias Dict(k, v) = Map(k, v)

foreign sqrt(x : Float) -> Float = "c_sqrt"

let identity(x : a) -> a = x

let add(x : Int, y : Int) -> Int = x + y
```

```sh
midnite build /tmp/test.mn
```

```
=== Tokens ===
Token(## some doc comment) (.comment = Doc) (0,19) (1,1)
Token(## ```) (.comment = Doc) (20,26) (2,1)
Token(## test) (.comment = Doc) (27,34) (3,1)
Token(## ```) (.comment = Doc) (35,41) (4,1)
Token(include) (.keyword = Include) (43,50) (6,1)
Token(Foo) (.identifier = Upper) (51,54) (6,9)
Token(.) (.delimiter = Dot) (54,55) (6,12)
Token(Bar) (.identifier = Upper) (55,58) (6,13)
Token(open) (.keyword = Open) (60,64) (8,1)
Token(MyModule) (.identifier = Upper) (65,73) (8,6)
Token(as) (.keyword = As) (74,76) (8,15)
Token(M) (.identifier = Upper) (77,78) (8,18)
Token(type) (.keyword = Type) (80,84) (10,1)
Token(alias) (.keyword = Alias) (85,90) (10,6)
Token(Dict) (.identifier = Upper) (91,95) (10,12)
Token(() (.delimiter = LeftParen) (95,96) (10,16)
Token(k) (.identifier = Lower) (96,97) (10,17)
Token(,) (.delimiter = Comma) (97,98) (10,18)
Token(v) (.identifier = Lower) (99,100) (10,20)
Token()) (.delimiter = RightParen) (100,101) (10,21)
Token(=) (.operator = Equal) (102,103) (10,23)
Token(Map) (.identifier = Upper) (104,107) (10,25)
Token(() (.delimiter = LeftParen) (107,108) (10,28)
Token(k) (.identifier = Lower) (108,109) (10,29)
Token(,) (.delimiter = Comma) (109,110) (10,30)
Token(v) (.identifier = Lower) (111,112) (10,32)
Token()) (.delimiter = RightParen) (112,113) (10,33)
Token(foreign) (.keyword = Foreign) (115,122) (12,1)
Token(sqrt) (.identifier = Lower) (123,127) (12,9)
Token(() (.delimiter = LeftParen) (127,128) (12,13)
Token(x) (.identifier = Lower) (128,129) (12,14)
Token(:) (.delimiter = Colon) (130,131) (12,16)
Token(Float) (.identifier = Upper) (132,137) (12,18)
Token()) (.delimiter = RightParen) (137,138) (12,23)
Token(->) (.symbol = ArrowRight) (139,141) (12,25)
Token(Float) (.identifier = Upper) (142,147) (12,28)
Token(=) (.operator = Equal) (148,149) (12,34)
Token("c_sqrt") (.literal = String) (150,158) (12,36)
Token(let) (.keyword = Let) (160,163) (14,1)
Token(identity) (.identifier = Lower) (164,172) (14,5)
Token(() (.delimiter = LeftParen) (172,173) (14,13)
Token(x) (.identifier = Lower) (173,174) (14,14)
Token(:) (.delimiter = Colon) (175,176) (14,16)
Token(a) (.identifier = Lower) (177,178) (14,18)
Token()) (.delimiter = RightParen) (178,179) (14,19)
Token(->) (.symbol = ArrowRight) (180,182) (14,21)
Token(a) (.identifier = Lower) (183,184) (14,24)
Token(=) (.operator = Equal) (185,186) (14,26)
Token(x) (.identifier = Lower) (187,188) (14,28)
Token(let) (.keyword = Let) (190,193) (16,1)
Token(add) (.identifier = Lower) (194,197) (16,5)
Token(() (.delimiter = LeftParen) (197,198) (16,8)
Token(x) (.identifier = Lower) (198,199) (16,9)
Token(:) (.delimiter = Colon) (200,201) (16,11)
Token(Int) (.identifier = Upper) (202,205) (16,13)
Token(,) (.delimiter = Comma) (205,206) (16,16)
Token(y) (.identifier = Lower) (207,208) (16,18)
Token(:) (.delimiter = Colon) (209,210) (16,20)
Token(Int) (.identifier = Upper) (211,214) (16,22)
Token()) (.delimiter = RightParen) (214,215) (16,25)
Token(->) (.symbol = ArrowRight) (216,218) (16,27)
Token(Int) (.identifier = Upper) (219,222) (16,30)
Token(=) (.operator = Equal) (223,224) (16,34)
Token(x) (.identifier = Lower) (225,226) (16,36)
Token(+) (.operator = IntAdd) (227,228) (16,38)
Token(y) (.identifier = Lower) (229,230) (16,40)

=== AST ===
Program {
    DocComment(some doc comment)
    DocComment(```)
    DocComment(test)
    DocComment(```)
    Include {
        path: Foo.Bar
    }
    ImportSpec {
        kind: Alias
        path: MyModule
        alias: M
    }
    TypeAlias {
        name: Dict
        type_params: [k, v]
        value: TypeApplication {
            constructor: UpperIdent(Map)
            args: [
                LowerIdent(k)
                LowerIdent(v)
            ]
        }
    }
    ForeignFunctionDecl {
        name: sqrt
        parameters: [
            Parameter {
                name: x
                type: UpperIdent(Float)
            }
        ]
        return_type: UpperIdent(Float)
        external_name: c_sqrt
    }
    FunctionDecl {
        name: identity
        parameters: [
            Parameter {
                name: x
                type: LowerIdent(a)
            }
        ]
        return_type: LowerIdent(a)
        value: LowerIdent(x)
    }
    FunctionDecl {
        name: add
        parameters: [
            Parameter {
                name: x
                type: UpperIdent(Int)
            }
            Parameter {
                name: y
                type: UpperIdent(Int)
            }
        ]
        return_type: UpperIdent(Int)
        value: ArithmeticExpr {
            operator: operator (+)
            left: LowerIdent(x)
            right: LowerIdent(y)
        }
    }
}
```