### PR TITLE
Use reference counters in AST

### DIFF
--- a/compiler/frontend/ast.zig
+++ b/compiler/frontend/ast.zig
@@ -2087,7 +2087,7 @@ test "[IntLiteralNode]" {
     const value = 42;
 
     // Action
-    const int_node = .{
+    const int_node = IntLiteralNode{
         .value = value,
         .token = .{
             .kind = .{ .literal = .Int },
@@ -2132,7 +2132,7 @@ test "[FloatLiteralNode]" {
     const value = 42.0;
 
     // Action
-    const float_node = .{
+    const float_node = FloatLiteralNode{
         .value = value,
         .token = .{
             .kind = .{ .literal = .Float },
@@ -2177,7 +2177,7 @@ test "[CharLiteralNode]" {
     const value = 'a';
 
     // Action
-    const char_node = .{
+    const char_node = CharLiteralNode{
         .value = value,
         .token = .{
             .kind = .{ .literal = .Char },
@@ -2431,6 +2431,8 @@ test "[ListNode]" {
         },
     };
 
+    try elements.append(elem1);
+
     const elem2 = try allocator.create(Node);
     elem2.* = .{
         .int_literal = .{
@@ -2447,7 +2449,6 @@ test "[ListNode]" {
         },
     };
 
-    try elements.append(elem1);
     try elements.append(elem2);
 
     const list_node = try allocator.create(ListNode);
@@ -3666,6 +3667,8 @@ test "[FunctionSignatureNode]" {
     const allocator = gpa.allocator();
 
     // Action
+    var parameter_types = std.ArrayList(*Node).init(allocator);
+
     const int_type1 = try allocator.create(UpperIdentifierNode);
     int_type1.* = .{
         .identifier = try allocator.dupe(u8, "Int"),
@@ -3682,6 +3685,8 @@ test "[FunctionSignatureNode]" {
 
     const int_node1 = try allocator.create(Node);
     int_node1.* = .{ .upper_identifier = int_type1 };
+
+    try parameter_types.append(int_node1);
 
     const int_type2 = try allocator.create(UpperIdentifierNode);
     int_type2.* = .{
@@ -3700,6 +3705,8 @@ test "[FunctionSignatureNode]" {
     const int_node2 = try allocator.create(Node);
     int_node2.* = .{ .upper_identifier = int_type2 };
 
+    try parameter_types.append(int_node2);
+
     const int_type3 = try allocator.create(UpperIdentifierNode);
     int_type3.* = .{
         .identifier = try allocator.dupe(u8, "Int"),
@@ -3716,10 +3723,6 @@ test "[FunctionSignatureNode]" {
 
     const return_type_node = try allocator.create(Node);
     return_type_node.* = .{ .upper_identifier = int_type3 };
-
-    var parameter_types = std.ArrayList(*Node).init(allocator);
-    try parameter_types.append(int_node1);
-    try parameter_types.append(int_node2);
 
     const func_signature = try allocator.create(FunctionSignatureNode);
 

--- a/compiler/frontend/ast.zig
+++ b/compiler/frontend/ast.zig
@@ -17,10 +17,23 @@ pub const CommentNode = struct {
     /// The token representing the start of this declaration.
     token: lexer.Token,
 
-    pub fn deinit(self: *CommentNode, allocator: std.mem.Allocator) void {
-        allocator.free(self.text);
+    /// Reference count for this node, defaults to 1 on creation.
+    ref_count: usize = 1,
 
-        allocator.destroy(self);
+    /// Increments the reference count when a new reference is created.
+    pub fn retain(self: *CommentNode) void {
+        self.ref_count += 1;
+    }
+
+    /// Decrements the reference count and cleans up if it reaches zero.
+    pub fn release(self: *CommentNode, allocator: std.mem.Allocator) void {
+        self.ref_count -= 1;
+
+        if (self.ref_count == 0) {
+            allocator.free(self.text);
+
+            allocator.destroy(self);
+        }
     }
 };
 
@@ -35,10 +48,23 @@ pub const DocCommentNode = struct {
     /// The token representing the start of this declaration.
     token: lexer.Token,
 
-    pub fn deinit(self: *DocCommentNode, allocator: std.mem.Allocator) void {
-        allocator.free(self.text);
+    /// Reference count for this node, defaults to 1 on creation.
+    ref_count: usize = 1,
 
-        allocator.destroy(self);
+    /// Increments the reference count when a new reference is created.
+    pub fn retain(self: *DocCommentNode) void {
+        self.ref_count += 1;
+    }
+
+    /// Decrements the reference count and cleans up if it reaches zero.
+    pub fn release(self: *DocCommentNode, allocator: std.mem.Allocator) void {
+        self.ref_count -= 1;
+
+        if (self.ref_count == 0) {
+            allocator.free(self.text);
+
+            allocator.destroy(self);
+        }
     }
 };
 
@@ -96,10 +122,23 @@ pub const StrLiteralNode = struct {
     /// The token representing the start of this declaration.
     token: lexer.Token,
 
-    pub fn deinit(self: *StrLiteralNode, allocator: std.mem.Allocator) void {
-        allocator.free(self.value);
+    /// Reference count for this node, defaults to 1 on creation.
+    ref_count: usize = 1,
 
-        allocator.destroy(self);
+    /// Increments the reference count when a new reference is created.
+    pub fn retain(self: *StrLiteralNode) void {
+        self.ref_count += 1;
+    }
+
+    /// Decrements the reference count and cleans up if it reaches zero.
+    pub fn release(self: *StrLiteralNode, allocator: std.mem.Allocator) void {
+        self.ref_count -= 1;
+
+        if (self.ref_count == 0) {
+            allocator.free(self.value);
+
+            allocator.destroy(self);
+        }
     }
 };
 
@@ -117,10 +156,23 @@ pub const MultilineStrLiteralNode = struct {
     /// The token representing the start of this declaration.
     token: lexer.Token,
 
-    pub fn deinit(self: *MultilineStrLiteralNode, allocator: std.mem.Allocator) void {
-        allocator.free(self.value);
+    /// Reference count for this node, defaults to 1 on creation.
+    ref_count: usize = 1,
 
-        allocator.destroy(self);
+    /// Increments the reference count when a new reference is created.
+    pub fn retain(self: *MultilineStrLiteralNode) void {
+        self.ref_count += 1;
+    }
+
+    /// Decrements the reference count and cleans up if it reaches zero.
+    pub fn release(self: *MultilineStrLiteralNode, allocator: std.mem.Allocator) void {
+        self.ref_count -= 1;
+
+        if (self.ref_count == 0) {
+            allocator.free(self.value);
+
+            allocator.destroy(self);
+        }
     }
 };
 
@@ -136,9 +188,23 @@ pub const LowerIdentifierNode = struct {
     /// The token representing the start of this declaration.
     token: lexer.Token,
 
-    pub fn deinit(self: *LowerIdentifierNode, allocator: std.mem.Allocator) void {
-        allocator.free(self.identifier);
-        allocator.destroy(self);
+    /// Reference count for this node, defaults to 1 on creation.
+    ref_count: usize = 1,
+
+    /// Increments the reference count when a new reference is created.
+    pub fn retain(self: *LowerIdentifierNode) void {
+        self.ref_count += 1;
+    }
+
+    /// Decrements the reference count and cleans up if it reaches zero.
+    pub fn release(self: *LowerIdentifierNode, allocator: std.mem.Allocator) void {
+        self.ref_count -= 1;
+
+        if (self.ref_count == 0) {
+            allocator.free(self.identifier);
+
+            allocator.destroy(self);
+        }
     }
 };
 
@@ -150,9 +216,23 @@ pub const UpperIdentifierNode = struct {
     /// The token representing the start of this declaration.
     token: lexer.Token,
 
-    pub fn deinit(self: *UpperIdentifierNode, allocator: std.mem.Allocator) void {
-        allocator.free(self.identifier);
-        allocator.destroy(self);
+    /// Reference count for this node, defaults to 1 on creation.
+    ref_count: usize = 1,
+
+    /// Increments the reference count when a new reference is created.
+    pub fn retain(self: *UpperIdentifierNode) void {
+        self.ref_count += 1;
+    }
+
+    /// Decrements the reference count and cleans up if it reaches zero.
+    pub fn release(self: *UpperIdentifierNode, allocator: std.mem.Allocator) void {
+        self.ref_count -= 1;
+
+        if (self.ref_count == 0) {
+            allocator.free(self.identifier);
+
+            allocator.destroy(self);
+        }
     }
 };
 
@@ -173,15 +253,27 @@ pub const ListNode = struct {
     /// The token representing the start of this declaration.
     token: lexer.Token,
 
-    pub fn deinit(self: *ListNode, allocator: std.mem.Allocator) void {
-        for (self.elements.items) |element| {
-            element.deinit(allocator);
-            allocator.destroy(element);
+    /// Reference count for this node, defaults to 1 on creation.
+    ref_count: usize = 1,
+
+    /// Increments the reference count when a new reference is created.
+    pub fn retain(self: *ListNode) void {
+        self.ref_count += 1;
+    }
+
+    /// Decrements the reference count and cleans up if it reaches zero.
+    pub fn release(self: *ListNode, allocator: std.mem.Allocator) void {
+        self.ref_count -= 1;
+
+        if (self.ref_count == 0) {
+            for (self.elements.items) |element| {
+                element.release(allocator);
+                allocator.destroy(element);
+            }
+            self.elements.deinit();
+
+            allocator.destroy(self);
         }
-
-        self.elements.deinit();
-
-        allocator.destroy(self);
     }
 };
 
@@ -199,15 +291,27 @@ pub const TupleNode = struct {
     /// The token representing the start of this tuple.
     token: lexer.Token,
 
-    pub fn deinit(self: *TupleNode, allocator: std.mem.Allocator) void {
-        for (self.elements.items) |element| {
-            element.deinit(allocator);
-            allocator.destroy(element);
+    /// Reference count for this node, defaults to 1 on creation.
+    ref_count: usize = 1,
+
+    /// Increments the reference count when a new reference is created.
+    pub fn retain(self: *TupleNode) void {
+        self.ref_count += 1;
+    }
+
+    /// Decrements the reference count and cleans up if it reaches zero.
+    pub fn release(self: *TupleNode, allocator: std.mem.Allocator) void {
+        self.ref_count -= 1;
+
+        if (self.ref_count == 0) {
+            for (self.elements.items) |element| {
+                element.release(allocator);
+                allocator.destroy(element);
+            }
+            self.elements.deinit();
+
+            allocator.destroy(self);
         }
-
-        self.elements.deinit();
-
-        allocator.destroy(self);
     }
 };
 
@@ -226,11 +330,24 @@ pub const UnaryExprNode = struct {
     /// The token representing the operator.
     operator: lexer.Token,
 
-    pub fn deinit(self: *UnaryExprNode, allocator: std.mem.Allocator) void {
-        self.operand.deinit(allocator);
-        allocator.destroy(self.operand);
+    /// Reference count for this node, defaults to 1 on creation.
+    ref_count: usize = 1,
 
-        allocator.destroy(self);
+    /// Increments the reference count when a new reference is created.
+    pub fn retain(self: *UnaryExprNode) void {
+        self.ref_count += 1;
+    }
+
+    /// Decrements the reference count and cleans up if it reaches zero.
+    pub fn release(self: *UnaryExprNode, allocator: std.mem.Allocator) void {
+        self.ref_count -= 1;
+
+        if (self.ref_count == 0) {
+            self.operand.release(allocator);
+            allocator.destroy(self.operand);
+
+            allocator.destroy(self);
+        }
     }
 };
 
@@ -244,14 +361,27 @@ pub const BinaryOp = struct {
     /// The token representing the operator.
     operator: lexer.Token,
 
-    pub fn deinit(self: *BinaryOp, allocator: std.mem.Allocator) void {
-        self.left.deinit(allocator);
-        allocator.destroy(self.left);
+    /// Reference count for this node, defaults to 1 on creation.
+    ref_count: usize = 1,
 
-        self.right.deinit(allocator);
-        allocator.destroy(self.right);
+    /// Increments the reference count when a new reference is created.
+    pub fn retain(self: *BinaryOp) void {
+        self.ref_count += 1;
+    }
 
-        allocator.destroy(self);
+    /// Decrements the reference count and cleans up if it reaches zero.
+    pub fn release(self: *BinaryOp, allocator: std.mem.Allocator) void {
+        self.ref_count -= 1;
+
+        if (self.ref_count == 0) {
+            self.left.release(allocator);
+            allocator.destroy(self.left);
+
+            self.right.release(allocator);
+            allocator.destroy(self.right);
+
+            allocator.destroy(self);
+        }
     }
 };
 
@@ -289,91 +419,104 @@ pub const ComparisonExprNode = BinaryOp;
 /// - `Some(x)`
 /// - `head :: tail`
 /// - `[]`
-pub const PatternNode = union(enum) {
-    wildcard: struct {
-        token: lexer.Token,
-    },
-    int_literal: IntLiteralNode,
-    float_literal: FloatLiteralNode,
-    char_literal: CharLiteralNode,
-    string_literal: *StrLiteralNode,
-    list: struct {
-        /// Array of pattern nodes for matching against list elements.
-        patterns: std.ArrayList(*PatternNode),
+pub const PatternNode = struct {
+    inner: Inner,
 
-        /// The token representing the start of the list pattern
-        token: lexer.Token,
-    },
-    variable: struct {
-        /// The name of the variable to bind.
-        name: *LowerIdentifierNode,
+    /// Reference count for this node, defaults to 1 on creation.
+    ref_count: usize = 1,
 
-        /// The token representing the variable.
-        token: lexer.Token,
-    },
-    constructor: struct {
-        /// The name of the constructor.
-        name: []const u8,
+    pub const Inner = union(enum(u8)) {
+        wildcard: struct {
+            token: lexer.Token,
+        },
+        int_literal: IntLiteralNode,
+        float_literal: FloatLiteralNode,
+        char_literal: CharLiteralNode,
+        string_literal: *StrLiteralNode,
+        list: struct {
+            /// Array of pattern nodes for matching against list elements.
+            patterns: std.ArrayList(*PatternNode),
 
-        /// Array of patterns for matching constructor arguments.
-        parameters: std.ArrayList(*PatternNode),
+            /// The token representing the start of the list pattern
+            token: lexer.Token,
+        },
+        variable: struct {
+            /// The name of the variable to bind.
+            name: *LowerIdentifierNode,
 
-        /// The token representing the constructor.
-        token: lexer.Token,
-    },
-    empty_list: struct {
-        /// The token representing the empty list pattern.
-        token: lexer.Token,
-    },
-    cons: struct {
-        /// Pattern for matching the head element.
-        head: *PatternNode,
+            /// The token representing the variable.
+            token: lexer.Token,
+        },
+        constructor: struct {
+            /// The name of the constructor.
+            name: []const u8,
 
-        /// Pattern for matching the tail list.
-        tail: *PatternNode,
+            /// Array of patterns for matching constructor arguments.
+            parameters: std.ArrayList(*PatternNode),
 
-        /// The token representing the cons pattern.
-        token: lexer.Token,
-    },
+            /// The token representing the constructor.
+            token: lexer.Token,
+        },
+        empty_list: struct {
+            /// The token representing the empty list pattern.
+            token: lexer.Token,
+        },
+        cons: struct {
+            /// Pattern for matching the head element.
+            head: *PatternNode,
 
-    pub fn deinit(self: *PatternNode, allocator: std.mem.Allocator) void {
-        switch (self.*) {
-            .wildcard,
-            .int_literal,
-            .float_literal,
-            .char_literal,
-            .empty_list,
-            => {},
-            .string_literal => |lit| {
-                lit.deinit(allocator);
-            },
-            .list => |list| {
-                for (list.patterns.items) |pattern| {
-                    pattern.deinit(allocator);
-                }
+            /// Pattern for matching the tail list.
+            tail: *PatternNode,
 
-                list.patterns.deinit();
-            },
-            .variable => |variable| {
-                variable.name.deinit(allocator);
-            },
-            .constructor => |constructor| {
-                allocator.free(constructor.name);
+            /// The token representing the cons pattern.
+            token: lexer.Token,
+        },
+    };
 
-                for (constructor.parameters.items) |param| {
-                    param.deinit(allocator);
-                    allocator.destroy(param);
-                }
+    /// Increments the reference count when a new reference is created.
+    pub fn retain(self: *PatternNode) void {
+        self.ref_count += 1;
+    }
 
-                constructor.parameters.deinit();
-            },
-            .cons => |cons| {
-                cons.head.deinit(allocator);
-                allocator.destroy(cons.head);
+    /// Decrements the reference count and cleans up if it reaches zero.
+    pub fn release(self: *PatternNode, allocator: std.mem.Allocator) void {
+        self.ref_count -= 1;
 
-                cons.tail.deinit(allocator);
-                allocator.destroy(cons.tail);
-            },
+        if (self.ref_count == 0) {
+            switch (self.inner) {
+                .wildcard => {},
+                .int_literal => {},
+                .float_literal => {},
+                .char_literal => {},
+                .string_literal => |lit| {
+                    lit.release(allocator);
+                },
+                .list => |list| {
+                    for (list.patterns.items) |pattern| {
+                        pattern.release(allocator);
+                    }
+                    list.patterns.deinit();
+                },
+                .variable => |variable| {
+                    variable.name.release(allocator);
+                },
+                .constructor => |constructor| {
+                    allocator.free(constructor.name);
+
+                    for (constructor.parameters.items) |param| {
+                        param.release(allocator);
+                    }
+                    constructor.parameters.deinit();
+                },
+                .empty_list => {},
+                .cons => |cons| {
+                    cons.head.release(allocator);
+
+                    cons.tail.release(allocator);
+                },
+            }
+
+            allocator.destroy(self);
         }
     }
 };
@@ -391,9 +534,24 @@ pub const GuardNode = struct {
     /// The token representing the start of this declaration.
     token: lexer.Token,
 
-    pub fn deinit(self: *GuardNode, allocator: std.mem.Allocator) void {
-        self.condition.deinit(allocator);
-        allocator.destroy(self.condition);
+    /// Reference count for this node, defaults to 1 on creation.
+    ref_count: usize = 1,
+
+    /// Increments the reference count when a new reference is created.
+    pub fn retain(self: *GuardNode) void {
+        self.ref_count += 1;
+    }
+
+    /// Decrements the reference count and cleans up if it reaches zero.
+    pub fn release(self: *GuardNode, allocator: std.mem.Allocator) void {
+        self.ref_count -= 1;
+
+        if (self.ref_count == 0) {
+            self.condition.release(allocator);
+            allocator.destroy(self.condition);
+
+            allocator.destroy(self);
+        }
     }
 };
 
@@ -403,7 +561,7 @@ pub const GuardNode = struct {
 /// Examples:
 /// - `0 => "zero"`
 /// - `x :: xs when length(xs) > 0 => count + 1`
-pub const MatchCase = struct {
+pub const MatchCaseNode = struct {
     /// The pattern to match against.
     pattern: *PatternNode,
 
@@ -416,16 +574,29 @@ pub const MatchCase = struct {
     /// The token representing the start of this declaration.
     token: lexer.Token,
 
-    pub fn deinit(self: *MatchCase, allocator: std.mem.Allocator) void {
-        self.pattern.deinit(allocator);
-        allocator.destroy(self.pattern);
+    /// Reference count for this node, defaults to 1 on creation.
+    ref_count: usize = 1,
 
-        self.expression.deinit(allocator);
-        allocator.destroy(self.expression);
+    /// Increments the reference count when a new reference is created.
+    pub fn retain(self: *MatchCaseNode) void {
+        self.ref_count += 1;
+    }
 
-        if (self.guard) |guard| {
-            guard.deinit(allocator);
-            allocator.destroy(guard);
+    /// Decrements the reference count and cleans up if it reaches zero.
+    pub fn release(self: *MatchCaseNode, allocator: std.mem.Allocator) void {
+        self.ref_count -= 1;
+
+        if (self.ref_count == 0) {
+            self.pattern.release(allocator);
+
+            self.expression.release(allocator);
+            allocator.destroy(self.expression);
+
+            if (self.guard) |guard| {
+                guard.release(allocator);
+            }
+
+            allocator.destroy(self);
         }
     }
 };
@@ -442,23 +613,34 @@ pub const MatchExprNode = struct {
     subject: *Node,
 
     /// Array of match cases to test against.
-    cases: std.ArrayList(*MatchCase),
+    cases: std.ArrayList(*MatchCaseNode),
 
     /// The token representing the start of this declaration.
     token: lexer.Token,
 
-    pub fn deinit(self: *MatchExprNode, allocator: std.mem.Allocator) void {
-        self.subject.deinit(allocator);
-        allocator.destroy(self.subject);
+    /// Reference count for this node, defaults to 1 on creation.
+    ref_count: usize = 1,
 
-        for (self.cases.items) |case| {
-            case.deinit(allocator);
-            allocator.destroy(case);
+    /// Increments the reference count when a new reference is created.
+    pub fn retain(self: *MatchExprNode) void {
+        self.ref_count += 1;
+    }
+
+    /// Decrements the reference count and cleans up if it reaches zero.
+    pub fn release(self: *MatchExprNode, allocator: std.mem.Allocator) void {
+        self.ref_count -= 1;
+
+        if (self.ref_count == 0) {
+            self.subject.release(allocator);
+            allocator.destroy(self.subject);
+
+            for (self.cases.items) |case| {
+                case.release(allocator);
+            }
+            self.cases.deinit();
+
+            allocator.destroy(self);
         }
-
-        self.cases.deinit();
-
-        allocator.destroy(self);
     }
 };
 
@@ -482,16 +664,30 @@ pub const FunctionSignatureNode = struct {
     /// The token representing the start of this declaration.
     token: lexer.Token,
 
-    pub fn deinit(self: *FunctionSignatureNode, allocator: std.mem.Allocator) void {
-        for (self.parameter_types.items) |param_type| {
-            param_type.deinit(allocator);
-            allocator.destroy(param_type);
+    /// Reference count for this node, defaults to 1 on creation.
+    ref_count: usize = 1,
+
+    /// Increments the reference count when a new reference is created.
+    pub fn retain(self: *FunctionSignatureNode) void {
+        self.ref_count += 1;
+    }
+
+    /// Decrements the reference count and cleans up if it reaches zero.
+    pub fn release(self: *FunctionSignatureNode, allocator: std.mem.Allocator) void {
+        self.ref_count -= 1;
+
+        if (self.ref_count == 0) {
+            for (self.parameter_types.items) |param_type| {
+                param_type.release(allocator);
+                allocator.destroy(param_type);
+            }
+            self.parameter_types.deinit();
+
+            self.return_type.release(allocator);
+            allocator.destroy(self.return_type);
+
+            allocator.destroy(self);
         }
-
-        self.parameter_types.deinit();
-
-        self.return_type.deinit(allocator);
-        allocator.destroy(self.return_type);
     }
 };
 
@@ -514,23 +710,34 @@ pub const LambdaExprNode = struct {
     /// The token representing the start of this declaration.
     token: lexer.Token,
 
-    pub fn deinit(self: *LambdaExprNode, allocator: std.mem.Allocator) void {
-        for (self.parameters.items) |param| {
-            param.deinit(allocator);
-            allocator.destroy(param);
+    /// Reference count for this node, defaults to 1 on creation.
+    ref_count: usize = 1,
+
+    /// Increments the reference count when a new reference is created.
+    pub fn retain(self: *LambdaExprNode) void {
+        self.ref_count += 1;
+    }
+
+    /// Decrements the reference count and cleans up if it reaches zero.
+    pub fn release(self: *LambdaExprNode, allocator: std.mem.Allocator) void {
+        self.ref_count -= 1;
+
+        if (self.ref_count == 0) {
+            for (self.parameters.items) |param| {
+                param.release(allocator);
+            }
+            self.parameters.deinit();
+
+            if (self.return_type) |rt| {
+                rt.release(allocator);
+                allocator.destroy(rt);
+            }
+
+            self.body.release(allocator);
+            allocator.destroy(self.body);
+
+            allocator.destroy(self);
         }
-
-        if (self.return_type) |rt| {
-            rt.deinit(allocator);
-            allocator.destroy(rt);
-        }
-
-        self.parameters.deinit();
-
-        self.body.deinit(allocator);
-        allocator.destroy(self.body);
-
-        allocator.destroy(self);
     }
 };
 
@@ -550,18 +757,30 @@ pub const FunctionCallNode = struct {
     /// The token representing the start of this application (usually the function's token).
     token: lexer.Token,
 
-    pub fn deinit(self: *FunctionCallNode, allocator: std.mem.Allocator) void {
-        self.function.deinit(allocator);
-        allocator.destroy(self.function);
+    /// Reference count for this node, defaults to 1 on creation.
+    ref_count: usize = 1,
 
-        for (self.arguments.items) |argument| {
-            argument.deinit(allocator);
-            allocator.destroy(argument);
+    /// Increments the reference count when a new reference is created.
+    pub fn retain(self: *FunctionCallNode) void {
+        self.ref_count += 1;
+    }
+
+    /// Decrements the reference count and cleans up if it reaches zero.
+    pub fn release(self: *FunctionCallNode, allocator: std.mem.Allocator) void {
+        self.ref_count -= 1;
+
+        if (self.ref_count == 0) {
+            self.function.release(allocator);
+            allocator.destroy(self.function);
+
+            for (self.arguments.items) |argument| {
+                argument.release(allocator);
+                allocator.destroy(argument);
+            }
+            self.arguments.deinit();
+
+            allocator.destroy(self);
         }
-
-        self.arguments.deinit();
-
-        allocator.destroy(self);
     }
 };
 
@@ -577,12 +796,27 @@ pub const ParamDeclNode = struct {
     /// The token representing this parameter declaration.
     token: lexer.Token,
 
-    pub fn deinit(self: *ParamDeclNode, allocator: std.mem.Allocator) void {
-        self.name.deinit(allocator);
+    /// Reference count for this node, defaults to 1 on creation.
+    ref_count: usize = 1,
 
-        if (self.type_annotation) |type_ann| {
-            type_ann.deinit(allocator);
-            allocator.destroy(type_ann);
+    /// Increments the reference count when a new reference is created.
+    pub fn retain(self: *ParamDeclNode) void {
+        self.ref_count += 1;
+    }
+
+    /// Decrements the reference count and cleans up if it reaches zero.
+    pub fn release(self: *ParamDeclNode, allocator: std.mem.Allocator) void {
+        self.ref_count -= 1;
+
+        if (self.ref_count == 0) {
+            self.name.release(allocator);
+
+            if (self.type_annotation) |ta| {
+                ta.release(allocator);
+                allocator.destroy(ta);
+            }
+
+            allocator.destroy(self);
         }
     }
 };
@@ -607,14 +841,27 @@ pub const ConsExprNode = struct {
     /// The token representing the cons operator.
     operator: lexer.Token,
 
-    pub fn deinit(self: *ConsExprNode, allocator: std.mem.Allocator) void {
-        self.head.deinit(allocator);
-        allocator.destroy(self.head);
+    /// Reference count for this node, defaults to 1 on creation.
+    ref_count: usize = 1,
 
-        self.tail.deinit(allocator);
-        allocator.destroy(self.tail);
+    /// Increments the reference count when a new reference is created.
+    pub fn retain(self: *ConsExprNode) void {
+        self.ref_count += 1;
+    }
 
-        allocator.destroy(self);
+    /// Decrements the reference count and cleans up if it reaches zero.
+    pub fn release(self: *ConsExprNode, allocator: std.mem.Allocator) void {
+        self.ref_count -= 1;
+
+        if (self.ref_count == 0) {
+            self.head.release(allocator);
+            allocator.destroy(self.head);
+
+            self.tail.release(allocator);
+            allocator.destroy(self.tail);
+
+            allocator.destroy(self);
+        }
     }
 };
 
@@ -648,14 +895,27 @@ pub const PipeExprNode = struct {
     /// The token representing the pipe operator.
     operator: lexer.Token,
 
-    pub fn deinit(self: *PipeExprNode, allocator: std.mem.Allocator) void {
-        self.value.deinit(allocator);
-        allocator.destroy(self.value);
+    /// Reference count for this node, defaults to 1 on creation.
+    ref_count: usize = 1,
 
-        self.func.deinit(allocator);
-        allocator.destroy(self.func);
+    /// Increments the reference count when a new reference is created.
+    pub fn retain(self: *PipeExprNode) void {
+        self.ref_count += 1;
+    }
 
-        allocator.destroy(self);
+    /// Decrements the reference count and cleans up if it reaches zero.
+    pub fn release(self: *PipeExprNode, allocator: std.mem.Allocator) void {
+        self.ref_count -= 1;
+
+        if (self.ref_count == 0) {
+            self.value.release(allocator);
+            allocator.destroy(self.value);
+
+            self.func.release(allocator);
+            allocator.destroy(self.func);
+
+            allocator.destroy(self);
+        }
     }
 };
 
@@ -684,17 +944,30 @@ pub const IfThenElseStmtNode = struct {
     /// The token representing the start of this declaration.
     token: lexer.Token,
 
-    pub fn deinit(self: *IfThenElseStmtNode, allocator: std.mem.Allocator) void {
-        self.condition.deinit(allocator);
-        allocator.destroy(self.condition);
+    /// Reference count for this node, defaults to 1 on creation.
+    ref_count: usize = 1,
 
-        self.then_branch.deinit(allocator);
-        allocator.destroy(self.then_branch);
+    /// Increments the reference count when a new reference is created.
+    pub fn retain(self: *IfThenElseStmtNode) void {
+        self.ref_count += 1;
+    }
 
-        self.else_branch.deinit(allocator);
-        allocator.destroy(self.else_branch);
+    /// Decrements the reference count and cleans up if it reaches zero.
+    pub fn release(self: *IfThenElseStmtNode, allocator: std.mem.Allocator) void {
+        self.ref_count -= 1;
 
-        allocator.destroy(self);
+        if (self.ref_count == 0) {
+            self.condition.release(allocator);
+            allocator.destroy(self.condition);
+
+            self.then_branch.release(allocator);
+            allocator.destroy(self.then_branch);
+
+            self.else_branch.release(allocator);
+            allocator.destroy(self.else_branch);
+
+            allocator.destroy(self);
+        }
     }
 };
 
@@ -732,17 +1005,29 @@ pub const TypeApplicationNode = struct {
     /// The token representing the type application.
     token: lexer.Token,
 
-    pub fn deinit(self: *TypeApplicationNode, allocator: std.mem.Allocator) void {
-        self.constructor.deinit(allocator);
+    /// Reference count for this node, defaults to 1 on creation.
+    ref_count: usize = 1,
 
-        for (self.args.items) |arg| {
-            arg.deinit(allocator);
-            allocator.destroy(arg);
+    /// Increments the reference count when a new reference is created.
+    pub fn retain(self: *TypeApplicationNode) void {
+        self.ref_count += 1;
+    }
+
+    /// Decrements the reference count and cleans up if it reaches zero.
+    pub fn release(self: *TypeApplicationNode, allocator: std.mem.Allocator) void {
+        self.ref_count -= 1;
+
+        if (self.ref_count == 0) {
+            self.constructor.release(allocator);
+
+            for (self.args.items) |arg| {
+                arg.release(allocator);
+                allocator.destroy(arg);
+            }
+            self.args.deinit();
+
+            allocator.destroy(self);
         }
-
-        self.args.deinit();
-
-        allocator.destroy(self);
     }
 };
 
@@ -768,19 +1053,31 @@ pub const TypeAliasNode = struct {
     /// The token representing the start of this declaration.
     token: lexer.Token,
 
-    pub fn deinit(self: *TypeAliasNode, allocator: std.mem.Allocator) void {
-        self.name.deinit(allocator);
+    /// Reference count for this node, defaults to 1 on creation.
+    ref_count: usize = 1,
 
-        for (self.type_params.items) |param| {
-            allocator.free(param);
+    /// Increments the reference count when a new reference is created.
+    pub fn retain(self: *TypeAliasNode) void {
+        self.ref_count += 1;
+    }
+
+    /// Decrements the reference count and cleans up if it reaches zero.
+    pub fn release(self: *TypeAliasNode, allocator: std.mem.Allocator) void {
+        self.ref_count -= 1;
+
+        if (self.ref_count == 0) {
+            self.name.release(allocator);
+
+            for (self.type_params.items) |param| {
+                allocator.free(param);
+            }
+            self.type_params.deinit();
+
+            self.value.release(allocator);
+            allocator.destroy(self.value);
+
+            allocator.destroy(self);
         }
-
-        self.type_params.deinit();
-
-        self.value.deinit(allocator);
-        allocator.destroy(self.value);
-
-        allocator.destroy(self);
     }
 };
 
@@ -802,16 +1099,29 @@ pub const VariantConstructorNode = struct {
     /// The token representing the start of this declaration.
     token: lexer.Token,
 
-    pub fn deinit(self: *VariantConstructorNode, allocator: std.mem.Allocator) void {
-        self.name.deinit(allocator);
-        allocator.destroy(self.name);
+    /// Reference count for this node, defaults to 1 on creation.
+    ref_count: usize = 1,
 
-        for (self.parameters.items) |param| {
-            param.deinit(allocator);
-            allocator.destroy(param);
+    /// Increments the reference count when a new reference is created.
+    pub fn retain(self: *VariantConstructorNode) void {
+        self.ref_count += 1;
+    }
+
+    /// Decrements the reference count and cleans up if it reaches zero.
+    pub fn release(self: *VariantConstructorNode, allocator: std.mem.Allocator) void {
+        self.ref_count -= 1;
+
+        if (self.ref_count == 0) {
+            self.name.release(allocator);
+
+            for (self.parameters.items) |param| {
+                param.release(allocator);
+                allocator.destroy(param);
+            }
+            self.parameters.deinit();
+
+            allocator.destroy(self);
         }
-
-        self.parameters.deinit();
     }
 };
 
@@ -837,24 +1147,33 @@ pub const VariantTypeNode = struct {
     /// The token representing the start of this declaration.
     token: lexer.Token,
 
-    pub fn deinit(self: *VariantTypeNode, allocator: std.mem.Allocator) void {
-        self.name.deinit(allocator);
-        allocator.destroy(self.name);
+    /// Reference count for this node, defaults to 1 on creation.
+    ref_count: usize = 1,
 
-        for (self.type_params.items) |param| {
-            allocator.free(param);
+    /// Increments the reference count when a new reference is created.
+    pub fn retain(self: *VariantTypeNode) void {
+        self.ref_count += 1;
+    }
+
+    /// Decrements the reference count and cleans up if it reaches zero.
+    pub fn release(self: *VariantTypeNode, allocator: std.mem.Allocator) void {
+        self.ref_count -= 1;
+
+        if (self.ref_count == 0) {
+            self.name.release(allocator);
+
+            for (self.type_params.items) |param| {
+                allocator.free(param);
+            }
+            self.type_params.deinit();
+
+            for (self.constructors.items) |constructor| {
+                constructor.release(allocator);
+            }
+            self.constructors.deinit();
+
+            allocator.destroy(self);
         }
-
-        self.type_params.deinit();
-
-        for (self.constructors.items) |constructor| {
-            constructor.deinit(allocator);
-            allocator.destroy(constructor);
-        }
-
-        self.constructors.deinit();
-
-        allocator.destroy(self);
     }
 };
 
@@ -869,11 +1188,26 @@ pub const RecordFieldNode = struct {
     /// The token representing this field declaration.
     token: lexer.Token,
 
-    pub fn deinit(self: *RecordFieldNode, allocator: std.mem.Allocator) void {
-        self.name.deinit(allocator);
+    /// Reference count for this node, defaults to 1 on creation.
+    ref_count: usize = 1,
 
-        self.type.deinit(allocator);
-        allocator.destroy(self.type);
+    /// Increments the reference count when a new reference is created.
+    pub fn retain(self: *RecordFieldNode) void {
+        self.ref_count += 1;
+    }
+
+    /// Decrements the reference count and cleans up if it reaches zero.
+    pub fn release(self: *RecordFieldNode, allocator: std.mem.Allocator) void {
+        self.ref_count -= 1;
+
+        if (self.ref_count == 0) {
+            self.name.release(allocator);
+
+            self.type.release(allocator);
+            allocator.destroy(self.type);
+
+            allocator.destroy(self);
+        }
     }
 };
 
@@ -895,23 +1229,33 @@ pub const RecordTypeNode = struct {
     /// The token representing the start of this declaration.
     token: lexer.Token,
 
-    pub fn deinit(self: *RecordTypeNode, allocator: std.mem.Allocator) void {
-        self.name.deinit(allocator);
+    /// Reference count for this node, defaults to 1 on creation.
+    ref_count: usize = 1,
 
-        for (self.type_params.items) |param| {
-            allocator.free(param);
+    /// Increments the reference count when a new reference is created.
+    pub fn retain(self: *RecordTypeNode) void {
+        self.ref_count += 1;
+    }
+
+    /// Decrements the reference count and cleans up if it reaches zero.
+    pub fn release(self: *RecordTypeNode, allocator: std.mem.Allocator) void {
+        self.ref_count -= 1;
+
+        if (self.ref_count == 0) {
+            self.name.release(allocator);
+
+            for (self.type_params.items) |param| {
+                allocator.free(param);
+            }
+            self.type_params.deinit();
+
+            for (self.fields.items) |field| {
+                field.release(allocator);
+            }
+            self.fields.deinit();
+
+            allocator.destroy(self);
         }
-
-        self.type_params.deinit();
-
-        for (self.fields.items) |field| {
-            field.deinit(allocator);
-            allocator.destroy(field);
-        }
-
-        self.fields.deinit();
-
-        allocator.destroy(self);
     }
 };
 
@@ -932,12 +1276,26 @@ pub const ModulePathNode = struct {
     /// The token representing the start of this declaration.
     token: lexer.Token,
 
-    pub fn deinit(self: *ModulePathNode, allocator: std.mem.Allocator) void {
-        for (self.segments.items) |segment| {
-            segment.deinit(allocator);
-        }
+    /// Reference count for this node, defaults to 1 on creation.
+    ref_count: usize = 1,
 
-        self.segments.deinit();
+    /// Increments the reference count when a new reference is created.
+    pub fn retain(self: *ModulePathNode) void {
+        self.ref_count += 1;
+    }
+
+    /// Decrements the reference count and cleans up if it reaches zero.
+    pub fn release(self: *ModulePathNode, allocator: std.mem.Allocator) void {
+        self.ref_count -= 1;
+
+        if (self.ref_count == 0) {
+            for (self.segments.items) |segment| {
+                segment.release(allocator);
+            }
+            self.segments.deinit();
+
+            allocator.destroy(self);
+        }
     }
 };
 
@@ -951,8 +1309,23 @@ pub const ExportItem = struct {
     /// The token representing the start of this declaration.
     token: lexer.Token,
 
-    pub fn deinit(self: ExportItem, allocator: std.mem.Allocator) void {
-        allocator.free(self.name);
+    /// Reference count for this node, defaults to 1 on creation.
+    ref_count: usize = 1,
+
+    /// Increments the reference count when a new reference is created.
+    pub fn retain(self: *ExportItem) void {
+        self.ref_count += 1;
+    }
+
+    /// Decrements the reference count and cleans up if it reaches zero.
+    pub fn release(self: *ExportItem, allocator: std.mem.Allocator) void {
+        self.ref_count -= 1;
+
+        if (self.ref_count == 0) {
+            allocator.free(self.name);
+
+            allocator.destroy(self);
+        }
     }
 };
 
@@ -967,87 +1340,120 @@ pub const ExportSpecNode = struct {
     exposing_all: bool,
 
     /// Optional array of specific items being exposed.
-    items: ?std.ArrayList(ExportItem),
+    items: ?std.ArrayList(*ExportItem),
 
     /// The token representing the start of this declaration.
     token: lexer.Token,
 
-    pub fn deinit(self: *ExportSpecNode, allocator: std.mem.Allocator) void {
-        if (self.items) |*items| {
-            for (items.items) |item| {
-                item.deinit(allocator);
+    /// Reference count for this node, defaults to 1 on creation.
+    ref_count: usize = 1,
+
+    /// Increments the reference count when a new reference is created.
+    pub fn retain(self: *ExportSpecNode) void {
+        self.ref_count += 1;
+    }
+
+    /// Decrements the reference count and cleans up if it reaches zero.
+    pub fn release(self: *ExportSpecNode, allocator: std.mem.Allocator) void {
+        self.ref_count -= 1;
+
+        if (self.ref_count == 0) {
+            if (self.items) |*items| {
+                for (items.items) |item| {
+                    item.release(allocator);
+                }
+                items.deinit();
             }
 
-            items.deinit();
+            allocator.destroy(self);
         }
     }
 };
 
 /// Items that can be imported from a module, potentially with aliases.
 /// These represent what appears in the parentheses after `using` or `hiding`.
-pub const ImportItem = union(enum) {
-    /// Import a function, optionally with an alias.
-    ///
-    /// Examples:
-    /// - `map as list_map` or just `map`
-    function: struct {
-        /// The original name of the function in the module.
-        name: []const u8,
+pub const ImportItem = struct {
+    inner: Inner,
 
-        /// Optional alias to use in the importing module.
-        alias: ?[]const u8,
-    },
+    /// Reference count for this node, defaults to 1 on creation.
+    ref_count: usize = 1,
 
-    /// Import an operator (like >>=).
-    ///
-    /// Examples:
-    /// - `(>>=)` or `(>>=) as bind`
-    operator: struct {
-        /// The operator symbol.
-        symbol: []const u8,
+    pub const Inner = union(enum(u8)) {
+        /// Import a function, optionally with an alias.
+        ///
+        /// Examples:
+        /// - `map as list_map` or just `map`
+        function: struct {
+            /// The original name of the function in the module.
+            name: []const u8,
 
-        /// Optional alias to use in the importing module.
-        alias: ?[]const u8,
-    },
+            /// Optional alias to use in the importing module.
+            alias: ?[]const u8,
+        },
 
-    /// Import a type, optionally exposing its constructors and/or with an alias.
-    ///
-    /// Examples:
-    /// - `Maybe(..)` or `Maybe(..) as Optional`
-    type: struct {
-        /// The name of the type.
-        name: []const u8,
+        /// Import an operator (like >>=).
+        ///
+        /// Examples:
+        /// - `(>>=)` or `(>>=) as bind`
+        operator: struct {
+            /// The operator symbol.
+            symbol: []const u8,
 
-        /// Whether to expose type constructors (indicated by (..)).
-        expose_constructors: bool,
+            /// Optional alias to use in the importing module.
+            alias: ?[]const u8,
+        },
 
-        /// Optional alias to use in the importing module.
-        alias: ?[]const u8,
-    },
+        /// Import a type, optionally exposing its constructors and/or with an alias.
+        ///
+        /// Examples:
+        /// - `Maybe(..)` or `Maybe(..) as Optional`
+        type: struct {
+            /// The name of the type.
+            name: []const u8,
 
-    pub fn deinit(self: *ImportItem, allocator: std.mem.Allocator) void {
-        switch (self.*) {
-            .function => |*f| {
-                allocator.free(f.name);
+            /// Whether to expose type constructors (indicated by (..)).
+            expose_constructors: bool,
 
-                if (f.alias) |alias| {
-                    allocator.free(alias);
-                }
-            },
-            .operator => |*op| {
-                allocator.free(op.symbol);
+            /// Optional alias to use in the importing module.
+            alias: ?[]const u8,
+        },
+    };
 
-                if (op.alias) |alias| {
-                    allocator.free(alias);
-                }
-            },
-            .type => |*t| {
-                allocator.free(t.name);
+    /// Increments the reference count when a new reference is created.
+    pub fn retain(self: *ImportItem) void {
+        self.ref_count += 1;
+    }
 
-                if (t.alias) |alias| {
-                    allocator.free(alias);
-                }
-            },
+    /// Decrements the reference count and cleans up if it reaches zero.
+    pub fn release(self: *ImportItem, allocator: std.mem.Allocator) void {
+        self.ref_count -= 1;
+
+        if (self.ref_count == 0) {
+            switch (self.inner) {
+                .function => |f| {
+                    allocator.free(f.name);
+
+                    if (f.alias) |alias| {
+                        allocator.free(alias);
+                    }
+                },
+                .operator => |op| {
+                    allocator.free(op.symbol);
+
+                    if (op.alias) |alias| {
+                        allocator.free(alias);
+                    }
+                },
+                .type => |t| {
+                    allocator.free(t.name);
+
+                    if (t.alias) |alias| {
+                        allocator.free(alias);
+                    }
+                },
+            }
+
+            allocator.destroy(self);
         }
     }
 };
@@ -1105,24 +1511,34 @@ pub const ImportSpecNode = struct {
     /// The token representing the start of this declaration.
     token: lexer.Token,
 
-    pub fn deinit(self: *ImportSpecNode, allocator: std.mem.Allocator) void {
-        self.path.deinit(allocator);
-        allocator.destroy(self.path);
+    /// Reference count for this node, defaults to 1 on creation.
+    ref_count: usize = 1,
 
-        if (self.alias) |alias| {
-            alias.deinit(allocator);
-        }
+    /// Increments the reference count when a new reference is created.
+    pub fn retain(self: *ImportSpecNode) void {
+        self.ref_count += 1;
+    }
 
-        if (self.items) |*items| {
-            for (items.items) |item| {
-                item.deinit(allocator);
-                allocator.destroy(item);
+    /// Decrements the reference count and cleans up if it reaches zero.
+    pub fn release(self: *ImportSpecNode, allocator: std.mem.Allocator) void {
+        self.ref_count -= 1;
+
+        if (self.ref_count == 0) {
+            self.path.release(allocator);
+
+            if (self.alias) |alias| {
+                alias.release(allocator);
             }
 
-            items.deinit();
-        }
+            if (self.items) |*items| {
+                for (items.items) |item| {
+                    item.release(allocator);
+                }
+                items.deinit();
+            }
 
-        allocator.destroy(self);
+            allocator.destroy(self);
+        }
     }
 };
 
@@ -1139,11 +1555,23 @@ pub const IncludeNode = struct {
     /// The token representing the start of this declaration.
     token: lexer.Token,
 
-    pub fn deinit(self: *IncludeNode, allocator: std.mem.Allocator) void {
-        self.path.deinit(allocator);
-        allocator.destroy(self.path);
+    /// Reference count for this node, defaults to 1 on creation.
+    ref_count: usize = 1,
 
-        allocator.destroy(self);
+    /// Increments the reference count when a new reference is created.
+    pub fn retain(self: *IncludeNode) void {
+        self.ref_count += 1;
+    }
+
+    /// Decrements the reference count and cleans up if it reaches zero.
+    pub fn release(self: *IncludeNode, allocator: std.mem.Allocator) void {
+        self.ref_count -= 1;
+
+        if (self.ref_count == 0) {
+            self.path.release(allocator);
+
+            allocator.destroy(self);
+        }
     }
 };
 
@@ -1175,25 +1603,36 @@ pub const FunctionDeclNode = struct {
     /// The token representing the start of this declaration.
     token: lexer.Token,
 
-    pub fn deinit(self: *FunctionDeclNode, allocator: std.mem.Allocator) void {
-        self.name.deinit(allocator);
+    /// Reference count for this node, defaults to 1 on creation.
+    ref_count: usize = 1,
 
-        for (self.parameters.items) |param| {
-            param.deinit(allocator);
-            allocator.destroy(param);
+    /// Increments the reference count when a new reference is created.
+    pub fn retain(self: *FunctionDeclNode) void {
+        self.ref_count += 1;
+    }
+
+    /// Decrements the reference count and cleans up if it reaches zero.
+    pub fn release(self: *FunctionDeclNode, allocator: std.mem.Allocator) void {
+        self.ref_count -= 1;
+
+        if (self.ref_count == 0) {
+            self.name.release(allocator);
+
+            for (self.parameters.items) |param| {
+                param.release(allocator);
+            }
+            self.parameters.deinit();
+
+            if (self.return_type) |rt| {
+                rt.release(allocator);
+                allocator.destroy(rt);
+            }
+
+            self.value.release(allocator);
+            allocator.destroy(self.value);
+
+            allocator.destroy(self);
         }
-
-        self.parameters.deinit();
-
-        if (self.return_type) |ret_type| {
-            ret_type.deinit(allocator);
-            allocator.destroy(ret_type);
-        }
-
-        self.value.deinit(allocator);
-        allocator.destroy(self.value);
-
-        allocator.destroy(self);
     }
 };
 
@@ -1219,22 +1658,33 @@ pub const ForeignFunctionDeclNode = struct {
     /// The token representing the start of this declaration.
     token: lexer.Token,
 
-    pub fn deinit(self: *ForeignFunctionDeclNode, allocator: std.mem.Allocator) void {
-        self.name.deinit(allocator);
+    /// Reference count for this node, defaults to 1 on creation.
+    ref_count: usize = 1,
 
-        for (self.parameters.items) |param| {
-            param.deinit(allocator);
-            allocator.destroy(param);
+    /// Increments the reference count when a new reference is created.
+    pub fn retain(self: *ForeignFunctionDeclNode) void {
+        self.ref_count += 1;
+    }
+
+    /// Decrements the reference count and cleans up if it reaches zero.
+    pub fn release(self: *ForeignFunctionDeclNode, allocator: std.mem.Allocator) void {
+        self.ref_count -= 1;
+
+        if (self.ref_count == 0) {
+            self.name.release(allocator);
+
+            for (self.parameters.items) |param| {
+                param.release(allocator);
+            }
+            self.parameters.deinit();
+
+            self.return_type.release(allocator);
+            allocator.destroy(self.return_type);
+
+            self.external_name.release(allocator);
+
+            allocator.destroy(self);
         }
-
-        self.parameters.deinit();
-
-        self.return_type.deinit(allocator);
-        allocator.destroy(self.return_type);
-
-        self.external_name.deinit(allocator);
-
-        allocator.destroy(self);
     }
 };
 
@@ -1259,21 +1709,31 @@ pub const ModuleDeclNode = struct {
     /// The token representing the start of this declaration.
     token: lexer.Token,
 
-    pub fn deinit(self: *ModuleDeclNode, allocator: std.mem.Allocator) void {
-        self.path.deinit(allocator);
-        allocator.destroy(self.path);
+    /// Reference count for this node, defaults to 1 on creation.
+    ref_count: usize = 1,
 
-        self.exports.deinit(allocator);
-        allocator.destroy(self.exports);
+    /// Increments the reference count when a new reference is created.
+    pub fn retain(self: *ModuleDeclNode) void {
+        self.ref_count += 1;
+    }
 
-        for (self.declarations.items) |declaration| {
-            declaration.deinit(allocator);
-            allocator.destroy(declaration);
+    /// Decrements the reference count and cleans up if it reaches zero.
+    pub fn release(self: *ModuleDeclNode, allocator: std.mem.Allocator) void {
+        self.ref_count -= 1;
+
+        if (self.ref_count == 0) {
+            self.path.release(allocator);
+
+            self.exports.release(allocator);
+
+            for (self.declarations.items) |declaration| {
+                declaration.release(allocator);
+                allocator.destroy(declaration);
+            }
+            self.declarations.deinit();
+
+            allocator.destroy(self);
         }
-
-        self.declarations.deinit();
-
-        allocator.destroy(self);
     }
 };
 
@@ -1286,15 +1746,27 @@ pub const ProgramNode = struct {
     /// The token representing the start of this declaration.
     token: lexer.Token,
 
-    pub fn deinit(self: *ProgramNode, allocator: std.mem.Allocator) void {
-        for (self.statements.items) |statement| {
-            statement.deinit(allocator);
-            allocator.destroy(statement);
+    /// Reference count for this node, defaults to 1 on creation.
+    ref_count: usize = 1,
+
+    /// Increments the reference count when a new reference is created.
+    pub fn retain(self: *ProgramNode) void {
+        self.ref_count += 1;
+    }
+
+    /// Decrements the reference count and cleans up if it reaches zero.
+    pub fn release(self: *ProgramNode, allocator: std.mem.Allocator) void {
+        self.ref_count -= 1;
+
+        if (self.ref_count == 0) {
+            for (self.statements.items) |statement| {
+                statement.release(allocator);
+                allocator.destroy(statement);
+            }
+            self.statements.deinit();
+
+            allocator.destroy(self);
         }
-
-        self.statements.deinit();
-
-        allocator.destroy(self);
     }
 };
 
@@ -1363,71 +1835,142 @@ pub const Node = union(enum) {
     module_decl: *ModuleDeclNode,
     program: *ProgramNode,
 
-    /// Cleans up resources associated with this node.
+    /// Increments the reference count to ensure this node remains valid.
     ///
-    /// Recursively deinitializes any child nodes that this node owns,
-    /// ensuring no memory leaks occur.
-    pub fn deinit(self: *Node, allocator: std.mem.Allocator) void {
+    /// This function should be called whenever a new reference to the node
+    /// is created, preventing premature deallocation.
+    pub fn retain(self: *Node) void {
         switch (self.*) {
             // Basic Literals
-            .comment => |comment| comment.deinit(allocator),
-            .doc_comment => |comment| comment.deinit(allocator),
+            .comment => |comment| comment.retain(),
+            .doc_comment => |comment| comment.retain(),
             .int_literal => {}, // no allocation
             .float_literal => {}, // no allocation
             .char_literal => {}, // no allocation
-            .str_literal => |lit| lit.deinit(allocator),
-            .multiline_str_literal => |lit| lit.deinit(allocator),
+            .str_literal => |lit| lit.retain(),
+            .multiline_str_literal => |lit| lit.retain(),
 
             // Identifiers
-            .lower_identifier => |ident| ident.deinit(allocator),
-            .upper_identifier => |ident| ident.deinit(allocator),
+            .lower_identifier => |ident| ident.retain(),
+            .upper_identifier => |ident| ident.retain(),
 
             // Basic Data Structures
-            .list => |list| list.deinit(allocator),
-            .tuple => |tuple| tuple.deinit(allocator),
+            .list => |list| list.retain(),
+            .tuple => |tuple| tuple.retain(),
 
             // Basic Expressions
-            .unary_expr => |expr| expr.deinit(allocator),
-            .arithmetic_expr => |expr| expr.deinit(allocator),
-            .logical_expr => |expr| expr.deinit(allocator),
-            .comparison_expr => |expr| expr.deinit(allocator),
+            .unary_expr => |expr| expr.retain(),
+            .arithmetic_expr => |expr| expr.retain(),
+            .logical_expr => |expr| expr.retain(),
+            .comparison_expr => |expr| expr.retain(),
 
             // Pattern Matching
-            .pattern => |pat| pat.deinit(allocator),
-            .match_expr => |expr| expr.deinit(allocator),
+            .pattern => |pat| pat.retain(),
+            .match_expr => |expr| expr.retain(),
 
             // Functions and Applications
-            .function_signature => |sig| sig.deinit(allocator),
-            .lambda_expr => |expr| expr.deinit(allocator),
-            .function_call => |expr| expr.deinit(allocator),
+            .function_signature => |sig| sig.retain(),
+            .lambda_expr => |expr| expr.retain(),
+            .function_call => |expr| expr.retain(),
 
             // Advanced Expressions
-            .cons_expr => |expr| expr.deinit(allocator),
-            .str_concat_expr => |expr| expr.deinit(allocator),
-            .list_concat_expr => |expr| expr.deinit(allocator),
-            .pipe_expr => |expr| expr.deinit(allocator),
+            .cons_expr => |expr| expr.retain(),
+            .str_concat_expr => |expr| expr.retain(),
+            .list_concat_expr => |expr| expr.retain(),
+            .pipe_expr => |expr| expr.retain(),
 
             // Control Flow
-            .if_then_else_stmt => |stmt| stmt.deinit(allocator),
+            .if_then_else_stmt => |stmt| stmt.retain(),
 
             // Type System
             .typed_hole => {}, // no allocation
-            .type_application => |app| app.deinit(allocator),
-            .type_alias => |alias| alias.deinit(allocator),
-            .variant_type => |vtype| vtype.deinit(allocator),
-            .record_type => |rtype| rtype.deinit(allocator),
+            .type_application => |app| app.retain(),
+            .type_alias => |alias| alias.retain(),
+            .variant_type => |vtype| vtype.retain(),
+            .record_type => |rtype| rtype.retain(),
 
             // Module System
-            .module_path => |path| path.deinit(allocator),
-            .export_spec => |spec| spec.deinit(allocator),
-            .import_spec => |spec| spec.deinit(allocator),
-            .include => |inc| inc.deinit(allocator),
+            .module_path => |path| path.retain(),
+            .export_spec => |spec| spec.retain(),
+            .import_spec => |spec| spec.retain(),
+            .include => |inc| inc.retain(),
 
             // Top-Level Declarations
-            .function_decl => |decl| decl.deinit(allocator),
-            .foreign_function_decl => |decl| decl.deinit(allocator),
-            .module_decl => |decl| decl.deinit(allocator),
-            .program => |prog| prog.deinit(allocator),
+            .function_decl => |decl| decl.retain(),
+            .foreign_function_decl => |decl| decl.retain(),
+            .module_decl => |decl| decl.retain(),
+            .program => |prog| prog.retain(),
+        }
+    }
+
+    /// Decrements the reference count and cleans up resources if no references remain.
+    ///
+    /// When the reference count reaches zero, this function recursively releases
+    /// any child nodes that this node owns, ensuring proper memory management
+    /// and preventing leaks.
+    ///
+    /// If other references still exist, the node remains valid.
+    pub fn release(self: *Node, allocator: std.mem.Allocator) void {
+        switch (self.*) {
+            // Basic Literals
+            .comment => |comment| comment.release(allocator),
+            .doc_comment => |comment| comment.release(allocator),
+            .int_literal => {}, // no allocation
+            .float_literal => {}, // no allocation
+            .char_literal => {}, // no allocation
+            .str_literal => |lit| lit.release(allocator),
+            .multiline_str_literal => |lit| lit.release(allocator),
+
+            // Identifiers
+            .lower_identifier => |ident| ident.release(allocator),
+            .upper_identifier => |ident| ident.release(allocator),
+
+            // Basic Data Structures
+            .list => |list| list.release(allocator),
+            .tuple => |tuple| tuple.release(allocator),
+
+            // Basic Expressions
+            .unary_expr => |expr| expr.release(allocator),
+            .arithmetic_expr => |expr| expr.release(allocator),
+            .logical_expr => |expr| expr.release(allocator),
+            .comparison_expr => |expr| expr.release(allocator),
+
+            // Pattern Matching
+            .pattern => |pat| pat.release(allocator),
+            .match_expr => |expr| expr.release(allocator),
+
+            // Functions and Applications
+            .function_signature => |sig| sig.release(allocator),
+            .lambda_expr => |expr| expr.release(allocator),
+            .function_call => |expr| expr.release(allocator),
+
+            // Advanced Expressions
+            .cons_expr => |expr| expr.release(allocator),
+            .str_concat_expr => |expr| expr.release(allocator),
+            .list_concat_expr => |expr| expr.release(allocator),
+            .pipe_expr => |expr| expr.release(allocator),
+
+            // Control Flow
+            .if_then_else_stmt => |stmt| stmt.release(allocator),
+
+            // Type System
+            .typed_hole => {}, // no allocation
+            .type_application => |app| app.release(allocator),
+            .type_alias => |alias| alias.release(allocator),
+            .variant_type => |vtype| vtype.release(allocator),
+            .record_type => |rtype| rtype.release(allocator),
+
+            // Module System
+            .module_path => |path| path.release(allocator),
+            .export_spec => |spec| spec.release(allocator),
+            .import_spec => |spec| spec.release(allocator),
+            .include => |inc| inc.release(allocator),
+
+            // Top-Level Declarations
+            .function_decl => |decl| decl.release(allocator),
+            .foreign_function_decl => |decl| decl.release(allocator),
+            .module_decl => |decl| decl.release(allocator),
+            .program => |prog| prog.release(allocator),
         }
     }
 };
@@ -1468,7 +2011,7 @@ test "[CommentNode]" {
 
     const node = try allocator.create(Node);
     defer {
-        node.deinit(allocator);
+        node.release(allocator);
         allocator.destroy(node);
     }
 
@@ -1514,7 +2057,7 @@ test "[DocCommentNode]" {
 
     const node = try allocator.create(Node);
     defer {
-        node.deinit(allocator);
+        node.release(allocator);
         allocator.destroy(node);
     }
 
@@ -1559,7 +2102,7 @@ test "[IntLiteralNode]" {
 
     const node = try allocator.create(Node);
     defer {
-        node.deinit(allocator);
+        node.release(allocator);
         allocator.destroy(node);
     }
 
@@ -1604,7 +2147,7 @@ test "[FloatLiteralNode]" {
 
     const node = try allocator.create(Node);
     defer {
-        node.deinit(allocator);
+        node.release(allocator);
         allocator.destroy(node);
     }
 
@@ -1649,7 +2192,7 @@ test "[CharLiteralNode]" {
 
     const node = try allocator.create(Node);
     defer {
-        node.deinit(allocator);
+        node.release(allocator);
         allocator.destroy(node);
     }
 
@@ -1695,7 +2238,7 @@ test "[StrLiteralNode]" {
 
     const node = try allocator.create(Node);
     defer {
-        node.deinit(allocator);
+        node.release(allocator);
         allocator.destroy(node);
     }
 
@@ -1725,11 +2268,7 @@ test "[MultilineStrLiteralNode]" {
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 
-    const value =
-        \\first line
-        \\second line
-        \\third line
-    ;
+    const value = "first line\nsecond line\nthird line";
 
     // Action
     const literal_node = try allocator.create(MultilineStrLiteralNode);
@@ -1748,14 +2287,14 @@ test "[MultilineStrLiteralNode]" {
 
     const node = try allocator.create(Node);
     defer {
-        node.deinit(allocator);
+        node.release(allocator);
         allocator.destroy(node);
     }
 
     node.* = .{ .multiline_str_literal = literal_node };
 
     // Assertions
-    // Verify the node is a string literal
+    // Verify the node is a multiline string literal
     try testing.expect(node.* == .multiline_str_literal);
 
     const literal = node.multiline_str_literal;
@@ -1794,7 +2333,7 @@ test "[LowerIdentifierNode]" {
 
     const node = try allocator.create(Node);
     defer {
-        node.deinit(allocator);
+        node.release(allocator);
         allocator.destroy(node);
     }
 
@@ -1843,7 +2382,7 @@ test "[UpperIdentifierNode]" {
 
     const node = try allocator.create(Node);
     defer {
-        node.deinit(allocator);
+        node.release(allocator);
         allocator.destroy(node);
     }
 
@@ -1874,6 +2413,8 @@ test "[ListNode]" {
     const allocator = gpa.allocator();
 
     // Action
+    var elements = std.ArrayList(*Node).init(allocator);
+
     const elem1 = try allocator.create(Node);
     elem1.* = .{
         .int_literal = .{
@@ -1906,7 +2447,6 @@ test "[ListNode]" {
         },
     };
 
-    var elements = std.ArrayList(*Node).init(allocator);
     try elements.append(elem1);
     try elements.append(elem2);
 
@@ -1926,7 +2466,7 @@ test "[ListNode]" {
 
     const node = try allocator.create(Node);
     defer {
-        node.deinit(allocator);
+        node.release(allocator);
         allocator.destroy(node);
     }
 
@@ -1958,6 +2498,8 @@ test "[TupleNode]" {
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 
+    var elements = std.ArrayList(*Node).init(allocator);
+
     const first = try allocator.create(Node);
     first.* = .{
         .int_literal = .{
@@ -1973,6 +2515,8 @@ test "[TupleNode]" {
             },
         },
     };
+
+    try elements.append(first);
 
     const second_str = try allocator.create(StrLiteralNode);
     second_str.* = .{
@@ -1991,8 +2535,6 @@ test "[TupleNode]" {
     const second = try allocator.create(Node);
     second.* = .{ .str_literal = second_str };
 
-    var elements = std.ArrayList(*Node).init(allocator);
-    try elements.append(first);
     try elements.append(second);
 
     const tuple_node = try allocator.create(TupleNode);
@@ -2011,7 +2553,7 @@ test "[TupleNode]" {
 
     const node = try allocator.create(Node);
     defer {
-        node.deinit(allocator);
+        node.release(allocator);
         allocator.destroy(node);
     }
 
@@ -2079,7 +2621,7 @@ test "[UnaryExprNode]" {
 
     const node = try allocator.create(Node);
     defer {
-        node.deinit(allocator);
+        node.release(allocator);
         allocator.destroy(node);
     }
 
@@ -2162,7 +2704,7 @@ test "[ArithmeticExprNode]" {
 
     const node = try allocator.create(Node);
     defer {
-        node.deinit(allocator);
+        node.release(allocator);
         allocator.destroy(node);
     }
 
@@ -2247,7 +2789,7 @@ test "[LogicalExprNode]" {
 
     const node = try allocator.create(Node);
     defer {
-        node.deinit(allocator);
+        node.release(allocator);
         allocator.destroy(node);
     }
 
@@ -2332,7 +2874,7 @@ test "[ComparisonExprNode]" {
 
     const node = try allocator.create(Node);
     defer {
-        node.deinit(allocator);
+        node.release(allocator);
         allocator.destroy(node);
     }
 
@@ -2385,7 +2927,9 @@ test "[MatchExprNode]" {
         const subject_node = try allocator.create(Node);
         subject_node.* = .{ .lower_identifier = opt_ident };
 
-        // Case 1: Some x => x
+        var cases = std.ArrayList(*MatchCaseNode).init(allocator);
+
+        // Case 1: Some(x) => x
         const x_name = try allocator.create(LowerIdentifierNode);
         x_name.* = .{
             .identifier = try allocator.dupe(u8, "x"),
@@ -2402,15 +2946,17 @@ test "[MatchExprNode]" {
 
         const var_pattern = try allocator.create(PatternNode);
         var_pattern.* = .{
-            .variable = .{
-                .name = x_name,
-                .token = .{
-                    .kind = .{ .identifier = .Lower },
-                    .lexeme = "x",
-                    .loc = .{
-                        .filename = TEST_FILE,
-                        .span = .{ .start = 20, .end = 21 },
-                        .src = .{ .line = 1, .col = 21 },
+            .inner = .{
+                .variable = .{
+                    .name = x_name,
+                    .token = .{
+                        .kind = .{ .identifier = .Lower },
+                        .lexeme = "x",
+                        .loc = .{
+                            .filename = TEST_FILE,
+                            .span = .{ .start = 20, .end = 21 },
+                            .src = .{ .line = 1, .col = 21 },
+                        },
                     },
                 },
             },
@@ -2421,16 +2967,18 @@ test "[MatchExprNode]" {
 
         const some_pattern = try allocator.create(PatternNode);
         some_pattern.* = .{
-            .constructor = .{
-                .name = try allocator.dupe(u8, "Some"),
-                .parameters = some_params,
-                .token = .{
-                    .kind = .{ .identifier = .Upper },
-                    .lexeme = "Some",
-                    .loc = .{
-                        .filename = TEST_FILE,
-                        .span = .{ .start = 15, .end = 19 },
-                        .src = .{ .line = 1, .col = 16 },
+            .inner = .{
+                .constructor = .{
+                    .name = try allocator.dupe(u8, "Some"),
+                    .parameters = some_params,
+                    .token = .{
+                        .kind = .{ .identifier = .Upper },
+                        .lexeme = "Some",
+                        .loc = .{
+                            .filename = TEST_FILE,
+                            .span = .{ .start = 15, .end = 19 },
+                            .src = .{ .line = 1, .col = 16 },
+                        },
                     },
                 },
             },
@@ -2453,7 +3001,7 @@ test "[MatchExprNode]" {
         const some_expr = try allocator.create(Node);
         some_expr.* = .{ .lower_identifier = x_expr_ident };
 
-        const some_case = try allocator.create(MatchCase);
+        const some_case = try allocator.create(MatchCaseNode);
         some_case.* = .{
             .pattern = some_pattern,
             .expression = some_expr,
@@ -2469,19 +3017,23 @@ test "[MatchExprNode]" {
             },
         };
 
+        try cases.append(some_case);
+
         // Case 2: None => 0
         const none_pattern = try allocator.create(PatternNode);
         none_pattern.* = .{
-            .constructor = .{
-                .name = try allocator.dupe(u8, "None"),
-                .parameters = std.ArrayList(*PatternNode).init(allocator),
-                .token = .{
-                    .kind = .{ .identifier = .Upper },
-                    .lexeme = "None",
-                    .loc = .{
-                        .filename = TEST_FILE,
-                        .span = .{ .start = 30, .end = 34 },
-                        .src = .{ .line = 1, .col = 31 },
+            .inner = .{
+                .constructor = .{
+                    .name = try allocator.dupe(u8, "None"),
+                    .parameters = std.ArrayList(*PatternNode).init(allocator),
+                    .token = .{
+                        .kind = .{ .identifier = .Upper },
+                        .lexeme = "None",
+                        .loc = .{
+                            .filename = TEST_FILE,
+                            .span = .{ .start = 30, .end = 34 },
+                            .src = .{ .line = 1, .col = 31 },
+                        },
                     },
                 },
             },
@@ -2503,7 +3055,7 @@ test "[MatchExprNode]" {
             },
         };
 
-        const none_case = try allocator.create(MatchCase);
+        const none_case = try allocator.create(MatchCaseNode);
         none_case.* = .{
             .pattern = none_pattern,
             .expression = none_expr,
@@ -2519,8 +3071,6 @@ test "[MatchExprNode]" {
             },
         };
 
-        var cases = std.ArrayList(*MatchCase).init(allocator);
-        try cases.append(some_case);
         try cases.append(none_case);
 
         const match_expr = try allocator.create(MatchExprNode);
@@ -2540,7 +3090,7 @@ test "[MatchExprNode]" {
 
         const node = try allocator.create(Node);
         defer {
-            node.deinit(allocator);
+            node.release(allocator);
             allocator.destroy(node);
         }
 
@@ -2556,18 +3106,19 @@ test "[MatchExprNode]" {
         try testing.expectEqual(@as(usize, 2), match.cases.items.len);
 
         // Ensure the constructor name for the first case is "Some"
-        const case1 = match.cases.items[0];
-        try testing.expectEqualStrings("Some", case1.pattern.constructor.name);
+        const case1 = match.cases.items[0].pattern.inner;
+        try testing.expectEqualStrings("Some", case1.constructor.name);
 
         // Check the argument for the "Some" constructor is a variable named "x"
-        try testing.expectEqualStrings("x", case1.pattern.constructor.parameters.items[0].variable.name.identifier);
+        try testing.expectEqual(@as(usize, 1), case1.constructor.parameters.items.len);
+        try testing.expectEqualStrings("x", case1.constructor.parameters.items[0].inner.variable.name.identifier);
 
         // Ensure the constructor name for the second case is "None"
-        const case2 = match.cases.items[1];
-        try testing.expectEqualStrings("None", case2.pattern.constructor.name);
+        const case2 = match.cases.items[1].pattern.inner;
+        try testing.expectEqualStrings("None", case2.constructor.name);
 
         // Verify the "None" constructor in the second case has no arguments
-        try testing.expectEqual(@as(usize, 0), case2.pattern.constructor.parameters.items.len);
+        try testing.expectEqual(@as(usize, 0), case2.constructor.parameters.items.len);
     }
 
     {
@@ -2593,6 +3144,8 @@ test "[MatchExprNode]" {
         const subject_node = try allocator.create(Node);
         subject_node.* = .{ .lower_identifier = list_ident };
 
+        var cases = std.ArrayList(*MatchCaseNode).init(allocator);
+
         // Case 1: head :: tail => head
         const head_ident = try allocator.create(LowerIdentifierNode);
         head_ident.* = .{
@@ -2610,15 +3163,17 @@ test "[MatchExprNode]" {
 
         const head_pattern = try allocator.create(PatternNode);
         head_pattern.* = .{
-            .variable = .{
-                .name = head_ident,
-                .token = .{
-                    .kind = .{ .identifier = .Lower },
-                    .lexeme = "head",
-                    .loc = .{
-                        .filename = TEST_FILE,
-                        .span = .{ .start = 15, .end = 19 },
-                        .src = .{ .line = 1, .col = 16 },
+            .inner = .{
+                .variable = .{
+                    .name = head_ident,
+                    .token = .{
+                        .kind = .{ .identifier = .Lower },
+                        .lexeme = "head",
+                        .loc = .{
+                            .filename = TEST_FILE,
+                            .span = .{ .start = 15, .end = 19 },
+                            .src = .{ .line = 1, .col = 16 },
+                        },
                     },
                 },
             },
@@ -2640,15 +3195,17 @@ test "[MatchExprNode]" {
 
         const tail_pattern = try allocator.create(PatternNode);
         tail_pattern.* = .{
-            .variable = .{
-                .name = tail_ident,
-                .token = .{
-                    .kind = .{ .identifier = .Lower },
-                    .lexeme = "tail",
-                    .loc = .{
-                        .filename = TEST_FILE,
-                        .span = .{ .start = 23, .end = 27 },
-                        .src = .{ .line = 1, .col = 24 },
+            .inner = .{
+                .variable = .{
+                    .name = tail_ident,
+                    .token = .{
+                        .kind = .{ .identifier = .Lower },
+                        .lexeme = "tail",
+                        .loc = .{
+                            .filename = TEST_FILE,
+                            .span = .{ .start = 23, .end = 27 },
+                            .src = .{ .line = 1, .col = 24 },
+                        },
                     },
                 },
             },
@@ -2656,16 +3213,18 @@ test "[MatchExprNode]" {
 
         const cons_pattern = try allocator.create(PatternNode);
         cons_pattern.* = .{
-            .cons = .{
-                .head = head_pattern,
-                .tail = tail_pattern,
-                .token = .{
-                    .kind = .{ .operator = .Cons },
-                    .lexeme = "::",
-                    .loc = .{
-                        .filename = TEST_FILE,
-                        .span = .{ .start = 20, .end = 22 },
-                        .src = .{ .line = 1, .col = 21 },
+            .inner = .{
+                .cons = .{
+                    .head = head_pattern,
+                    .tail = tail_pattern,
+                    .token = .{
+                        .kind = .{ .operator = .Cons },
+                        .lexeme = "::",
+                        .loc = .{
+                            .filename = TEST_FILE,
+                            .span = .{ .start = 20, .end = 22 },
+                            .src = .{ .line = 1, .col = 21 },
+                        },
                     },
                 },
             },
@@ -2688,7 +3247,7 @@ test "[MatchExprNode]" {
         const head_expr = try allocator.create(Node);
         head_expr.* = .{ .lower_identifier = head_expr_ident };
 
-        const cons_case = try allocator.create(MatchCase);
+        const cons_case = try allocator.create(MatchCaseNode);
         cons_case.* = .{
             .pattern = cons_pattern,
             .expression = head_expr,
@@ -2704,17 +3263,21 @@ test "[MatchExprNode]" {
             },
         };
 
+        try cases.append(cons_case);
+
         // Case 2: [] => 0
         const empty_pattern = try allocator.create(PatternNode);
         empty_pattern.* = .{
-            .empty_list = .{
-                .token = .{
-                    .kind = .{ .delimiter = .LeftBracket },
-                    .lexeme = "[]",
-                    .loc = .{
-                        .filename = TEST_FILE,
-                        .span = .{ .start = 39, .end = 41 },
-                        .src = .{ .line = 1, .col = 40 },
+            .inner = .{
+                .empty_list = .{
+                    .token = .{
+                        .kind = .{ .delimiter = .LeftBracket },
+                        .lexeme = "[]",
+                        .loc = .{
+                            .filename = TEST_FILE,
+                            .span = .{ .start = 39, .end = 41 },
+                            .src = .{ .line = 1, .col = 40 },
+                        },
                     },
                 },
             },
@@ -2736,7 +3299,7 @@ test "[MatchExprNode]" {
             },
         };
 
-        const empty_case = try allocator.create(MatchCase);
+        const empty_case = try allocator.create(MatchCaseNode);
         empty_case.* = .{
             .pattern = empty_pattern,
             .expression = zero_node,
@@ -2752,8 +3315,6 @@ test "[MatchExprNode]" {
             },
         };
 
-        var cases = std.ArrayList(*MatchCase).init(allocator);
-        try cases.append(cons_case);
         try cases.append(empty_case);
 
         const match_expr = try allocator.create(MatchExprNode);
@@ -2773,7 +3334,7 @@ test "[MatchExprNode]" {
 
         const node = try allocator.create(Node);
         defer {
-            node.deinit(allocator);
+            node.release(allocator);
             allocator.destroy(node);
         }
 
@@ -2789,22 +3350,22 @@ test "[MatchExprNode]" {
         try testing.expectEqual(@as(usize, 2), match.cases.items.len);
 
         // Test the first case (cons pattern)
-        const list_cons_case = match.cases.items[0];
+        const list_cons_case = match.cases.items[0].pattern.inner;
 
         // Verify the pattern in the first case is a cons pattern (head :: tail)
-        try testing.expect(list_cons_case.pattern.* == .cons);
+        try testing.expect(list_cons_case == .cons);
 
         // Ensure the name of the head variable in the cons pattern is "head"
-        try testing.expectEqualStrings("head", list_cons_case.pattern.cons.head.variable.name.identifier);
+        try testing.expectEqualStrings("head", list_cons_case.cons.head.inner.variable.name.identifier);
 
         // Ensure the name of the tail variable in the cons pattern is "tail"
-        try testing.expectEqualStrings("tail", list_cons_case.pattern.cons.tail.variable.name.identifier);
+        try testing.expectEqualStrings("tail", list_cons_case.cons.tail.inner.variable.name.identifier);
 
         // Test the second case (empty list pattern)
-        const empty_list_case = match.cases.items[1];
+        const empty_list_case = match.cases.items[1].pattern.inner;
 
         // Verify the pattern in the second case is an empty list
-        try testing.expect(empty_list_case.pattern.* == .empty_list);
+        try testing.expect(empty_list_case == .empty_list);
     }
 
     {
@@ -2829,6 +3390,8 @@ test "[MatchExprNode]" {
         const subject_node = try allocator.create(Node);
         subject_node.* = .{ .lower_identifier = x_ident };
 
+        var cases = std.ArrayList(*MatchCaseNode).init(allocator);
+
         // Case 1: n when n > 0 => "positive"
         const n_ident = try allocator.create(LowerIdentifierNode);
         n_ident.* = .{
@@ -2846,15 +3409,17 @@ test "[MatchExprNode]" {
 
         const n_pattern = try allocator.create(PatternNode);
         n_pattern.* = .{
-            .variable = .{
-                .name = n_ident,
-                .token = .{
-                    .kind = .{ .identifier = .Lower },
-                    .lexeme = "n",
-                    .loc = .{
-                        .filename = TEST_FILE,
-                        .span = .{ .start = 13, .end = 14 },
-                        .src = .{ .line = 1, .col = 14 },
+            .inner = .{
+                .variable = .{
+                    .name = n_ident,
+                    .token = .{
+                        .kind = .{ .identifier = .Lower },
+                        .lexeme = "n",
+                        .loc = .{
+                            .filename = TEST_FILE,
+                            .span = .{ .start = 13, .end = 14 },
+                            .src = .{ .line = 1, .col = 14 },
+                        },
                     },
                 },
             },
@@ -2942,7 +3507,7 @@ test "[MatchExprNode]" {
         const positive_expr = try allocator.create(Node);
         positive_expr.* = .{ .str_literal = positive_str };
 
-        const guarded_case = try allocator.create(MatchCase);
+        const guarded_case = try allocator.create(MatchCaseNode);
         guarded_case.* = .{
             .pattern = n_pattern,
             .expression = positive_expr,
@@ -2957,6 +3522,8 @@ test "[MatchExprNode]" {
                 },
             },
         };
+
+        try cases.append(guarded_case);
 
         // Case 2: n => "non-positive"
         const n2_ident = try allocator.create(LowerIdentifierNode);
@@ -2975,15 +3542,17 @@ test "[MatchExprNode]" {
 
         const n2_pattern = try allocator.create(PatternNode);
         n2_pattern.* = .{
-            .variable = .{
-                .name = n2_ident,
-                .token = .{
-                    .kind = .{ .identifier = .Lower },
-                    .lexeme = "n",
-                    .loc = .{
-                        .filename = TEST_FILE,
-                        .span = .{ .start = 36, .end = 37 },
-                        .src = .{ .line = 1, .col = 37 },
+            .inner = .{
+                .variable = .{
+                    .name = n2_ident,
+                    .token = .{
+                        .kind = .{ .identifier = .Lower },
+                        .lexeme = "n",
+                        .loc = .{
+                            .filename = TEST_FILE,
+                            .span = .{ .start = 36, .end = 37 },
+                            .src = .{ .line = 1, .col = 37 },
+                        },
                     },
                 },
             },
@@ -3006,7 +3575,7 @@ test "[MatchExprNode]" {
         const non_positive_expr = try allocator.create(Node);
         non_positive_expr.* = .{ .str_literal = non_pos_str };
 
-        const default_case = try allocator.create(MatchCase);
+        const default_case = try allocator.create(MatchCaseNode);
         default_case.* = .{
             .pattern = n2_pattern,
             .expression = non_positive_expr,
@@ -3022,8 +3591,6 @@ test "[MatchExprNode]" {
             },
         };
 
-        var cases = std.ArrayList(*MatchCase).init(allocator);
-        try cases.append(guarded_case);
         try cases.append(default_case);
 
         const match_expr = try allocator.create(MatchExprNode);
@@ -3043,7 +3610,7 @@ test "[MatchExprNode]" {
 
         const node = try allocator.create(Node);
         defer {
-            node.deinit(allocator);
+            node.release(allocator);
             allocator.destroy(node);
         }
 
@@ -3062,10 +3629,10 @@ test "[MatchExprNode]" {
         const positive_case = match.cases.items[0];
 
         // Verify the pattern in the guarded case is a variable
-        try testing.expect(positive_case.pattern.* == .variable);
+        try testing.expect(positive_case.pattern.inner == .variable);
 
         // Verify the name of the variable
-        try testing.expectEqualStrings("n", positive_case.pattern.variable.name.identifier);
+        try testing.expectEqualStrings("n", positive_case.pattern.inner.variable.name.identifier);
 
         // Ensure the guarded case has a guard condition
         try testing.expect(positive_case.guard != null);
@@ -3077,10 +3644,10 @@ test "[MatchExprNode]" {
         const non_positive_case = match.cases.items[1];
 
         // Verify the pattern in the catch-all case is a variable
-        try testing.expect(non_positive_case.pattern.* == .variable);
+        try testing.expect(non_positive_case.pattern.inner == .variable);
 
         // Ensure the name of the variable in the pattern is "n"
-        try testing.expectEqualStrings("n", non_positive_case.pattern.variable.name.identifier);
+        try testing.expectEqualStrings("n", non_positive_case.pattern.inner.variable.name.identifier);
 
         // Ensure the catch-all case does not have a guard condition
         try testing.expect(non_positive_case.guard == null);
@@ -3155,7 +3722,6 @@ test "[FunctionSignatureNode]" {
     try parameter_types.append(int_node2);
 
     const func_signature = try allocator.create(FunctionSignatureNode);
-    defer allocator.destroy(func_signature);
 
     func_signature.* = .{
         .parameter_types = parameter_types,
@@ -3173,7 +3739,7 @@ test "[FunctionSignatureNode]" {
 
     const node = try allocator.create(Node);
     defer {
-        node.deinit(allocator);
+        node.release(allocator);
         allocator.destroy(node);
     }
 
@@ -3237,6 +3803,8 @@ test "[LambdaExprNode]" {
         .token = x_param_ident.token,
     };
 
+    try parameters.append(x_param);
+
     const y_param_ident = try allocator.create(LowerIdentifierNode);
     y_param_ident.* = .{
         .identifier = try allocator.dupe(u8, "y"),
@@ -3258,7 +3826,6 @@ test "[LambdaExprNode]" {
         .token = y_param_ident.token,
     };
 
-    try parameters.append(x_param);
     try parameters.append(y_param);
 
     const x_ident = try allocator.create(LowerIdentifierNode);
@@ -3331,7 +3898,7 @@ test "[LambdaExprNode]" {
 
     const node = try allocator.create(Node);
     defer {
-        node.deinit(allocator);
+        node.release(allocator);
         allocator.destroy(node);
     }
 
@@ -3447,7 +4014,7 @@ test "[FunctionCallNode]" {
 
     const node = try allocator.create(Node);
     defer {
-        node.deinit(allocator);
+        node.release(allocator);
         allocator.destroy(node);
     }
 
@@ -3484,8 +4051,6 @@ test "[ConsExprNode]" {
     const allocator = gpa.allocator();
 
     // Action
-    var elements = std.ArrayList(*Node).init(allocator);
-
     const one_node = try allocator.create(Node);
     one_node.* = .{
         .int_literal = .{
@@ -3501,6 +4066,8 @@ test "[ConsExprNode]" {
             },
         },
     };
+
+    var elements = std.ArrayList(*Node).init(allocator);
 
     const two_node = try allocator.create(Node);
     two_node.* = .{
@@ -3518,6 +4085,8 @@ test "[ConsExprNode]" {
         },
     };
 
+    try elements.append(two_node);
+
     const three_node = try allocator.create(Node);
     three_node.* = .{
         .int_literal = .{
@@ -3534,7 +4103,6 @@ test "[ConsExprNode]" {
         },
     };
 
-    try elements.append(two_node);
     try elements.append(three_node);
 
     const list_node = try allocator.create(ListNode);
@@ -3571,7 +4139,7 @@ test "[ConsExprNode]" {
 
     const node = try allocator.create(Node);
     defer {
-        node.deinit(allocator);
+        node.release(allocator);
         allocator.destroy(node);
     }
 
@@ -3670,7 +4238,7 @@ test "[StrConcatExprNode]" {
 
     const node = try allocator.create(Node);
     defer {
-        node.deinit(allocator);
+        node.release(allocator);
         allocator.destroy(node);
     }
 
@@ -3722,6 +4290,8 @@ test "[ListConcatExprNode]" {
         },
     };
 
+    try left_elements.append(one_node);
+
     const two_node = try allocator.create(Node);
     two_node.* = .{
         .int_literal = .{
@@ -3738,7 +4308,6 @@ test "[ListConcatExprNode]" {
         },
     };
 
-    try left_elements.append(one_node);
     try left_elements.append(two_node);
 
     const left_list = try allocator.create(ListNode);
@@ -3776,6 +4345,8 @@ test "[ListConcatExprNode]" {
         },
     };
 
+    try right_elements.append(three_node);
+
     const four_node = try allocator.create(Node);
     four_node.* = .{
         .int_literal = .{
@@ -3792,7 +4363,6 @@ test "[ListConcatExprNode]" {
         },
     };
 
-    try right_elements.append(three_node);
     try right_elements.append(four_node);
 
     const right_list = try allocator.create(ListNode);
@@ -3829,7 +4399,7 @@ test "[ListConcatExprNode]" {
 
     const node = try allocator.create(Node);
     defer {
-        node.deinit(allocator);
+        node.release(allocator);
         allocator.destroy(node);
     }
 
@@ -3956,7 +4526,7 @@ test "[PipeExprNode]" {
 
     const node = try allocator.create(Node);
     defer {
-        node.deinit(allocator);
+        node.release(allocator);
         allocator.destroy(node);
     }
 
@@ -4103,7 +4673,7 @@ test "[IfThenElseStmtNode]" {
 
     const node = try allocator.create(Node);
     defer {
-        node.deinit(allocator);
+        node.release(allocator);
         allocator.destroy(node);
     }
 
@@ -4189,7 +4759,7 @@ test "[TypedHoleNode]" {
 
     const node = try allocator.create(Node);
     defer {
-        node.deinit(allocator);
+        node.release(allocator);
         allocator.destroy(node);
     }
 
@@ -4229,6 +4799,8 @@ test "[TypeApplicationNode]" {
         },
     };
 
+    var args = std.ArrayList(*Node).init(allocator);
+
     const k_ident = try allocator.create(LowerIdentifierNode);
     k_ident.* = .{
         .identifier = try allocator.dupe(u8, "k"),
@@ -4245,6 +4817,8 @@ test "[TypeApplicationNode]" {
 
     const k_node = try allocator.create(Node);
     k_node.* = .{ .lower_identifier = k_ident };
+
+    try args.append(k_node);
 
     const v_ident = try allocator.create(LowerIdentifierNode);
     v_ident.* = .{
@@ -4263,8 +4837,6 @@ test "[TypeApplicationNode]" {
     const v_node = try allocator.create(Node);
     v_node.* = .{ .lower_identifier = v_ident };
 
-    var args = std.ArrayList(*Node).init(allocator);
-    try args.append(k_node);
     try args.append(v_node);
 
     const type_application = try allocator.create(TypeApplicationNode);
@@ -4284,7 +4856,7 @@ test "[TypeApplicationNode]" {
 
     const node = try allocator.create(Node);
     defer {
-        node.deinit(allocator);
+        node.release(allocator);
         allocator.destroy(node);
     }
 
@@ -4372,7 +4944,7 @@ test "[TypeAliasNode]" {
 
     const node = try allocator.create(Node);
     defer {
-        node.deinit(allocator);
+        node.release(allocator);
         allocator.destroy(node);
     }
 
@@ -4436,6 +5008,8 @@ test "[VariantTypeNode]" {
     try type_params.append(try allocator.dupe(u8, "e"));
     try type_params.append(try allocator.dupe(u8, "a"));
 
+    var constructors = std.ArrayList(*VariantConstructorNode).init(allocator);
+
     const e_ident = try allocator.create(LowerIdentifierNode);
     e_ident.* = .{
         .identifier = try allocator.dupe(u8, "e"),
@@ -4484,6 +5058,8 @@ test "[VariantTypeNode]" {
             },
         },
     };
+
+    try constructors.append(err_constructor);
 
     const a_ident = try allocator.create(LowerIdentifierNode);
     a_ident.* = .{
@@ -4534,8 +5110,6 @@ test "[VariantTypeNode]" {
         },
     };
 
-    var constructors = std.ArrayList(*VariantConstructorNode).init(allocator);
-    try constructors.append(err_constructor);
     try constructors.append(ok_constructor);
 
     const variant_type = try allocator.create(VariantTypeNode);
@@ -4556,7 +5130,7 @@ test "[VariantTypeNode]" {
 
     const node = try allocator.create(Node);
     defer {
-        node.deinit(allocator);
+        node.release(allocator);
         allocator.destroy(node);
     }
 
@@ -4671,6 +5245,8 @@ test "[RecordTypeNode]" {
         .token = x_ident.token,
     };
 
+    try fields.append(field_x);
+
     const y_ident = try allocator.create(LowerIdentifierNode);
     y_ident.* = .{
         .identifier = try allocator.dupe(u8, "y"),
@@ -4709,7 +5285,6 @@ test "[RecordTypeNode]" {
         .token = y_ident.token,
     };
 
-    try fields.append(field_x);
     try fields.append(field_y);
 
     const rtype_node = try allocator.create(RecordTypeNode);
@@ -4730,7 +5305,7 @@ test "[RecordTypeNode]" {
 
     const node = try allocator.create(Node);
     defer {
-        node.deinit(allocator);
+        node.release(allocator);
         allocator.destroy(node);
     }
 
@@ -4810,6 +5385,8 @@ test "[ModulePathNode]" {
         },
     };
 
+    try segments.append(std_ident);
+
     const list_ident = try allocator.create(UpperIdentifierNode);
     list_ident.* = .{
         .identifier = try allocator.dupe(u8, "List"),
@@ -4824,11 +5401,9 @@ test "[ModulePathNode]" {
         },
     };
 
-    try segments.append(std_ident);
     try segments.append(list_ident);
 
     const path_node = try allocator.create(ModulePathNode);
-    defer allocator.destroy(path_node);
 
     path_node.* = .{
         .segments = segments,
@@ -4837,7 +5412,7 @@ test "[ModulePathNode]" {
 
     const node = try allocator.create(Node);
     defer {
-        node.deinit(allocator);
+        node.release(allocator);
         allocator.destroy(node);
     }
 
@@ -4868,7 +5443,10 @@ test "[ExportSpecNode]" {
     const allocator = gpa.allocator();
 
     // Action
-    const item1 = ExportItem{
+    var items = std.ArrayList(*ExportItem).init(allocator);
+
+    const item1 = try allocator.create(ExportItem);
+    item1.* = .{
         .name = try allocator.dupe(u8, "func1"),
         .expose_constructors = false,
         .token = .{
@@ -4882,7 +5460,10 @@ test "[ExportSpecNode]" {
         },
     };
 
-    const item2 = ExportItem{
+    try items.append(item1);
+
+    const item2 = try allocator.create(ExportItem);
+    item2.* = .{
         .name = try allocator.dupe(u8, "Type1"),
         .expose_constructors = true,
         .token = .{
@@ -4896,8 +5477,6 @@ test "[ExportSpecNode]" {
         },
     };
 
-    var items = std.ArrayList(ExportItem).init(allocator);
-    try items.append(item1);
     try items.append(item2);
 
     const export_node = try allocator.create(ExportSpecNode);
@@ -4917,10 +5496,8 @@ test "[ExportSpecNode]" {
 
     const node = try allocator.create(Node);
     defer {
-        node.deinit(allocator);
+        node.release(allocator);
         allocator.destroy(node);
-
-        allocator.destroy(export_node);
     }
 
     node.* = .{ .export_spec = export_node };
@@ -4996,7 +5573,7 @@ test "[ImportSpecNode]" {
 
         const node = try allocator.create(Node);
         defer {
-            node.deinit(allocator);
+            node.release(allocator);
             allocator.destroy(node);
         }
 
@@ -5082,7 +5659,7 @@ test "[ImportSpecNode]" {
 
         const node = try allocator.create(Node);
         defer {
-            node.deinit(allocator);
+            node.release(allocator);
             allocator.destroy(node);
         }
 
@@ -5138,44 +5715,56 @@ test "[ImportSpecNode]" {
             .token = module_ident.token,
         };
 
+        var items = std.ArrayList(*ImportItem).init(allocator);
+
         const map_item = try allocator.create(ImportItem);
         map_item.* = .{
-            .function = .{
-                .name = try allocator.dupe(u8, "map"),
-                .alias = null,
+            .inner = .{
+                .function = .{
+                    .name = try allocator.dupe(u8, "map"),
+                    .alias = null,
+                },
             },
         };
+
+        try items.append(map_item);
 
         const filter_item = try allocator.create(ImportItem);
         filter_item.* = .{
-            .function = .{
-                .name = try allocator.dupe(u8, "filter"),
-                .alias = null,
+            .inner = .{
+                .function = .{
+                    .name = try allocator.dupe(u8, "filter"),
+                    .alias = null,
+                },
             },
         };
+
+        try items.append(filter_item);
 
         const maybe_item = try allocator.create(ImportItem);
         maybe_item.* = .{
-            .type = .{
-                .name = try allocator.dupe(u8, "Maybe"),
-                .expose_constructors = false,
-                .alias = null,
+            .inner = .{
+                .type = .{
+                    .name = try allocator.dupe(u8, "Maybe"),
+                    .expose_constructors = false,
+                    .alias = null,
+                },
             },
         };
+
+        try items.append(maybe_item);
 
         const either_item = try allocator.create(ImportItem);
         either_item.* = .{
-            .type = .{
-                .name = try allocator.dupe(u8, "Either"),
-                .expose_constructors = true,
-                .alias = null,
+            .inner = .{
+                .type = .{
+                    .name = try allocator.dupe(u8, "Either"),
+                    .expose_constructors = true,
+                    .alias = null,
+                },
             },
         };
 
-        var items = std.ArrayList(*ImportItem).init(allocator);
-        try items.append(map_item);
-        try items.append(filter_item);
-        try items.append(maybe_item);
         try items.append(either_item);
 
         const import_node = try allocator.create(ImportSpecNode);
@@ -5197,7 +5786,7 @@ test "[ImportSpecNode]" {
 
         const node = try allocator.create(Node);
         defer {
-            node.deinit(allocator);
+            node.release(allocator);
             allocator.destroy(node);
         }
 
@@ -5226,23 +5815,28 @@ test "[ImportSpecNode]" {
         try testing.expectEqual(@as(usize, 4), spec.items.?.items.len);
 
         // Verify first two items are functions
-        try testing.expect(spec.items.?.items[0].* == .function);
-        try testing.expectEqualStrings("map", spec.items.?.items[0].function.name);
-        try testing.expect(spec.items.?.items[0].function.alias == null);
-        try testing.expect(spec.items.?.items[1].* == .function);
-        try testing.expectEqualStrings("filter", spec.items.?.items[1].function.name);
-        try testing.expect(spec.items.?.items[1].function.alias == null);
+        const item1 = spec.items.?.items[0].inner;
+        try testing.expect(item1 == .function);
+        try testing.expectEqualStrings("map", item1.function.name);
+        try testing.expect(item1.function.alias == null);
+
+        const item2 = spec.items.?.items[1].inner;
+        try testing.expect(item2 == .function);
+        try testing.expectEqualStrings("filter", item2.function.name);
+        try testing.expect(item2.function.alias == null);
 
         // Verify last two items are types
-        try testing.expect(spec.items.?.items[2].* == .type);
-        try testing.expectEqualStrings("Maybe", spec.items.?.items[2].type.name);
-        try testing.expect(spec.items.?.items[2].type.alias == null);
-        try testing.expect(spec.items.?.items[2].type.expose_constructors == false);
+        const item3 = spec.items.?.items[2].inner;
+        try testing.expect(item3 == .type);
+        try testing.expectEqualStrings("Maybe", item3.type.name);
+        try testing.expect(item3.type.alias == null);
+        try testing.expect(item3.type.expose_constructors == false);
 
-        try testing.expect(spec.items.?.items[3].* == .type);
-        try testing.expectEqualStrings("Either", spec.items.?.items[3].type.name);
-        try testing.expect(spec.items.?.items[3].type.alias == null);
-        try testing.expect(spec.items.?.items[3].type.expose_constructors == true);
+        const item4 = spec.items.?.items[3].inner;
+        try testing.expect(item4 == .type);
+        try testing.expectEqualStrings("Either", item4.type.name);
+        try testing.expect(item4.type.alias == null);
+        try testing.expect(item4.type.expose_constructors == true);
     }
 
     {
@@ -5276,9 +5870,11 @@ test "[ImportSpecNode]" {
 
         const map_item = try allocator.create(ImportItem);
         map_item.* = .{
-            .function = .{
-                .name = try allocator.dupe(u8, "map"),
-                .alias = try allocator.dupe(u8, "list_map"),
+            .inner = .{
+                .function = .{
+                    .name = try allocator.dupe(u8, "map"),
+                    .alias = try allocator.dupe(u8, "list_map"),
+                },
             },
         };
 
@@ -5303,7 +5899,7 @@ test "[ImportSpecNode]" {
 
         const node = try allocator.create(Node);
         defer {
-            node.deinit(allocator);
+            node.release(allocator);
             allocator.destroy(node);
         }
 
@@ -5328,11 +5924,12 @@ test "[ImportSpecNode]" {
         try testing.expect(spec.alias == null);
 
         // Verify items list contains one item
-        try testing.expect(spec.items != null);
         try testing.expectEqual(@as(usize, 1), spec.items.?.items.len);
-        try testing.expect(spec.items.?.items[0].* == .function);
-        try testing.expectEqualStrings("map", spec.items.?.items[0].function.name);
-        try testing.expectEqualStrings("list_map", spec.items.?.items[0].function.alias.?);
+
+        const item1 = spec.items.?.items[0].inner;
+        try testing.expect(item1 == .function);
+        try testing.expectEqualStrings("map", item1.function.name);
+        try testing.expectEqualStrings("list_map", item1.function.alias.?);
     }
 
     {
@@ -5366,9 +5963,11 @@ test "[ImportSpecNode]" {
 
         const internal_func = try allocator.create(ImportItem);
         internal_func.* = .{
-            .function = .{
-                .name = try allocator.dupe(u8, "internal_func"),
-                .alias = null,
+            .inner = .{
+                .function = .{
+                    .name = try allocator.dupe(u8, "internal_func"),
+                    .alias = null,
+                },
             },
         };
 
@@ -5393,7 +5992,7 @@ test "[ImportSpecNode]" {
 
         const node = try allocator.create(Node);
         defer {
-            node.deinit(allocator);
+            node.release(allocator);
             allocator.destroy(node);
         }
 
@@ -5418,11 +6017,12 @@ test "[ImportSpecNode]" {
         try testing.expect(spec.alias == null);
 
         // Verify items list contains one item to hide
-        try testing.expect(spec.items != null);
         try testing.expectEqual(@as(usize, 1), spec.items.?.items.len);
-        try testing.expect(spec.items.?.items[0].* == .function);
-        try testing.expectEqualStrings("internal_func", spec.items.?.items[0].function.name);
-        try testing.expect(spec.items.?.items[0].function.alias == null);
+
+        const item1 = spec.items.?.items[0].inner;
+        try testing.expect(item1 == .function);
+        try testing.expectEqualStrings("internal_func", item1.function.name);
+        try testing.expect(item1.function.alias == null);
     }
 }
 
@@ -5451,6 +6051,8 @@ test "[IncludeNode]" {
         },
     };
 
+    try segments.append(std_ident);
+
     const list_ident = try allocator.create(UpperIdentifierNode);
     list_ident.* = .{
         .identifier = try allocator.dupe(u8, "List"),
@@ -5465,7 +6067,6 @@ test "[IncludeNode]" {
         },
     };
 
-    try segments.append(std_ident);
     try segments.append(list_ident);
 
     const path_node = try allocator.create(ModulePathNode);
@@ -5490,7 +6091,7 @@ test "[IncludeNode]" {
 
     const node = try allocator.create(Node);
     defer {
-        node.deinit(allocator);
+        node.release(allocator);
         allocator.destroy(node);
     }
 
@@ -5535,6 +6136,8 @@ test "[FunctionDeclNode]" {
         },
     };
 
+    var parameters = std.ArrayList(*ParamDeclNode).init(allocator);
+
     const x_ident = try allocator.create(LowerIdentifierNode);
     x_ident.* = .{
         .identifier = try allocator.dupe(u8, "x"),
@@ -5572,6 +6175,8 @@ test "[FunctionDeclNode]" {
         .type_annotation = x_type_node,
         .token = x_ident.token,
     };
+
+    try parameters.append(x_param);
 
     const y_ident = try allocator.create(LowerIdentifierNode);
     y_ident.* = .{
@@ -5611,8 +6216,6 @@ test "[FunctionDeclNode]" {
         .token = y_ident.token,
     };
 
-    var parameters = std.ArrayList(*ParamDeclNode).init(allocator);
-    try parameters.append(x_param);
     try parameters.append(y_param);
 
     const int_type3 = try allocator.create(UpperIdentifierNode);
@@ -5703,7 +6306,7 @@ test "[FunctionDeclNode]" {
 
     const node = try allocator.create(Node);
     defer {
-        node.deinit(allocator);
+        node.release(allocator);
         allocator.destroy(node);
     }
 
@@ -5767,6 +6370,8 @@ test "[ForeignFunctionDeclNode]" {
     const allocator = gpa.allocator();
 
     // Action
+    var parameters = std.ArrayList(*ParamDeclNode).init(allocator);
+
     const float_type1 = try allocator.create(UpperIdentifierNode);
     float_type1.* = .{
         .identifier = try allocator.dupe(u8, "Float"),
@@ -5813,7 +6418,6 @@ test "[ForeignFunctionDeclNode]" {
         },
     };
 
-    var parameters = std.ArrayList(*ParamDeclNode).init(allocator);
     try parameters.append(x_param);
 
     const float_type2 = try allocator.create(UpperIdentifierNode);
@@ -5880,7 +6484,7 @@ test "[ForeignFunctionDeclNode]" {
 
     const node = try allocator.create(Node);
     defer {
-        node.deinit(allocator);
+        node.release(allocator);
         allocator.destroy(node);
     }
 
@@ -6013,7 +6617,7 @@ test "[ModuleDeclNode]" {
 
     const node = try allocator.create(Node);
     defer {
-        node.deinit(allocator);
+        node.release(allocator);
         allocator.destroy(node);
     }
 
@@ -6045,6 +6649,8 @@ test "[ProgramNode]" {
     const allocator = gpa.allocator();
 
     // Action
+    var statements = std.ArrayList(*Node).init(allocator);
+
     const comment_node = try allocator.create(CommentNode);
     comment_node.* = .{
         .text = try allocator.dupe(u8, "program statement"),
@@ -6058,8 +6664,6 @@ test "[ProgramNode]" {
             },
         },
     };
-
-    var statements = std.ArrayList(*Node).init(allocator);
 
     const stmt = try allocator.create(Node);
     stmt.* = .{ .comment = comment_node };
@@ -6082,7 +6686,7 @@ test "[ProgramNode]" {
 
     const node = try allocator.create(Node);
     defer {
-        node.deinit(allocator);
+        node.release(allocator);
         allocator.destroy(node);
     }
 

--- a/compiler/frontend/ast_printer.zig
+++ b/compiler/frontend/ast_printer.zig
@@ -863,7 +863,7 @@ pub const AstPrinter = struct {
                     for (items.items) |item| {
                         try self.printIndent();
 
-                        switch (item.*) {
+                        switch (item.inner) {
                             .function => |f| {
                                 try self.writer.styled(term.Color.Bold, "Function");
                                 try self.writer.styled(term.Color.Dim, " {\n");
@@ -1173,7 +1173,7 @@ pub const AstPrinter = struct {
     }
 
     fn printPattern(self: *AstPrinter, pattern: *const ast.PatternNode) !void {
-        switch (pattern.*) {
+        switch (pattern.inner) {
             .wildcard => {
                 try self.writer.styled(term.Color.Bold, "WildcardPattern");
                 try self.writer.plain("(_)\n");

--- a/compiler/frontend/parser.zig
+++ b/compiler/frontend/parser.zig
@@ -411,7 +411,7 @@ pub const Parser = struct {
         var statements = std.ArrayList(*ast.Node).init(self.allocator);
         errdefer {
             for (statements.items) |item| {
-                item.rel(self.allocator);
+                item.release(self.allocator);
                 self.allocator.destroy(item);
             }
             statements.deinit();
@@ -800,64 +800,6 @@ pub const Parser = struct {
     fn parseTypeDecl(self: *Parser) ParserError!*ast.Node {
         const start_token = try self.expect(lexer.TokenKind{ .keyword = .Type });
 
-        // if (try self.match(lexer.TokenKind{ .keyword = .Alias })) {
-        //     const type_ident = try self.parseUpperIdentifier();
-        //     errdefer type_ident.release(self.allocator);
-
-        //     var type_params = std.ArrayList([]const u8).init(self.allocator);
-        //     errdefer {
-        //         for (type_params.items) |param| {
-        //             self.allocator.free(param);
-        //         }
-        //         type_params.deinit();
-        //     }
-
-        //     if (try self.match(lexer.TokenKind{ .delimiter = .LeftParen })) {
-        //         const param = try self.parseLowerIdentifier();
-        //         errdefer param.release(self.allocator);
-
-        //         try type_params.append(try self.allocator.dupe(u8, param.identifier));
-        //         param.release(self.allocator);
-
-        //         while (try self.match(lexer.TokenKind{ .delimiter = .Comma })) {
-        //             const next_param = try self.parseLowerIdentifier();
-        //             errdefer next_param.release(self.allocator);
-
-        //             try type_params.append(try self.allocator.dupe(u8, next_param.identifier));
-        //             next_param.release(self.allocator);
-        //         }
-
-        //         _ = try self.expect(lexer.TokenKind{ .delimiter = .RightParen });
-        //     }
-
-        //     _ = try self.expect(lexer.TokenKind{ .operator = .Equal });
-
-        //     const value = try self.parseTypeExpr();
-        //     errdefer {
-        //         value.release(self.allocator);
-        //         self.allocator.destroy(value);
-        //     }
-
-        //     const alias_node = try self.allocator.create(ast.TypeAliasNode);
-        //     errdefer alias_node.release(self.allocator);
-
-        //     alias_node.* = .{
-        //         .name = type_ident,
-        //         .type_params = type_params,
-        //         .value = value,
-        //         .token = start_token,
-        //     };
-
-        //     const node = try self.allocator.create(ast.Node);
-        //     errdefer {
-        //         node.release(self.allocator);
-        //         self.allocator.destroy(node);
-        //     }
-
-        //     node.* = .{ .type_alias = alias_node };
-
-        //     return node;
-        // }
         if (try self.match(lexer.TokenKind{ .keyword = .Alias })) {
             const type_ident = try self.parseUpperIdentifier();
             errdefer type_ident.release(self.allocator);
@@ -890,7 +832,6 @@ pub const Parser = struct {
 
             _ = try self.expect(lexer.TokenKind{ .operator = .Equal });
 
-            // Handle function type explicitly
             var parameter_types = std.ArrayList(*ast.Node).init(self.allocator);
             errdefer {
                 for (parameter_types.items) |param_type| {

--- a/compiler/frontend/parser.zig
+++ b/compiler/frontend/parser.zig
@@ -138,9 +138,9 @@ pub const Parser = struct {
     }
 
     pub fn init(allocator: std.mem.Allocator, l: *lexer.Lexer) !*Parser {
-        const parser = try allocator.create(Parser);
         const first_token = try l.nextToken();
 
+        const parser = try allocator.create(Parser);
         parser.* = .{
             .lexer = l,
             .current_token = first_token,
@@ -212,7 +212,7 @@ pub const Parser = struct {
 
         const node = try self.allocator.create(ast.LowerIdentifierNode);
         errdefer {
-            node.deinit(self.allocator);
+            node.release(self.allocator);
             self.allocator.destroy(node);
         }
 
@@ -230,7 +230,7 @@ pub const Parser = struct {
 
         const node = try self.allocator.create(ast.UpperIdentifierNode);
         errdefer {
-            node.deinit(self.allocator);
+            node.release(self.allocator);
             self.allocator.destroy(node);
         }
 
@@ -330,7 +330,7 @@ pub const Parser = struct {
 
         const node = try self.allocator.create(ast.StrLiteralNode);
         errdefer {
-            node.deinit(self.allocator);
+            node.release(self.allocator);
             self.allocator.destroy(node);
         }
 
@@ -411,10 +411,9 @@ pub const Parser = struct {
         var statements = std.ArrayList(*ast.Node).init(self.allocator);
         errdefer {
             for (statements.items) |item| {
-                item.deinit(self.allocator);
+                item.rel(self.allocator);
                 self.allocator.destroy(item);
             }
-
             statements.deinit();
         }
 
@@ -424,10 +423,7 @@ pub const Parser = struct {
         }
 
         const program_node = try self.allocator.create(ast.ProgramNode);
-        errdefer {
-            program_node.deinit(self.allocator);
-            self.allocator.destroy(program_node);
-        }
+        errdefer program_node.release(self.allocator);
 
         program_node.* = .{
             .statements = statements,
@@ -436,7 +432,7 @@ pub const Parser = struct {
 
         const node = try self.allocator.create(ast.Node);
         errdefer {
-            node.deinit(self.allocator);
+            node.release(self.allocator);
             self.allocator.destroy(node);
         }
 
@@ -477,14 +473,15 @@ pub const Parser = struct {
         const start_token = try self.expect(lexer.TokenKind{ .keyword = .Open });
 
         const path_node = try self.parseModulePath();
-        defer self.allocator.destroy(path_node);
+        const module_path = path_node.module_path;
+        self.allocator.destroy(path_node);
 
         var kind: ast.ImportKind = .Simple;
 
         var alias: ?*ast.UpperIdentifierNode = null;
         errdefer {
             if (alias) |a| {
-                a.deinit(self.allocator);
+                a.release(self.allocator);
             }
         }
 
@@ -492,13 +489,9 @@ pub const Parser = struct {
         errdefer {
             if (items) |*import_list| {
                 for (import_list.items) |item| {
-                    item.deinit(self.allocator);
-                    self.allocator.destroy(item);
+                    item.release(self.allocator);
                 }
-
                 import_list.deinit();
-
-                self.allocator.destroy(import_list);
             }
         }
 
@@ -522,10 +515,8 @@ pub const Parser = struct {
                     errdefer {
                         if (items) |*import_list| {
                             for (import_list.items) |item| {
-                                item.deinit(self.allocator);
-                                self.allocator.destroy(item);
+                                item.release(self.allocator);
                             }
-
                             import_list.deinit();
                         }
                     }
@@ -535,7 +526,7 @@ pub const Parser = struct {
                             .identifier => |ident| switch (ident) {
                                 .Lower => {
                                     const func = try self.parseLowerIdentifier();
-                                    defer func.deinit(self.allocator);
+                                    defer func.release(self.allocator);
 
                                     var func_alias: ?[]const u8 = null;
                                     errdefer {
@@ -546,21 +537,20 @@ pub const Parser = struct {
 
                                     if (try self.match(lexer.TokenKind{ .keyword = .As })) {
                                         const alias_ident = try self.parseLowerIdentifier();
-                                        defer alias_ident.deinit(self.allocator);
+                                        defer alias_ident.release(self.allocator);
 
                                         func_alias = try self.allocator.dupe(u8, alias_ident.identifier);
                                     }
 
                                     const import_item = try self.allocator.create(ast.ImportItem);
-                                    errdefer {
-                                        import_item.deinit(self.allocator);
-                                        self.allocator.destroy(import_item);
-                                    }
+                                    errdefer import_item.release(self.allocator);
 
                                     import_item.* = .{
-                                        .function = .{
-                                            .name = try self.allocator.dupe(u8, func.identifier),
-                                            .alias = func_alias,
+                                        .inner = .{
+                                            .function = .{
+                                                .name = try self.allocator.dupe(u8, func.identifier),
+                                                .alias = func_alias,
+                                            },
                                         },
                                     };
 
@@ -568,7 +558,7 @@ pub const Parser = struct {
                                 },
                                 .Upper => {
                                     const type_name = try self.parseUpperIdentifier();
-                                    defer type_name.deinit(self.allocator);
+                                    defer type_name.release(self.allocator);
 
                                     var expose_constructors = false;
 
@@ -587,22 +577,21 @@ pub const Parser = struct {
 
                                     if (try self.match(lexer.TokenKind{ .keyword = .As })) {
                                         const alias_ident = try self.parseUpperIdentifier();
-                                        defer alias_ident.deinit(self.allocator);
+                                        defer alias_ident.release(self.allocator);
 
                                         type_alias = try self.allocator.dupe(u8, alias_ident.identifier);
                                     }
 
                                     const import_item = try self.allocator.create(ast.ImportItem);
-                                    errdefer {
-                                        import_item.deinit(self.allocator);
-                                        self.allocator.destroy(import_item);
-                                    }
+                                    errdefer import_item.release(self.allocator);
 
                                     import_item.* = .{
-                                        .type = .{
-                                            .name = try self.allocator.dupe(u8, type_name.identifier),
-                                            .expose_constructors = expose_constructors,
-                                            .alias = type_alias,
+                                        .inner = .{
+                                            .type = .{
+                                                .name = try self.allocator.dupe(u8, type_name.identifier),
+                                                .expose_constructors = expose_constructors,
+                                                .alias = type_alias,
+                                            },
                                         },
                                     };
 
@@ -627,21 +616,20 @@ pub const Parser = struct {
 
                                     if (try self.match(lexer.TokenKind{ .keyword = .As })) {
                                         const alias_ident = try self.parseLowerIdentifier();
-                                        defer alias_ident.deinit(self.allocator);
+                                        defer alias_ident.release(self.allocator);
 
                                         op_alias = try self.allocator.dupe(u8, alias_ident.identifier);
                                     }
 
                                     const import_item = try self.allocator.create(ast.ImportItem);
-                                    errdefer {
-                                        import_item.deinit(self.allocator);
-                                        self.allocator.destroy(import_item);
-                                    }
+                                    errdefer import_item.release(self.allocator);
 
                                     import_item.* = .{
-                                        .operator = .{
-                                            .symbol = try self.allocator.dupe(u8, op),
-                                            .alias = op_alias,
+                                        .inner = .{
+                                            .operator = .{
+                                                .symbol = try self.allocator.dupe(u8, op),
+                                                .alias = op_alias,
+                                            },
                                         },
                                     };
 
@@ -677,13 +665,9 @@ pub const Parser = struct {
                     errdefer {
                         if (items) |*import_list| {
                             for (import_list.items) |item| {
-                                item.deinit(self.allocator);
-                                self.allocator.destroy(item);
+                                item.release(self.allocator);
                             }
-
                             import_list.deinit();
-
-                            self.allocator.destroy(import_list);
                         }
                     }
 
@@ -692,18 +676,17 @@ pub const Parser = struct {
                             .identifier => |ident| switch (ident) {
                                 .Lower => {
                                     const func = try self.parseLowerIdentifier();
-                                    defer func.deinit(self.allocator);
+                                    defer func.release(self.allocator);
 
                                     const import_item = try self.allocator.create(ast.ImportItem);
-                                    errdefer {
-                                        import_item.deinit(self.allocator);
-                                        self.allocator.destroy(import_item);
-                                    }
+                                    errdefer import_item.release(self.allocator);
 
                                     import_item.* = .{
-                                        .function = .{
-                                            .name = try self.allocator.dupe(u8, func.identifier),
-                                            .alias = null,
+                                        .inner = .{
+                                            .function = .{
+                                                .name = try self.allocator.dupe(u8, func.identifier),
+                                                .alias = null,
+                                            },
                                         },
                                     };
 
@@ -711,7 +694,7 @@ pub const Parser = struct {
                                 },
                                 .Upper => {
                                     const type_name = try self.parseUpperIdentifier();
-                                    defer type_name.deinit(self.allocator);
+                                    defer type_name.release(self.allocator);
 
                                     var expose_constructors = false;
 
@@ -722,16 +705,15 @@ pub const Parser = struct {
                                     }
 
                                     const import_item = try self.allocator.create(ast.ImportItem);
-                                    errdefer {
-                                        import_item.deinit(self.allocator);
-                                        self.allocator.destroy(import_item);
-                                    }
+                                    errdefer import_item.release(self.allocator);
 
                                     import_item.* = .{
-                                        .type = .{
-                                            .name = try self.allocator.dupe(u8, type_name.identifier),
-                                            .expose_constructors = expose_constructors,
-                                            .alias = null,
+                                        .inner = .{
+                                            .type = .{
+                                                .name = try self.allocator.dupe(u8, type_name.identifier),
+                                                .expose_constructors = expose_constructors,
+                                                .alias = null,
+                                            },
                                         },
                                     };
 
@@ -749,15 +731,14 @@ pub const Parser = struct {
                                     _ = try self.expect(lexer.TokenKind{ .delimiter = .RightParen });
 
                                     const import_item = try self.allocator.create(ast.ImportItem);
-                                    errdefer {
-                                        import_item.deinit(self.allocator);
-                                        self.allocator.destroy(import_item);
-                                    }
+                                    errdefer import_item.release(self.allocator);
 
                                     import_item.* = .{
-                                        .operator = .{
-                                            .symbol = try self.allocator.dupe(u8, op),
-                                            .alias = null,
+                                        .inner = .{
+                                            .operator = .{
+                                                .symbol = try self.allocator.dupe(u8, op),
+                                                .alias = null,
+                                            },
                                         },
                                     };
 
@@ -788,13 +769,10 @@ pub const Parser = struct {
         }
 
         const import_node = try self.allocator.create(ast.ImportSpecNode);
-        errdefer {
-            import_node.deinit(self.allocator);
-            self.allocator.destroy(import_node);
-        }
+        errdefer import_node.release(self.allocator);
 
         import_node.* = .{
-            .path = path_node.module_path,
+            .path = module_path,
             .kind = kind,
             .alias = alias,
             .items = items,
@@ -803,7 +781,7 @@ pub const Parser = struct {
 
         const node = try self.allocator.create(ast.Node);
         errdefer {
-            node.deinit(self.allocator);
+            node.release(self.allocator);
             self.allocator.destroy(node);
         }
 
@@ -822,32 +800,89 @@ pub const Parser = struct {
     fn parseTypeDecl(self: *Parser) ParserError!*ast.Node {
         const start_token = try self.expect(lexer.TokenKind{ .keyword = .Type });
 
+        // if (try self.match(lexer.TokenKind{ .keyword = .Alias })) {
+        //     const type_ident = try self.parseUpperIdentifier();
+        //     errdefer type_ident.release(self.allocator);
+
+        //     var type_params = std.ArrayList([]const u8).init(self.allocator);
+        //     errdefer {
+        //         for (type_params.items) |param| {
+        //             self.allocator.free(param);
+        //         }
+        //         type_params.deinit();
+        //     }
+
+        //     if (try self.match(lexer.TokenKind{ .delimiter = .LeftParen })) {
+        //         const param = try self.parseLowerIdentifier();
+        //         errdefer param.release(self.allocator);
+
+        //         try type_params.append(try self.allocator.dupe(u8, param.identifier));
+        //         param.release(self.allocator);
+
+        //         while (try self.match(lexer.TokenKind{ .delimiter = .Comma })) {
+        //             const next_param = try self.parseLowerIdentifier();
+        //             errdefer next_param.release(self.allocator);
+
+        //             try type_params.append(try self.allocator.dupe(u8, next_param.identifier));
+        //             next_param.release(self.allocator);
+        //         }
+
+        //         _ = try self.expect(lexer.TokenKind{ .delimiter = .RightParen });
+        //     }
+
+        //     _ = try self.expect(lexer.TokenKind{ .operator = .Equal });
+
+        //     const value = try self.parseTypeExpr();
+        //     errdefer {
+        //         value.release(self.allocator);
+        //         self.allocator.destroy(value);
+        //     }
+
+        //     const alias_node = try self.allocator.create(ast.TypeAliasNode);
+        //     errdefer alias_node.release(self.allocator);
+
+        //     alias_node.* = .{
+        //         .name = type_ident,
+        //         .type_params = type_params,
+        //         .value = value,
+        //         .token = start_token,
+        //     };
+
+        //     const node = try self.allocator.create(ast.Node);
+        //     errdefer {
+        //         node.release(self.allocator);
+        //         self.allocator.destroy(node);
+        //     }
+
+        //     node.* = .{ .type_alias = alias_node };
+
+        //     return node;
+        // }
         if (try self.match(lexer.TokenKind{ .keyword = .Alias })) {
             const type_ident = try self.parseUpperIdentifier();
-            errdefer type_ident.deinit(self.allocator);
+            errdefer type_ident.release(self.allocator);
 
             var type_params = std.ArrayList([]const u8).init(self.allocator);
             errdefer {
                 for (type_params.items) |param| {
                     self.allocator.free(param);
                 }
-
                 type_params.deinit();
             }
 
             if (try self.match(lexer.TokenKind{ .delimiter = .LeftParen })) {
                 const param = try self.parseLowerIdentifier();
-                errdefer param.deinit(self.allocator);
-                defer param.deinit(self.allocator);
+                errdefer param.release(self.allocator);
 
                 try type_params.append(try self.allocator.dupe(u8, param.identifier));
+                param.release(self.allocator);
 
                 while (try self.match(lexer.TokenKind{ .delimiter = .Comma })) {
                     const next_param = try self.parseLowerIdentifier();
-                    errdefer next_param.deinit(self.allocator);
-                    defer next_param.deinit(self.allocator);
+                    errdefer next_param.release(self.allocator);
 
                     try type_params.append(try self.allocator.dupe(u8, next_param.identifier));
+                    next_param.release(self.allocator);
                 }
 
                 _ = try self.expect(lexer.TokenKind{ .delimiter = .RightParen });
@@ -855,17 +890,87 @@ pub const Parser = struct {
 
             _ = try self.expect(lexer.TokenKind{ .operator = .Equal });
 
-            const value = try self.parseTypeExpr();
+            // Handle function type explicitly
+            var parameter_types = std.ArrayList(*ast.Node).init(self.allocator);
             errdefer {
-                value.deinit(self.allocator);
-                self.allocator.destroy(value);
+                for (parameter_types.items) |param_type| {
+                    param_type.release(self.allocator);
+                    self.allocator.destroy(param_type);
+                }
+                parameter_types.deinit();
+            }
+
+            if (try self.match(lexer.TokenKind{ .delimiter = .LeftParen })) {
+                const first_type = try self.parseSimpleType();
+                errdefer {
+                    first_type.release(self.allocator);
+                    self.allocator.destroy(first_type);
+                }
+
+                try parameter_types.append(first_type);
+
+                if (try self.match(lexer.TokenKind{ .delimiter = .Comma })) {
+                    while (true) {
+                        const next_type = try self.parseSimpleType();
+                        errdefer {
+                            next_type.release(self.allocator);
+                            self.allocator.destroy(next_type);
+                        }
+
+                        try parameter_types.append(next_type);
+
+                        if (!try self.match(lexer.TokenKind{ .delimiter = .Comma })) {
+                            break;
+                        }
+                    }
+                }
+
+                _ = try self.expect(lexer.TokenKind{ .delimiter = .RightParen });
+            } else {
+                const single_type = try self.parseSimpleType();
+                errdefer {
+                    single_type.release(self.allocator);
+                    self.allocator.destroy(single_type);
+                }
+
+                try parameter_types.append(single_type);
+            }
+
+            var value: *ast.Node = undefined;
+            if (try self.match(lexer.TokenKind{ .symbol = .ArrowRight })) {
+                const return_type = try self.parseTypeExpr();
+                errdefer {
+                    return_type.release(self.allocator);
+                    self.allocator.destroy(return_type);
+                }
+
+                const function_sig_node = try self.allocator.create(ast.FunctionSignatureNode);
+                errdefer function_sig_node.release(self.allocator);
+
+                function_sig_node.* = .{
+                    .parameter_types = parameter_types,
+                    .return_type = return_type,
+                    .token = start_token,
+                };
+
+                value = try self.allocator.create(ast.Node);
+                errdefer {
+                    value.release(self.allocator);
+                    self.allocator.destroy(value);
+                }
+
+                value.* = .{ .function_signature = function_sig_node };
+            } else {
+                if (parameter_types.items.len == 1) {
+                    value = parameter_types.items[0];
+                    parameter_types.deinit();
+                } else {
+                    return error.UnexpectedToken;
+                }
             }
 
             const alias_node = try self.allocator.create(ast.TypeAliasNode);
-            errdefer {
-                alias_node.deinit(self.allocator);
-                self.allocator.destroy(alias_node);
-            }
+            errdefer alias_node.release(self.allocator);
 
             alias_node.* = .{
                 .name = type_ident,
@@ -876,7 +981,7 @@ pub const Parser = struct {
 
             const node = try self.allocator.create(ast.Node);
             errdefer {
-                node.deinit(self.allocator);
+                node.release(self.allocator);
                 self.allocator.destroy(node);
             }
 
@@ -886,34 +991,34 @@ pub const Parser = struct {
         }
 
         const type_ident = try self.parseUpperIdentifier();
-        errdefer type_ident.deinit(self.allocator);
+        errdefer type_ident.release(self.allocator);
 
         var type_params = std.ArrayList([]const u8).init(self.allocator);
         errdefer {
             for (type_params.items) |param| {
                 self.allocator.free(param);
             }
-
             type_params.deinit();
         }
 
         if (try self.match(lexer.TokenKind{ .delimiter = .LeftParen })) {
             const param = try self.parseLowerIdentifier();
-            errdefer param.deinit(self.allocator);
+            errdefer param.release(self.allocator);
 
             try type_params.append(try self.allocator.dupe(u8, param.identifier));
+            param.release(self.allocator);
 
             while (try self.match(lexer.TokenKind{ .delimiter = .Comma })) {
                 const next_param = try self.parseLowerIdentifier();
-                errdefer next_param.deinit(self.allocator);
+                errdefer next_param.release(self.allocator);
 
                 try type_params.append(try self.allocator.dupe(u8, next_param.identifier));
-                next_param.deinit(self.allocator);
+                next_param.release(self.allocator);
             }
 
             _ = try self.expect(lexer.TokenKind{ .delimiter = .RightParen });
 
-            param.deinit(self.allocator);
+            param.release(self.allocator);
         }
 
         _ = try self.expect(lexer.TokenKind{ .operator = .Equal });
@@ -922,29 +1027,24 @@ pub const Parser = struct {
             var fields = std.ArrayList(*ast.RecordFieldNode).init(self.allocator);
             errdefer {
                 for (fields.items) |field| {
-                    field.deinit(self.allocator);
-                    self.allocator.destroy(field);
+                    field.release(self.allocator);
                 }
-
                 fields.deinit();
             }
 
             const first_field_name = try self.parseLowerIdentifier();
-            errdefer first_field_name.deinit(self.allocator);
+            errdefer first_field_name.release(self.allocator);
 
             _ = try self.expect(lexer.TokenKind{ .delimiter = .Colon });
 
             const first_field_type = try self.parseTypeExpr();
             errdefer {
-                first_field_type.deinit(self.allocator);
+                first_field_type.release(self.allocator);
                 self.allocator.destroy(first_field_type);
             }
 
             const first_field_node = try self.allocator.create(ast.RecordFieldNode);
-            errdefer {
-                first_field_node.deinit(self.allocator);
-                self.allocator.destroy(first_field_node);
-            }
+            errdefer first_field_node.release(self.allocator);
 
             first_field_node.* = .{
                 .name = first_field_name,
@@ -956,21 +1056,18 @@ pub const Parser = struct {
 
             while (try self.match(lexer.TokenKind{ .delimiter = .Comma })) {
                 const field_name = try self.parseLowerIdentifier();
-                errdefer field_name.deinit(self.allocator);
+                errdefer field_name.release(self.allocator);
 
                 _ = try self.expect(lexer.TokenKind{ .delimiter = .Colon });
 
                 const field_type = try self.parseTypeExpr();
                 errdefer {
-                    field_type.deinit(self.allocator);
+                    field_type.release(self.allocator);
                     self.allocator.destroy(field_type);
                 }
 
                 const field_node = try self.allocator.create(ast.RecordFieldNode);
-                errdefer {
-                    field_node.deinit(self.allocator);
-                    self.allocator.destroy(field_node);
-                }
+                errdefer field_node.release(self.allocator);
 
                 field_node.* = .{
                     .name = field_name,
@@ -984,10 +1081,7 @@ pub const Parser = struct {
             _ = try self.expect(lexer.TokenKind{ .delimiter = .RightBrace });
 
             const rtype_node = try self.allocator.create(ast.RecordTypeNode);
-            errdefer {
-                rtype_node.deinit(self.allocator);
-                self.allocator.destroy(rtype_node);
-            }
+            errdefer rtype_node.release(self.allocator);
 
             rtype_node.* = .{
                 .name = type_ident,
@@ -998,7 +1092,7 @@ pub const Parser = struct {
 
             const node = try self.allocator.create(ast.Node);
             errdefer {
-                node.deinit(self.allocator);
+                node.release(self.allocator);
                 self.allocator.destroy(node);
             }
 
@@ -1010,10 +1104,8 @@ pub const Parser = struct {
         var constructors = std.ArrayList(*ast.VariantConstructorNode).init(self.allocator);
         errdefer {
             for (constructors.items) |constructor| {
-                constructor.deinit(self.allocator);
-                self.allocator.destroy(constructor);
+                constructor.release(self.allocator);
             }
-
             constructors.deinit();
         }
 
@@ -1021,37 +1113,43 @@ pub const Parser = struct {
 
         while (true) {
             const constructor = try self.parseUpperIdentifier();
-            errdefer constructor.deinit(self.allocator);
+            errdefer constructor.release(self.allocator);
 
             var parameters = std.ArrayList(*ast.Node).init(self.allocator);
             errdefer {
                 for (parameters.items) |param| {
-                    param.deinit(self.allocator);
+                    param.release(self.allocator);
                     self.allocator.destroy(param);
                 }
-
                 parameters.deinit();
             }
 
-            while (!self.check(lexer.TokenKind{ .symbol = .Pipe }) and
-                !self.check(lexer.TokenKind{ .special = .Eof }) and
-                !self.check(lexer.TokenKind{ .keyword = .Foreign }) and
-                !self.check(lexer.TokenKind{ .keyword = .Include }) and
-                !self.check(lexer.TokenKind{ .keyword = .Let }) and
-                !self.check(lexer.TokenKind{ .comment = .Regular }) and
-                !self.check(lexer.TokenKind{ .comment = .Doc }) and
-                !self.check(lexer.TokenKind{ .keyword = .Type }))
-            {
-                const param = try self.parseTypeExpr();
+            // Check for parameters in parentheses
+            if (try self.match(lexer.TokenKind{ .delimiter = .LeftParen })) {
+                const first_param = try self.parseTypeExpr();
+                errdefer {
+                    first_param.release(self.allocator);
+                    self.allocator.destroy(first_param);
+                }
 
-                try parameters.append(param);
+                try parameters.append(first_param);
+
+                // Parse additional parameters separated by commas
+                while (try self.match(lexer.TokenKind{ .delimiter = .Comma })) {
+                    const next_param = try self.parseTypeExpr();
+                    errdefer {
+                        next_param.release(self.allocator);
+                        self.allocator.destroy(next_param);
+                    }
+
+                    try parameters.append(next_param);
+                }
+
+                _ = try self.expect(lexer.TokenKind{ .delimiter = .RightParen });
             }
 
             const constructor_node = try self.allocator.create(ast.VariantConstructorNode);
-            errdefer {
-                constructor_node.deinit(self.allocator);
-                self.allocator.destroy(constructor_node);
-            }
+            errdefer constructor_node.release(self.allocator);
 
             constructor_node.* = .{
                 .name = constructor,
@@ -1071,10 +1169,7 @@ pub const Parser = struct {
         }
 
         const vtype_node = try self.allocator.create(ast.VariantTypeNode);
-        errdefer {
-            vtype_node.deinit(self.allocator);
-            self.allocator.destroy(vtype_node);
-        }
+        errdefer vtype_node.release(self.allocator);
 
         vtype_node.* = .{
             .name = type_ident,
@@ -1085,7 +1180,7 @@ pub const Parser = struct {
 
         const node = try self.allocator.create(ast.Node);
         errdefer {
-            node.deinit(self.allocator);
+            node.release(self.allocator);
             self.allocator.destroy(node);
         }
 
@@ -1104,28 +1199,24 @@ pub const Parser = struct {
         const start_token = try self.expect(lexer.TokenKind{ .keyword = .Let });
 
         const fn_name = try self.parseLowerIdentifier();
-        errdefer fn_name.deinit(self.allocator);
+        errdefer fn_name.release(self.allocator);
 
         _ = try self.expect(lexer.TokenKind{ .delimiter = .LeftParen });
 
         var parameters = std.ArrayList(*ast.ParamDeclNode).init(self.allocator);
         errdefer {
             for (parameters.items) |param| {
-                param.deinit(self.allocator);
-                self.allocator.destroy(param);
+                param.release(self.allocator);
             }
-
             parameters.deinit();
         }
 
         if (!self.check(lexer.TokenKind{ .delimiter = .RightParen })) {
             const first_param = try self.parseParameter();
-
             try parameters.append(first_param);
 
             while (try self.match(lexer.TokenKind{ .delimiter = .Comma })) {
                 const next_param = try self.parseParameter();
-
                 try parameters.append(next_param);
             }
         }
@@ -1135,7 +1226,7 @@ pub const Parser = struct {
         var return_type: ?*ast.Node = null;
         errdefer {
             if (return_type) |rt| {
-                rt.deinit(self.allocator);
+                rt.release(self.allocator);
                 self.allocator.destroy(rt);
             }
         }
@@ -1151,16 +1242,10 @@ pub const Parser = struct {
         _ = try self.expect(lexer.TokenKind{ .operator = .Equal });
 
         const value = try self.parseExpression();
-        errdefer {
-            value.deinit(self.allocator);
-            self.allocator.destroy(value);
-        }
+        errdefer value.release(self.allocator);
 
         const func_decl_node = try self.allocator.create(ast.FunctionDeclNode);
-        errdefer {
-            func_decl_node.deinit(self.allocator);
-            self.allocator.destroy(func_decl_node);
-        }
+        errdefer func_decl_node.release(self.allocator);
 
         func_decl_node.* = .{
             .name = fn_name,
@@ -1192,28 +1277,24 @@ pub const Parser = struct {
         const start_token = try self.expect(lexer.TokenKind{ .keyword = .Foreign });
 
         const fn_name = try self.parseLowerIdentifier();
-        errdefer fn_name.deinit(self.allocator);
+        errdefer fn_name.release(self.allocator);
 
         _ = try self.expect(lexer.TokenKind{ .delimiter = .LeftParen });
 
         var parameters = std.ArrayList(*ast.ParamDeclNode).init(self.allocator);
         errdefer {
             for (parameters.items) |param| {
-                param.deinit(self.allocator);
-                self.allocator.destroy(param);
+                param.release(self.allocator);
             }
-
             parameters.deinit();
         }
 
         if (!self.check(lexer.TokenKind{ .delimiter = .RightParen })) {
             const first_param = try self.parseParameter();
-
             try parameters.append(first_param);
 
             while (try self.match(lexer.TokenKind{ .delimiter = .Comma })) {
                 const second_param = try self.parseParameter();
-
                 try parameters.append(second_param);
             }
         }
@@ -1223,10 +1304,7 @@ pub const Parser = struct {
         _ = try self.match(lexer.TokenKind{ .symbol = .ArrowRight });
 
         const return_type = try self.parseTypeExpr();
-        errdefer {
-            return_type.deinit(self.allocator);
-            self.allocator.destroy(return_type);
-        }
+        errdefer return_type.release(self.allocator);
 
         assert((return_type.* == .lower_identifier) or
             (return_type.* == .upper_identifier) or
@@ -1235,17 +1313,14 @@ pub const Parser = struct {
         _ = try self.expect(lexer.TokenKind{ .operator = .Equal });
 
         const external_name = try self.parseStrLiteral();
-        errdefer external_name.deinit(self.allocator);
+        errdefer external_name.release(self.allocator);
 
         if (external_name.value.len == 0) {
             return error.EmptyFFIReference;
         }
 
         const foreign_node = try self.allocator.create(ast.ForeignFunctionDeclNode);
-        errdefer {
-            foreign_node.deinit(self.allocator);
-            self.allocator.destroy(foreign_node);
-        }
+        errdefer foreign_node.release(self.allocator);
 
         foreign_node.* = .{
             .name = fn_name,
@@ -1257,7 +1332,7 @@ pub const Parser = struct {
 
         const node = try self.allocator.create(ast.Node);
         errdefer {
-            node.deinit(self.allocator);
+            node.release(self.allocator);
             self.allocator.destroy(node);
         }
 
@@ -1275,22 +1350,20 @@ pub const Parser = struct {
         const start_token = try self.expect(lexer.TokenKind{ .keyword = .Include });
 
         const path_node = try self.parseModulePath();
-        defer self.allocator.destroy(path_node);
+        const module_path = path_node.module_path;
+        self.allocator.destroy(path_node);
 
         const include_node = try self.allocator.create(ast.IncludeNode);
-        errdefer {
-            include_node.deinit(self.allocator);
-            self.allocator.destroy(include_node);
-        }
+        errdefer include_node.release(self.allocator);
 
         include_node.* = .{
-            .path = path_node.module_path,
+            .path = module_path,
             .token = start_token,
         };
 
         const node = try self.allocator.create(ast.Node);
         errdefer {
-            node.deinit(self.allocator);
+            node.release(self.allocator);
             self.allocator.destroy(node);
         }
 
@@ -1332,7 +1405,7 @@ pub const Parser = struct {
 
             const node = try self.allocator.create(ast.Node);
             errdefer {
-                node.deinit(self.allocator);
+                node.release(self.allocator);
                 self.allocator.destroy(node);
             }
 
@@ -1343,10 +1416,7 @@ pub const Parser = struct {
                         op == .IntDiv or op == .IntMul or op == .IntSub)
                     {
                         const arithmetic_node = try self.allocator.create(ast.ArithmeticExprNode);
-                        errdefer {
-                            arithmetic_node.deinit(self.allocator);
-                            self.allocator.destroy(arithmetic_node);
-                        }
+                        errdefer arithmetic_node.release(self.allocator);
 
                         arithmetic_node.* = .{
                             .left = left,
@@ -1357,10 +1427,7 @@ pub const Parser = struct {
                         node.* = .{ .arithmetic_expr = arithmetic_node };
                     } else if (op == .LogicalAnd or op == .LogicalOr) {
                         const logical_node = try self.allocator.create(ast.LogicalExprNode);
-                        errdefer {
-                            logical_node.deinit(self.allocator);
-                            self.allocator.destroy(logical_node);
-                        }
+                        errdefer logical_node.release(self.allocator);
 
                         logical_node.* = .{
                             .left = left,
@@ -1373,10 +1440,7 @@ pub const Parser = struct {
                         op == .LessThan or op == .LessThanEqual or op == .NotEqual)
                     {
                         const comparison_node = try self.allocator.create(ast.ComparisonExprNode);
-                        errdefer {
-                            comparison_node.deinit(self.allocator);
-                            self.allocator.destroy(comparison_node);
-                        }
+                        errdefer comparison_node.release(self.allocator);
 
                         comparison_node.* = .{
                             .left = left,
@@ -1387,10 +1451,7 @@ pub const Parser = struct {
                         node.* = .{ .comparison_expr = comparison_node };
                     } else if (op == .StrConcat) {
                         const str_concat_node = try self.allocator.create(ast.StrConcatExprNode);
-                        errdefer {
-                            str_concat_node.deinit(self.allocator);
-                            self.allocator.destroy(str_concat_node);
-                        }
+                        errdefer str_concat_node.release(self.allocator);
 
                         str_concat_node.* = .{
                             .left = left,
@@ -1401,10 +1462,7 @@ pub const Parser = struct {
                         node.* = .{ .str_concat_expr = str_concat_node };
                     } else if (op == .ListConcat) {
                         const list_concat_node = try self.allocator.create(ast.ListConcatExprNode);
-                        errdefer {
-                            list_concat_node.deinit(self.allocator);
-                            self.allocator.destroy(list_concat_node);
-                        }
+                        errdefer list_concat_node.release(self.allocator);
 
                         list_concat_node.* = .{
                             .left = left,
@@ -1415,10 +1473,7 @@ pub const Parser = struct {
                         node.* = .{ .list_concat_expr = list_concat_node };
                     } else if (op == .Cons) {
                         const cons_node = try self.allocator.create(ast.ConsExprNode);
-                        errdefer {
-                            cons_node.deinit(self.allocator);
-                            self.allocator.destroy(cons_node);
-                        }
+                        errdefer cons_node.release(self.allocator);
 
                         cons_node.* = .{
                             .head = left,
@@ -1456,10 +1511,7 @@ pub const Parser = struct {
             const operand = try self.parseSimpleExpr();
 
             const unary_node = try self.allocator.create(ast.UnaryExprNode);
-            errdefer {
-                unary_node.deinit(self.allocator);
-                self.allocator.destroy(unary_node);
-            }
+            errdefer unary_node.release(self.allocator);
 
             unary_node.* = .{
                 .operand = operand,
@@ -1468,7 +1520,7 @@ pub const Parser = struct {
 
             const node = try self.allocator.create(ast.Node);
             errdefer {
-                node.deinit(self.allocator);
+                node.release(self.allocator);
                 self.allocator.destroy(node);
             }
 
@@ -1479,7 +1531,7 @@ pub const Parser = struct {
 
         if (self.check(lexer.TokenKind{ .identifier = .Lower })) {
             const ident = try self.parseLowerIdentifier();
-            errdefer ident.deinit(self.allocator);
+            errdefer ident.release(self.allocator);
 
             if (self.check(lexer.TokenKind{ .delimiter = .LeftParen })) {
                 return self.parseFunctionCall(ident);
@@ -1487,7 +1539,7 @@ pub const Parser = struct {
 
             const node = try self.allocator.create(ast.Node);
             errdefer {
-                node.deinit(self.allocator);
+                node.release(self.allocator);
                 self.allocator.destroy(node);
             }
 
@@ -1511,10 +1563,9 @@ pub const Parser = struct {
         var arguments = std.ArrayList(*ast.Node).init(self.allocator);
         errdefer {
             for (arguments.items) |arg| {
-                arg.deinit(self.allocator);
+                arg.release(self.allocator);
                 self.allocator.destroy(arg);
             }
-
             arguments.deinit();
         }
 
@@ -1532,17 +1583,14 @@ pub const Parser = struct {
 
         const func_node = try self.allocator.create(ast.Node);
         errdefer {
-            func_node.deinit(self.allocator);
+            func_node.release(self.allocator);
             self.allocator.destroy(func_node);
         }
 
         func_node.* = .{ .lower_identifier = fn_name };
 
         const call_node = try self.allocator.create(ast.FunctionCallNode);
-        errdefer {
-            call_node.deinit(self.allocator);
-            self.allocator.destroy(call_node);
-        }
+        errdefer call_node.release(self.allocator);
 
         call_node.* = .{
             .function = func_node,
@@ -1552,7 +1600,7 @@ pub const Parser = struct {
 
         const node = try self.allocator.create(ast.Node);
         errdefer {
-            node.deinit(self.allocator);
+            node.release(self.allocator);
             self.allocator.destroy(node);
         }
 
@@ -1584,7 +1632,7 @@ pub const Parser = struct {
             .identifier => |ident| {
                 const node = try self.allocator.create(ast.Node);
                 errdefer {
-                    node.deinit(self.allocator);
+                    node.release(self.allocator);
                     self.allocator.destroy(node);
                 }
 
@@ -1610,7 +1658,10 @@ pub const Parser = struct {
             },
             .literal => |lit| {
                 const node = try self.allocator.create(ast.Node);
-                errdefer node.deinit(self.allocator);
+                errdefer {
+                    node.release(self.allocator);
+                    self.allocator.destroy(node);
+                }
 
                 switch (lit) {
                     .Char => {
@@ -1655,20 +1706,17 @@ pub const Parser = struct {
         var parameters = std.ArrayList(*ast.ParamDeclNode).init(self.allocator);
         errdefer {
             for (parameters.items) |param| {
-                param.deinit(self.allocator);
+                param.release(self.allocator);
             }
-
             parameters.deinit();
         }
 
         if (!self.check(lexer.TokenKind{ .delimiter = .RightParen })) {
             const first_param = try self.parseParameter();
-
             try parameters.append(first_param);
 
             while (try self.match(lexer.TokenKind{ .delimiter = .Comma })) {
                 const next_param = try self.parseParameter();
-
                 try parameters.append(next_param);
             }
         }
@@ -1678,7 +1726,7 @@ pub const Parser = struct {
         var return_type: ?*ast.Node = null;
         errdefer {
             if (return_type) |rt| {
-                rt.deinit(self.allocator);
+                rt.release(self.allocator);
                 self.allocator.destroy(rt);
             }
         }
@@ -1690,16 +1738,10 @@ pub const Parser = struct {
         _ = try self.expect(lexer.TokenKind{ .symbol = .DoubleArrowRight });
 
         const body = try self.parseExpression();
-        errdefer {
-            body.deinit(self.allocator);
-            self.allocator.destroy(body);
-        }
+        errdefer body.release(self.allocator);
 
         const lambda_node = try self.allocator.create(ast.LambdaExprNode);
-        errdefer {
-            lambda_node.deinit(self.allocator);
-            self.allocator.destroy(lambda_node);
-        }
+        errdefer lambda_node.release(self.allocator);
 
         lambda_node.* = .{
             .parameters = parameters,
@@ -1710,7 +1752,7 @@ pub const Parser = struct {
 
         const node = try self.allocator.create(ast.Node);
         errdefer {
-            node.deinit(self.allocator);
+            node.release(self.allocator);
             self.allocator.destroy(node);
         }
 
@@ -1724,12 +1766,12 @@ pub const Parser = struct {
         const param_token = self.current_token;
 
         const name = try self.parseLowerIdentifier();
-        errdefer name.deinit(self.allocator);
+        errdefer name.release(self.allocator);
 
         var type_annotation: ?*ast.Node = null;
         errdefer {
             if (type_annotation) |t| {
-                t.deinit(self.allocator);
+                t.release(self.allocator);
                 self.allocator.destroy(t);
             }
         }
@@ -1740,7 +1782,7 @@ pub const Parser = struct {
 
         const node = try self.allocator.create(ast.ParamDeclNode);
         errdefer {
-            node.deinit(self.allocator);
+            node.release(self.allocator);
             self.allocator.destroy(node);
         }
 
@@ -1766,19 +1808,15 @@ pub const Parser = struct {
         var elements = std.ArrayList(*ast.Node).init(self.allocator);
         errdefer {
             for (elements.items) |elem| {
-                elem.deinit(self.allocator);
+                elem.release(self.allocator);
                 self.allocator.destroy(elem);
             }
-
             elements.deinit();
         }
 
         if (try self.match(lexer.TokenKind{ .delimiter = .RightBracket })) {
             const empty_list = try self.allocator.create(ast.ListNode);
-            errdefer {
-                empty_list.deinit(self.allocator);
-                self.allocator.destroy(empty_list);
-            }
+            errdefer empty_list.release(self.allocator);
 
             empty_list.* = .{
                 .elements = elements,
@@ -1787,7 +1825,7 @@ pub const Parser = struct {
 
             const node = try self.allocator.create(ast.Node);
             errdefer {
-                node.deinit(self.allocator);
+                node.release(self.allocator);
                 self.allocator.destroy(node);
             }
 
@@ -1807,10 +1845,7 @@ pub const Parser = struct {
         _ = try self.expect(lexer.TokenKind{ .delimiter = .RightBracket });
 
         const list_node = try self.allocator.create(ast.ListNode);
-        errdefer {
-            list_node.deinit(self.allocator);
-            self.allocator.destroy(list_node);
-        }
+        errdefer list_node.release(self.allocator);
 
         list_node.* = .{
             .elements = elements,
@@ -1819,7 +1854,7 @@ pub const Parser = struct {
 
         const node = try self.allocator.create(ast.Node);
         errdefer {
-            node.deinit(self.allocator);
+            node.release(self.allocator);
             self.allocator.destroy(node);
         }
 
@@ -1840,28 +1875,21 @@ pub const Parser = struct {
         var elements = std.ArrayList(*ast.Node).init(self.allocator);
         errdefer {
             for (elements.items) |elem| {
-                elem.deinit(self.allocator);
+                elem.release(self.allocator);
                 self.allocator.destroy(elem);
             }
-
             elements.deinit();
         }
 
         const first = try self.parseSimpleExpr();
-        errdefer {
-            first.deinit(self.allocator);
-            self.allocator.destroy(first);
-        }
+        errdefer first.release(self.allocator);
 
         try elements.append(first);
 
         _ = try self.match(lexer.TokenKind{ .delimiter = .Comma });
 
         const second = try self.parseSimpleExpr();
-        errdefer {
-            second.deinit(self.allocator);
-            self.allocator.destroy(second);
-        }
+        errdefer second.release(self.allocator);
 
         try elements.append(second);
 
@@ -1870,10 +1898,7 @@ pub const Parser = struct {
         assert(elements.items.len == 2);
 
         const tuple_node = try self.allocator.create(ast.TupleNode);
-        errdefer {
-            tuple_node.deinit(self.allocator);
-            self.allocator.destroy(tuple_node);
-        }
+        errdefer tuple_node.release(self.allocator);
 
         tuple_node.* = .{
             .elements = elements,
@@ -1882,7 +1907,7 @@ pub const Parser = struct {
 
         const node = try self.allocator.create(ast.Node);
         errdefer {
-            node.deinit(self.allocator);
+            node.release(self.allocator);
             self.allocator.destroy(node);
         }
 
@@ -1914,32 +1939,20 @@ pub const Parser = struct {
         const start_token = try self.expect(lexer.TokenKind{ .keyword = .If });
 
         const condition = try self.parseExpression();
-        errdefer {
-            condition.deinit(self.allocator);
-            self.allocator.destroy(condition);
-        }
+        errdefer condition.release(self.allocator);
 
         _ = try self.expect(lexer.TokenKind{ .keyword = .Then });
 
         const then_branch = try self.parseExpression();
-        errdefer {
-            then_branch.deinit(self.allocator);
-            self.allocator.destroy(then_branch);
-        }
+        errdefer then_branch.release(self.allocator);
 
         _ = try self.expect(lexer.TokenKind{ .keyword = .Else });
 
         const else_branch = try self.parseExpression();
-        errdefer {
-            else_branch.deinit(self.allocator);
-            self.allocator.destroy(else_branch);
-        }
+        errdefer else_branch.release(self.allocator);
 
         const if_node = try self.allocator.create(ast.IfThenElseStmtNode);
-        errdefer {
-            if_node.deinit(self.allocator);
-            self.allocator.destroy(if_node);
-        }
+        errdefer if_node.release(self.allocator);
 
         if_node.* = .{
             .condition = condition,
@@ -1950,7 +1963,7 @@ pub const Parser = struct {
 
         const node = try self.allocator.create(ast.Node);
         errdefer {
-            node.deinit(self.allocator);
+            node.release(self.allocator);
             self.allocator.destroy(node);
         }
 
@@ -1966,58 +1979,94 @@ pub const Parser = struct {
     /// - `Int`
     /// - `Maybe(a)`
     /// - `List(String)`
+    // fn parseTypeExpr(self: *Parser) ParserError!*ast.Node {
+    //     const start_token = self.current_token;
+
+    //     var parameter_types = std.ArrayList(*ast.Node).init(self.allocator);
+    //     errdefer {
+    //         for (parameter_types.items) |param_type| {
+    //             param_type.release(self.allocator);
+    //             self.allocator.destroy(param_type);
+    //         }
+    //         parameter_types.deinit();
+    //     }
+
+    //     // Handle parenthesized parameter list: (a, b)
+    //     if (try self.match(lexer.TokenKind{ .delimiter = .LeftParen })) {
+    //         const first_type = try self.parseSimpleType();
+    //         errdefer {
+    //             first_type.release(self.allocator);
+    //             self.allocator.destroy(first_type);
+    //         }
+
+    //         try parameter_types.append(first_type);
+
+    //         if (try self.match(lexer.TokenKind{ .delimiter = .Comma })) {
+    //             while (true) {
+    //                 const next_type = try self.parseSimpleType();
+    //                 errdefer {
+    //                     next_type.release(self.allocator);
+    //                     self.allocator.destroy(next_type);
+    //                 }
+
+    //                 try parameter_types.append(next_type);
+
+    //                 if (!try self.match(lexer.TokenKind{ .delimiter = .Comma })) {
+    //                     break;
+    //                 }
+    //             }
+    //         }
+
+    //         _ = try self.expect(lexer.TokenKind{ .delimiter = .RightParen });
+    //     } else {
+    //         const single_type = try self.parseSimpleType();
+    //         errdefer {
+    //             single_type.release(self.allocator);
+    //             self.allocator.destroy(single_type);
+    //         }
+
+    //         try parameter_types.append(single_type);
+    //     }
+
+    //     if (!try self.match(lexer.TokenKind{ .symbol = .ArrowRight })) {
+    //         if (parameter_types.items.len == 1) {
+    //             const result = parameter_types.items[0];
+    //             parameter_types.deinit();
+
+    //             return result;
+    //         }
+
+    //         // For now, error if multiple types without arrow (future tuple support)
+    //         return error.UnexpectedToken;
+    //     }
+
+    //     const return_type = try self.parseTypeExpr();
+    //     errdefer {
+    //         return_type.release(self.allocator);
+    //         self.allocator.destroy(return_type);
+    //     }
+
+    //     const function_sig_node = try self.allocator.create(ast.FunctionSignatureNode);
+    //     errdefer function_sig_node.release(self.allocator);
+
+    //     function_sig_node.* = .{
+    //         .parameter_types = parameter_types,
+    //         .return_type = return_type,
+    //         .token = start_token,
+    //     };
+
+    //     const node = try self.allocator.create(ast.Node);
+    //     errdefer {
+    //         node.release(self.allocator);
+    //         self.allocator.destroy(node);
+    //     }
+
+    //     node.* = .{ .function_signature = function_sig_node };
+
+    //     return node;
+    // }
     fn parseTypeExpr(self: *Parser) ParserError!*ast.Node {
-        const start_token = self.current_token;
-
-        const first_type = try self.parseSimpleType();
-        errdefer {
-            first_type.deinit(self.allocator);
-            self.allocator.destroy(first_type);
-        }
-
-        if (!try self.match(lexer.TokenKind{ .symbol = .ArrowRight })) {
-            return first_type;
-        }
-
-        var parameter_types = std.ArrayList(*ast.Node).init(self.allocator);
-        errdefer {
-            for (parameter_types.items) |param_type| {
-                param_type.deinit(self.allocator);
-                self.allocator.destroy(param_type);
-            }
-
-            parameter_types.deinit();
-        }
-
-        try parameter_types.append(first_type);
-
-        const return_type = try self.parseTypeExpr();
-        errdefer {
-            return_type.deinit(self.allocator);
-            self.allocator.destroy(return_type);
-        }
-
-        const function_sig_node = try self.allocator.create(ast.FunctionSignatureNode);
-        errdefer {
-            function_sig_node.deinit(self.allocator);
-            self.allocator.destroy(function_sig_node);
-        }
-
-        function_sig_node.* = .{
-            .parameter_types = parameter_types,
-            .return_type = return_type,
-            .token = start_token,
-        };
-
-        const node = try self.allocator.create(ast.Node);
-        errdefer {
-            node.deinit(self.allocator);
-            self.allocator.destroy(node);
-        }
-
-        node.* = .{ .function_signature = function_sig_node };
-
-        return node;
+        return try self.parseSimpleType();
     }
 
     /// Helper function to parse non-function types.
@@ -2026,25 +2075,21 @@ pub const Parser = struct {
             const start_token = self.current_token;
 
             const type_name = try self.parseUpperIdentifier();
-            errdefer {
-                type_name.deinit(self.allocator);
-                self.allocator.destroy(type_name);
-            }
+            errdefer type_name.release(self.allocator);
 
             var type_args = std.ArrayList(*ast.Node).init(self.allocator);
             errdefer {
                 for (type_args.items) |t| {
-                    t.deinit(self.allocator);
+                    t.release(self.allocator);
                     self.allocator.destroy(t);
                 }
-
                 type_args.deinit();
             }
 
             if (try self.match(lexer.TokenKind{ .delimiter = .LeftParen })) {
                 const first_arg = try self.parseTypeExpr();
                 errdefer {
-                    first_arg.deinit(self.allocator);
+                    first_arg.release(self.allocator);
                     self.allocator.destroy(first_arg);
                 }
 
@@ -2053,7 +2098,7 @@ pub const Parser = struct {
                 while (try self.match(lexer.TokenKind{ .delimiter = .Comma })) {
                     const next_arg = try self.parseTypeExpr();
                     errdefer {
-                        next_arg.deinit(self.allocator);
+                        next_arg.release(self.allocator);
                         self.allocator.destroy(next_arg);
                     }
 
@@ -2063,10 +2108,7 @@ pub const Parser = struct {
                 _ = try self.expect(lexer.TokenKind{ .delimiter = .RightParen });
 
                 const type_app_node = try self.allocator.create(ast.TypeApplicationNode);
-                errdefer {
-                    type_app_node.deinit(self.allocator);
-                    self.allocator.destroy(type_app_node);
-                }
+                errdefer type_app_node.release(self.allocator);
 
                 type_app_node.* = .{
                     .constructor = type_name,
@@ -2076,7 +2118,7 @@ pub const Parser = struct {
 
                 const node = try self.allocator.create(ast.Node);
                 errdefer {
-                    node.deinit(self.allocator);
+                    node.release(self.allocator);
                     self.allocator.destroy(node);
                 }
 
@@ -2087,7 +2129,7 @@ pub const Parser = struct {
 
             const node = try self.allocator.create(ast.Node);
             errdefer {
-                node.deinit(self.allocator);
+                node.release(self.allocator);
                 self.allocator.destroy(node);
             }
 
@@ -2098,14 +2140,11 @@ pub const Parser = struct {
 
         if (self.check(lexer.TokenKind{ .identifier = .Lower })) {
             const type_var = try self.parseLowerIdentifier();
-            errdefer {
-                type_var.deinit(self.allocator);
-                self.allocator.destroy(type_var);
-            }
+            errdefer type_var.release(self.allocator);
 
             const node = try self.allocator.create(ast.Node);
             errdefer {
-                node.deinit(self.allocator);
+                node.release(self.allocator);
                 self.allocator.destroy(node);
             }
 
@@ -2118,15 +2157,15 @@ pub const Parser = struct {
             var types = std.ArrayList(*ast.Node).init(self.allocator);
             errdefer {
                 for (types.items) |t| {
-                    t.deinit(self.allocator);
+                    t.release(self.allocator);
+                    self.allocator.destroy(t);
                 }
-
                 types.deinit();
             }
 
             const first_type = try self.parseTypeExpr();
             errdefer {
-                first_type.deinit(self.allocator);
+                first_type.release(self.allocator);
                 self.allocator.destroy(first_type);
             }
 
@@ -2136,7 +2175,7 @@ pub const Parser = struct {
                 while (true) {
                     const next_type = try self.parseTypeExpr();
                     errdefer {
-                        next_type.deinit(self.allocator);
+                        next_type.release(self.allocator);
                         self.allocator.destroy(next_type);
                     }
 
@@ -2152,11 +2191,11 @@ pub const Parser = struct {
 
             if (types.items.len > 1) {
                 const result = types.items[0]; // Temporary logic, need to properly handle function param lists
-                // for (types.items[1..]) |t| {
-                // t.deinit(self.allocator);
-                // self.allocator.destroy(t);
-                // }
 
+                for (types.items[1..]) |t| {
+                    t.release(self.allocator);
+                    self.allocator.destroy(t);
+                }
                 types.deinit();
 
                 return result;
@@ -2165,11 +2204,6 @@ pub const Parser = struct {
             // For a single parenthesized type, just return the inner type
             const result = types.items[0];
             types.deinit();
-            // for (types.items) |t| {
-            //     t.deinit(self.allocator);
-            //     self.allocator.destroy(t);
-            // }
-            // types.deinit();
 
             return result;
         }
@@ -2177,7 +2211,7 @@ pub const Parser = struct {
         if (try self.match(lexer.TokenKind{ .special = .Hole })) {
             const node = try self.allocator.create(ast.Node);
             errdefer {
-                node.deinit(self.allocator);
+                node.release(self.allocator);
                 self.allocator.destroy(node);
             }
 
@@ -2203,27 +2237,21 @@ pub const Parser = struct {
         var segments = std.ArrayList(*ast.UpperIdentifierNode).init(self.allocator);
         errdefer {
             for (segments.items) |segment| {
-                segment.deinit(self.allocator);
+                segment.release(self.allocator);
             }
-
             segments.deinit();
         }
 
         const first_segment = try self.parseUpperIdentifier();
-
         try segments.append(first_segment);
 
         while (try self.match(lexer.TokenKind{ .delimiter = .Dot })) {
             const next_segment = try self.parseUpperIdentifier();
-
             try segments.append(next_segment);
         }
 
         const path_node = try self.allocator.create(ast.ModulePathNode);
-        errdefer {
-            path_node.deinit(self.allocator);
-            self.allocator.destroy(path_node);
-        }
+        errdefer path_node.release(self.allocator);
 
         path_node.* = .{
             .segments = segments,
@@ -2232,7 +2260,7 @@ pub const Parser = struct {
 
         const node = try self.allocator.create(ast.Node);
         errdefer {
-            node.deinit(self.allocator);
+            node.release(self.allocator);
             self.allocator.destroy(node);
         }
 
@@ -2254,10 +2282,7 @@ pub const Parser = struct {
         const trimmed = std.mem.trimRight(u8, start_token.lexeme[i..], &std.ascii.whitespace);
 
         const comment_node = try self.allocator.create(ast.CommentNode);
-        errdefer {
-            comment_node.deinit(self.allocator);
-            self.allocator.destroy(comment_node);
-        }
+        errdefer comment_node.release(self.allocator);
 
         comment_node.* = .{
             .text = try self.allocator.dupe(u8, trimmed),
@@ -2266,7 +2291,7 @@ pub const Parser = struct {
 
         const node = try self.allocator.create(ast.Node);
         errdefer {
-            node.deinit(self.allocator);
+            node.release(self.allocator);
             self.allocator.destroy(node);
         }
 
@@ -2288,10 +2313,7 @@ pub const Parser = struct {
         const trimmed = std.mem.trimRight(u8, start_token.lexeme[i..], &std.ascii.whitespace);
 
         const comment_node = try self.allocator.create(ast.DocCommentNode);
-        errdefer {
-            comment_node.deinit(self.allocator);
-            self.allocator.destroy(comment_node);
-        }
+        errdefer comment_node.release(self.allocator);
 
         comment_node.* = .{
             .text = try self.allocator.dupe(u8, trimmed),
@@ -2300,7 +2322,7 @@ pub const Parser = struct {
 
         const node = try self.allocator.create(ast.Node);
         errdefer {
-            node.deinit(self.allocator);
+            node.release(self.allocator);
             self.allocator.destroy(node);
         }
 
@@ -2329,7 +2351,7 @@ test "[comment]" {
         // Action
         const node = try parser.parseComment();
         defer {
-            node.deinit(allocator);
+            node.release(allocator);
             allocator.destroy(node);
         }
 
@@ -2362,7 +2384,7 @@ test "[doc_comment]" {
         // Action
         const node = try parser.parseDocComment();
         defer {
-            node.deinit(allocator);
+            node.release(allocator);
             allocator.destroy(node);
         }
 
@@ -2581,7 +2603,7 @@ test "[str_literal]" {
 
         // Action
         const literal = try parser.parseStrLiteral();
-        defer literal.deinit(allocator);
+        defer literal.release(allocator);
 
         // Assertions
         // Validate the literal token and its properties
@@ -2622,7 +2644,7 @@ test "[lower_identifier]" {
 
         // Action
         const ident = try parser.parseLowerIdentifier();
-        defer ident.deinit(allocator);
+        defer ident.release(allocator);
 
         // Assertions
         // Verify the token is recognized as a lower identifier
@@ -2662,7 +2684,7 @@ test "[upper_identifier]" {
 
         // Action
         const ident = try parser.parseUpperIdentifier();
-        defer ident.deinit(allocator);
+        defer ident.release(allocator);
 
         // Assertions
         // Verify the token is recognized as an upper identifier
@@ -2691,7 +2713,7 @@ test "[unary_expr]" {
         // Action
         const expr = try parser.parseSimpleExpr();
         defer {
-            expr.deinit(allocator);
+            expr.release(allocator);
             allocator.destroy(expr);
         }
 
@@ -2728,7 +2750,7 @@ test "[arithmetic_expr]" {
         // Action
         const expr = try parser.parseExpression();
         defer {
-            expr.deinit(allocator);
+            expr.release(allocator);
             allocator.destroy(expr);
         }
 
@@ -2817,7 +2839,7 @@ test "[comparison_expr]" {
         // Action
         const expr = try parser.parseExpression();
         defer {
-            expr.deinit(allocator);
+            expr.release(allocator);
             allocator.destroy(expr);
         }
 
@@ -2876,7 +2898,7 @@ test "[logical_expr]" {
         // Action
         const expr = try parser.parseExpression();
         defer {
-            expr.deinit(allocator);
+            expr.release(allocator);
             allocator.destroy(expr);
         }
 
@@ -2920,7 +2942,7 @@ test "[cons_expr]" {
         // Action
         const node = try parser.parseExpression();
         defer {
-            node.deinit(allocator);
+            node.release(allocator);
             allocator.destroy(node);
         }
 
@@ -3038,7 +3060,7 @@ test "[operator precedence]" {
         // Action
         const expr = try parser.parseExpression();
         defer {
-            expr.deinit(allocator);
+            expr.release(allocator);
             allocator.destroy(expr);
         }
 
@@ -3079,7 +3101,7 @@ test "[operator precedence] (structural)" {
         // Action
         const expr = try parser.parseExpression();
         defer {
-            expr.deinit(allocator);
+            expr.release(allocator);
             allocator.destroy(expr);
         }
 
@@ -3124,7 +3146,7 @@ test "[operator precedence] (structural)" {
         // Action
         const expr = try parser.parseExpression();
         defer {
-            expr.deinit(allocator);
+            expr.release(allocator);
             allocator.destroy(expr);
         }
 
@@ -3188,7 +3210,7 @@ test "[lambda_expr]" {
         // Action
         const node = try parser.parseExpression();
         defer {
-            node.deinit(allocator);
+            node.release(allocator);
             allocator.destroy(node);
         }
 
@@ -3220,7 +3242,7 @@ test "[lambda_expr]" {
         // Action
         const node = try parser.parseExpression();
         defer {
-            node.deinit(allocator);
+            node.release(allocator);
             allocator.destroy(node);
         }
 
@@ -3258,7 +3280,7 @@ test "[lambda_expr]" {
         // Action
         const node = try parser.parseExpression();
         defer {
-            node.deinit(allocator);
+            node.release(allocator);
             allocator.destroy(node);
         }
 
@@ -3313,7 +3335,7 @@ test "[if_then_else_stmt]" {
         // Action
         const node = try parser.parseIfThenElse();
         defer {
-            node.deinit(allocator);
+            node.release(allocator);
             allocator.destroy(node);
         }
 
@@ -3373,7 +3395,7 @@ test "[function_decl]" {
         // Action
         const node = try parser.parseFunctionDecl();
         defer {
-            node.deinit(allocator);
+            node.release(allocator);
             allocator.destroy(node);
         }
 
@@ -3430,7 +3452,7 @@ test "[function_decl]" {
         // Action
         const node = try parser.parseFunctionDecl();
         defer {
-            node.deinit(allocator);
+            node.release(allocator);
             allocator.destroy(node);
         }
 
@@ -3487,7 +3509,7 @@ test "[function_decl]" {
         // Action
         const node = try parser.parseFunctionDecl();
         defer {
-            node.deinit(allocator);
+            node.release(allocator);
             allocator.destroy(node);
         }
 
@@ -3538,7 +3560,7 @@ test "[function_call]" {
         // Action
         const node = try parser.parseSimpleExpr();
         defer {
-            node.deinit(allocator);
+            node.release(allocator);
             allocator.destroy(node);
         }
 
@@ -3577,7 +3599,7 @@ test "[foreign_function_decl]" {
         // Action
         const node = try parser.parseForeignFunctionDecl();
         defer {
-            node.deinit(allocator);
+            node.release(allocator);
             allocator.destroy(node);
         }
 
@@ -3624,8 +3646,7 @@ test "[module_path]" {
         // Action
         const node = try parser.parseModulePath();
         defer {
-            node.deinit(allocator);
-            allocator.destroy(node.module_path);
+            node.release(allocator);
             allocator.destroy(node);
         }
 
@@ -3659,7 +3680,7 @@ test "[include]" {
         // Action
         const node = try parser.parseInclude();
         defer {
-            node.deinit(allocator);
+            node.release(allocator);
             allocator.destroy(node);
         }
 
@@ -3694,7 +3715,7 @@ test "[import_spec]" {
         // Action
         const node = try parser.parseImportSpec();
         defer {
-            node.deinit(allocator);
+            node.release(allocator);
             allocator.destroy(node);
         }
 
@@ -3734,7 +3755,7 @@ test "[import_spec]" {
         // Action
         const node = try parser.parseImportSpec();
         defer {
-            node.deinit(allocator);
+            node.release(allocator);
             allocator.destroy(node);
         }
 
@@ -3777,7 +3798,7 @@ test "[import_spec]" {
         // Action
         const node = try parser.parseImportSpec();
         defer {
-            node.deinit(allocator);
+            node.release(allocator);
             allocator.destroy(node);
         }
 
@@ -3804,31 +3825,27 @@ test "[import_spec]" {
         try testing.expect(import_spec.items.?.items.len == 4);
 
         // Check first function import (map)
-        const item1 = import_spec.items.?.items[0];
-
-        try testing.expect(item1.* == .function);
+        const item1 = import_spec.items.?.items[0].inner;
+        try testing.expect(item1 == .function);
         try testing.expectEqualStrings("map", item1.function.name);
         try testing.expect(item1.function.alias == null);
 
         // Check second function import (filter)
-        const item2 = import_spec.items.?.items[1];
-
-        try testing.expect(item2.* == .function);
+        const item2 = import_spec.items.?.items[1].inner;
+        try testing.expect(item2 == .function);
         try testing.expectEqualStrings("filter", item2.function.name);
         try testing.expect(item2.function.alias == null);
 
         // Check first type import (Maybe without constructors)
-        const item3 = import_spec.items.?.items[2];
-
-        try testing.expect(item3.* == .type);
+        const item3 = import_spec.items.?.items[2].inner;
+        try testing.expect(item3 == .type);
         try testing.expectEqualStrings("Maybe", item3.type.name);
         try testing.expect(item3.type.alias == null);
         try testing.expect(item3.type.expose_constructors == false);
 
         // Check second type import (Either with constructors)
-        const item4 = import_spec.items.?.items[3];
-
-        try testing.expect(item4.* == .type);
+        const item4 = import_spec.items.?.items[3].inner;
+        try testing.expect(item4 == .type);
         try testing.expectEqualStrings("Either", item4.type.name);
         try testing.expect(item4.type.alias == null);
         try testing.expect(item4.type.expose_constructors == true);
@@ -3844,7 +3861,7 @@ test "[import_spec]" {
         // Action
         const node = try parser.parseImportSpec();
         defer {
-            node.deinit(allocator);
+            node.release(allocator);
             allocator.destroy(node);
         }
 
@@ -3871,17 +3888,15 @@ test "[import_spec]" {
         try testing.expect(import_spec.items != null);
 
         // Check first item (map as list_map)
-        const item1 = import_spec.items.?.items[0];
-
-        try testing.expect(item1.* == .function);
+        const item1 = import_spec.items.?.items[0].inner;
+        try testing.expect(item1 == .function);
         try testing.expectEqualStrings("map", item1.function.name);
         try testing.expect(item1.function.alias != null);
         try testing.expectEqualStrings("list_map", item1.function.alias.?);
 
         // Check second item (filter)
-        const item2 = import_spec.items.?.items[1];
-
-        try testing.expect(item2.* == .function);
+        const item2 = import_spec.items.?.items[1].inner;
+        try testing.expect(item2 == .function);
         try testing.expectEqualStrings("filter", item2.function.name);
         try testing.expect(item2.function.alias == null);
     }
@@ -3896,7 +3911,7 @@ test "[import_spec]" {
         // Action
         const node = try parser.parseImportSpec();
         defer {
-            node.deinit(allocator);
+            node.release(allocator);
             allocator.destroy(node);
         }
 
@@ -3923,9 +3938,8 @@ test "[import_spec]" {
         try testing.expect(import_spec.items.?.items.len == 1);
 
         // Check the hidden function
-        const item = import_spec.items.?.items[0];
-
-        try testing.expect(item.* == .function);
+        const item = import_spec.items.?.items[0].inner;
+        try testing.expect(item == .function);
         try testing.expectEqualStrings("internal_func", item.function.name);
         try testing.expect(item.function.alias == null);
     }
@@ -3947,7 +3961,7 @@ test "[type_alias]" {
         // Action
         const node = try parser.parseTypeDecl();
         defer {
-            node.deinit(allocator);
+            node.release(allocator);
             allocator.destroy(node);
         }
 
@@ -3977,7 +3991,7 @@ test "[type_alias]" {
         // Action
         const node = try parser.parseTypeDecl();
         defer {
-            node.deinit(allocator);
+            node.release(allocator);
             allocator.destroy(node);
         }
 
@@ -4019,57 +4033,57 @@ test "[type_alias]" {
         try testing.expectEqualStrings("v", arg2.lower_identifier.identifier);
     }
 
-    // {
-    //     // Function type
-    //     const source = "type alias Reducer(a, b) = (a, b) -> b";
-    //     var l = lexer.Lexer.init(source, TEST_FILE);
-    //     var parser = try Parser.init(allocator, &l);
-    //     defer parser.deinit();
+    {
+        // Function type
+        const source = "type alias Reducer(a, b) = (a, b) -> b";
+        var l = lexer.Lexer.init(source, TEST_FILE);
+        var parser = try Parser.init(allocator, &l);
+        defer parser.deinit();
 
-    //     // Action
-    //     const node = try parser.parseTypeDecl();
-    //     defer {
-    //         node.deinit(allocator);
-    //         allocator.destroy(node);
-    //     }
+        // Action
+        const node = try parser.parseTypeDecl();
+        defer {
+            node.release(allocator);
+            allocator.destroy(node);
+        }
 
-    //     // Assertions
-    //     // Verify that the parsed node represents a type alias declaration
-    //     try testing.expect(node.* == .type_alias);
+        // Assertions
+        // Verify that the parsed node represents a type alias declaration
+        try testing.expect(node.* == .type_alias);
 
-    //     const type_alias = node.type_alias;
+        const type_alias = node.type_alias;
 
-    //     // ??
-    //     try testing.expectEqualStrings("Reducer", type_alias.name.identifier);
+        // Verify the type alias name
+        try testing.expectEqualStrings("Reducer", type_alias.name.identifier);
 
-    //     // ?
-    //     try testing.expectEqual(@as(usize, 2), type_alias.type_params.items.len);
-    //     try testing.expectEqualStrings("a", type_alias.type_params.items[0]);
-    //     try testing.expectEqualStrings("b", type_alias.type_params.items[1]);
+        // Verify type parameters
+        try testing.expectEqual(@as(usize, 2), type_alias.type_params.items.len);
+        try testing.expectEqualStrings("a", type_alias.type_params.items[0]);
+        try testing.expectEqualStrings("b", type_alias.type_params.items[1]);
 
-    //     // Ensure the type alias represents a function type
-    //     try testing.expect(type_alias.value.* == .function_signature);
+        // Ensure the type alias represents a function type
+        try testing.expect(type_alias.value.* == .function_signature);
 
-    //     // const func_sig = type_alias.value.function_signature;
+        const func_sig = type_alias.value.function_signature;
 
-    //     // The function type should have three type entries: 'a -> b -> b'
-    //     // try testing.expectEqual(@as(usize, 3), func_sig.parameter_types.items.len);
+        // The function type should have two parameter types: 'a' and 'b'
+        try testing.expectEqual(@as(usize, 2), func_sig.parameter_types.items.len);
 
-    //     // Ensure the first parameter type is 'a'
-    //     // const sig_type1 = func_sig.parameter_types.items[0];
-    //     // try testing.expect(sig_type1.* == .lower_identifier);
-    //     // try testing.expectEqualStrings("a", sig_type1.lower_identifier.identifier);
+        // Ensure the first parameter type is 'a'
+        const sig_type1 = func_sig.parameter_types.items[0];
+        try testing.expect(sig_type1.* == .lower_identifier);
+        try testing.expectEqualStrings("a", sig_type1.lower_identifier.identifier);
 
-    //     // Ensure the second parameter type is 'b'
-    //     // const sig_type2 = func_sig.parameter_types.items[1];
-    //     // try testing.expect(sig_type2.* == .lower_identifier);
-    //     // try testing.expectEqualStrings("b", sig_type2.lower_identifier.identifier);
+        // Ensure the second parameter type is 'b'
+        const sig_type2 = func_sig.parameter_types.items[1];
+        try testing.expect(sig_type2.* == .lower_identifier);
+        try testing.expectEqualStrings("b", sig_type2.lower_identifier.identifier);
 
-    //     // Ensure the return type is also 'b'
-    //     // const sig_type3 = func_sig.parameter_types.items[2];
-    //     // try testing.expect(sig_type3.* == .lower_identifier);
-    //     // try testing.expectEqualStrings("b", sig_type3.lower_identifier.identifier);
-    // }
+        // Ensure the return type is 'b'
+        const return_type = func_sig.return_type;
+        try testing.expect(return_type.* == .lower_identifier);
+        try testing.expectEqualStrings("b", return_type.lower_identifier.identifier);
+    }
 
     {
         // Complex nested type
@@ -4081,7 +4095,7 @@ test "[type_alias]" {
         // Action
         const node = try parser.parseTypeDecl();
         defer {
-            node.deinit(allocator);
+            node.release(allocator);
             allocator.destroy(node);
         }
 
@@ -4172,7 +4186,7 @@ test "[record_type]" {
         // Action
         const node = try parser.parseTypeDecl();
         defer {
-            node.deinit(allocator);
+            node.release(allocator);
             allocator.destroy(node);
         }
 
@@ -4225,7 +4239,7 @@ test "[record_type]" {
         // Action
         const node = try parser.parseTypeDecl();
         defer {
-            node.deinit(allocator);
+            node.release(allocator);
             allocator.destroy(node);
         }
 
@@ -4279,7 +4293,7 @@ test "[record_type]" {
         // Action
         const node = try parser.parseTypeDecl();
         defer {
-            node.deinit(allocator);
+            node.release(allocator);
             allocator.destroy(node);
         }
 
@@ -4354,7 +4368,7 @@ test "[record_type]" {
         // Action
         const node = try parser.parseTypeDecl();
         defer {
-            node.deinit(allocator);
+            node.release(allocator);
             allocator.destroy(node);
         }
 
@@ -4467,7 +4481,7 @@ test "[variant_type]" {
         // Action
         const node = try parser.parseTypeDecl();
         defer {
-            node.deinit(allocator);
+            node.release(allocator);
             allocator.destroy(node);
         }
 
@@ -4509,162 +4523,162 @@ test "[variant_type]" {
         }
     }
 
-    // {
-    //     const source = "type Maybe(a) = | None | Some(a)";
-    //     var l = lexer.Lexer.init(source, TEST_FILE);
-    //     var parser = try Parser.init(allocator, &l);
-    //     defer parser.deinit();
+    {
+        const source = "type Maybe(a) = | None | Some(a)";
+        var l = lexer.Lexer.init(source, TEST_FILE);
+        var parser = try Parser.init(allocator, &l);
+        defer parser.deinit();
 
-    //     // Action
-    //     const node = try parser.parseTypeDecl();
-    //     defer {
-    //         node.deinit(allocator);
-    //         allocator.destroy(node);
-    //     }
+        // Action
+        const node = try parser.parseTypeDecl();
+        defer {
+            node.release(allocator);
+            allocator.destroy(node);
+        }
 
-    //     // Assertions
-    //     // Ensure the parsed node is a variant type
-    //     try testing.expect(node.* == .variant_type);
+        // Assertions
+        // Ensure the parsed node is a variant type
+        try testing.expect(node.* == .variant_type);
 
-    //     const variant = node.variant_type;
+        const variant = node.variant_type;
 
-    //     // Validate the name of the variant type
-    //     try testing.expectEqualStrings("Maybe", variant.name.identifier);
+        // Validate the name of the variant type
+        try testing.expectEqualStrings("Maybe", variant.name.identifier);
 
-    //     // Ensure 'Maybe' has a single type parameter 'a'
-    //     try testing.expectEqual(@as(usize, 1), variant.type_params.items.len);
-    //     try testing.expectEqualStrings("a", variant.type_params.items[0]);
+        // Ensure 'Maybe' has a single type parameter 'a'
+        try testing.expectEqual(@as(usize, 1), variant.type_params.items.len);
+        try testing.expectEqualStrings("a", variant.type_params.items[0]);
 
-    //     // Ensure the variant type has exactly two constructors (None, Some)
-    //     try testing.expectEqual(@as(usize, 2), variant.constructors.items.len);
+        // Ensure the variant type has exactly two constructors (None, Some)
+        try testing.expectEqual(@as(usize, 2), variant.constructors.items.len);
 
-    //     // Check first constructor (None)
-    //     {
-    //         const none_constructor = variant.constructors.items[0];
+        // Check first constructor (None)
+        {
+            const none_constructor = variant.constructors.items[0];
 
-    //         // Ensure the constructor is named 'None'
-    //         try testing.expectEqualStrings("None", none_constructor.name.identifier);
+            // Ensure the constructor is named 'None'
+            try testing.expectEqualStrings("None", none_constructor.name.identifier);
 
-    //         // Ensure 'None' has no associated parameters
-    //         try testing.expectEqual(@as(usize, 0), none_constructor.parameters.items.len);
-    //     }
+            // Ensure 'None' has no associated parameters
+            try testing.expectEqual(@as(usize, 0), none_constructor.parameters.items.len);
+        }
 
-    //     // Check second constructor (Some a)
-    //     {
-    //         const some_constructor = variant.constructors.items[1];
+        // Check second constructor (Some a)
+        {
+            const some_constructor = variant.constructors.items[1];
 
-    //         // Ensure the constructor is named 'Some'
-    //         try testing.expectEqualStrings("Some", some_constructor.name.identifier);
+            // Ensure the constructor is named 'Some'
+            try testing.expectEqualStrings("Some", some_constructor.name.identifier);
 
-    //         // Ensure 'Some' has exactly one associated parameter
-    //         try testing.expectEqual(@as(usize, 1), some_constructor.parameters.items.len);
+            // Ensure 'Some' has exactly one associated parameter
+            try testing.expectEqual(@as(usize, 1), some_constructor.parameters.items.len);
 
-    //         const param = some_constructor.parameters.items[0];
+            const param = some_constructor.parameters.items[0];
 
-    //         // Validate that the parameter is the type variable 'a'
-    //         try testing.expect(param.* == .lower_identifier);
-    //         try testing.expectEqualStrings("a", param.lower_identifier.identifier);
-    //     }
-    // }
+            // Validate that the parameter is the type variable 'a'
+            try testing.expect(param.* == .lower_identifier);
+            try testing.expectEqualStrings("a", param.lower_identifier.identifier);
+        }
+    }
 
-    // {
-    //     const source = "type Tree(a) = | Leaf | Branch(Tree(a), a, Tree(a))";
-    //     var l = lexer.Lexer.init(source, TEST_FILE);
-    //     var parser = try Parser.init(allocator, &l);
-    //     defer parser.deinit();
+    {
+        const source = "type Tree(a) = | Leaf | Branch(Tree(a), a, Tree(a))";
+        var l = lexer.Lexer.init(source, TEST_FILE);
+        var parser = try Parser.init(allocator, &l);
+        defer parser.deinit();
 
-    //     // Action
-    //     const node = try parser.parseTypeDecl();
-    //     defer {
-    //         node.deinit(allocator);
-    //         allocator.destroy(node);
-    //     }
+        // Action
+        const node = try parser.parseTypeDecl();
+        defer {
+            node.release(allocator);
+            allocator.destroy(node);
+        }
 
-    //     // Assertions
-    //     // Ensure the parsed node is a variant type
-    //     try testing.expect(node.* == .variant_type);
+        // Assertions
+        // Ensure the parsed node is a variant type
+        try testing.expect(node.* == .variant_type);
 
-    //     const variant = node.variant_type;
+        const variant = node.variant_type;
 
-    //     // Validate the name of the variant type
-    //     try testing.expectEqualStrings("Tree", variant.name.identifier);
+        // Validate the name of the variant type
+        try testing.expectEqualStrings("Tree", variant.name.identifier);
 
-    //     // Ensure 'Tree' has a single type parameter 'a'
-    //     try testing.expectEqual(@as(usize, 1), variant.type_params.items.len);
-    //     try testing.expectEqualStrings("a", variant.type_params.items[0]);
+        // Ensure 'Tree' has a single type parameter 'a'
+        try testing.expectEqual(@as(usize, 1), variant.type_params.items.len);
+        try testing.expectEqualStrings("a", variant.type_params.items[0]);
 
-    //     // Ensure the variant type has exactly two constructors (Leaf, Branch)
-    //     try testing.expectEqual(@as(usize, 2), variant.constructors.items.len);
+        // Ensure the variant type has exactly two constructors (Leaf, Branch)
+        try testing.expectEqual(@as(usize, 2), variant.constructors.items.len);
 
-    //     // Check first constructor (Leaf)
-    //     {
-    //         const leaf_constructor = variant.constructors.items[0];
+        // Check first constructor (Leaf)
+        {
+            const leaf_constructor = variant.constructors.items[0];
 
-    //         // Ensure the constructor is named 'Leaf'
-    //         try testing.expectEqualStrings("Leaf", leaf_constructor.name.identifier);
+            // Ensure the constructor is named 'Leaf'
+            try testing.expectEqualStrings("Leaf", leaf_constructor.name.identifier);
 
-    //         // Ensure 'Leaf' has no associated parameters
-    //         try testing.expectEqual(@as(usize, 0), leaf_constructor.parameters.items.len);
-    //     }
+            // Ensure 'Leaf' has no associated parameters
+            try testing.expectEqual(@as(usize, 0), leaf_constructor.parameters.items.len);
+        }
 
-    //     // Check second constructor (Branch (Tree a) a (Tree a))
-    //     {
-    //         const branch_constructor = variant.constructors.items[1];
+        // Check second constructor (Branch (Tree a) a (Tree a))
+        {
+            const branch_constructor = variant.constructors.items[1];
 
-    //         // Ensure the constructor is named 'Branch'
-    //         try testing.expectEqualStrings("Branch", branch_constructor.name.identifier);
+            // Ensure the constructor is named 'Branch'
+            try testing.expectEqualStrings("Branch", branch_constructor.name.identifier);
 
-    //         // Ensure 'Branch' has exactly three parameters
-    //         try testing.expectEqual(@as(usize, 3), branch_constructor.parameters.items.len);
+            // Ensure 'Branch' has exactly three parameters
+            try testing.expectEqual(@as(usize, 3), branch_constructor.parameters.items.len);
 
-    //         // First parameter (Tree a)
-    //         {
-    //             const param1 = branch_constructor.parameters.items[0];
+            // First parameter (Tree a)
+            {
+                const param1 = branch_constructor.parameters.items[0];
 
-    //             // Ensure 'param1' is a type application
-    //             try testing.expect(param1.* == .type_application);
+                // Ensure 'param1' is a type application
+                try testing.expect(param1.* == .type_application);
 
-    //             const app = param1.type_application;
+                const app = param1.type_application;
 
-    //             // Ensure the base type is 'Tree'
-    //             try testing.expectEqual(lexer.TokenKind{ .identifier = .Upper }, app.constructor.token.kind);
-    //             try testing.expectEqualStrings("Tree", app.constructor.identifier);
+                // Ensure the base type is 'Tree'
+                try testing.expectEqual(lexer.TokenKind{ .identifier = .Upper }, app.constructor.token.kind);
+                try testing.expectEqualStrings("Tree", app.constructor.identifier);
 
-    //             // Ensure 'Tree' is applied to one argument ('a')
-    //             try testing.expectEqual(@as(usize, 1), app.args.items.len);
-    //             try testing.expect(app.args.items[0].* == .lower_identifier);
-    //             try testing.expectEqualStrings("a", app.args.items[0].lower_identifier.identifier);
-    //         }
+                // Ensure 'Tree' is applied to one argument ('a')
+                try testing.expectEqual(@as(usize, 1), app.args.items.len);
+                try testing.expect(app.args.items[0].* == .lower_identifier);
+                try testing.expectEqualStrings("a", app.args.items[0].lower_identifier.identifier);
+            }
 
-    //         // Second parameter (a)
-    //         {
-    //             const param2 = branch_constructor.parameters.items[1];
+            // Second parameter (a)
+            {
+                const param2 = branch_constructor.parameters.items[1];
 
-    //             // Ensure 'param2' is the type variable 'a'
-    //             try testing.expect(param2.* == .lower_identifier);
-    //             try testing.expectEqualStrings("a", param2.lower_identifier.identifier);
-    //         }
+                // Ensure 'param2' is the type variable 'a'
+                try testing.expect(param2.* == .lower_identifier);
+                try testing.expectEqualStrings("a", param2.lower_identifier.identifier);
+            }
 
-    //         // Third parameter (Tree a)
-    //         {
-    //             const param3 = branch_constructor.parameters.items[2];
+            // Third parameter (Tree a)
+            {
+                const param3 = branch_constructor.parameters.items[2];
 
-    //             // Ensure 'param3' is a type application
-    //             try testing.expect(param3.* == .type_application);
+                // Ensure 'param3' is a type application
+                try testing.expect(param3.* == .type_application);
 
-    //             const app = param3.type_application;
+                const app = param3.type_application;
 
-    //             // Ensure the base type is 'Tree'
-    //             try testing.expectEqual(lexer.TokenKind{ .identifier = .Upper }, app.constructor.token.kind);
-    //             try testing.expectEqualStrings("Tree", app.constructor.identifier);
+                // Ensure the base type is 'Tree'
+                try testing.expectEqual(lexer.TokenKind{ .identifier = .Upper }, app.constructor.token.kind);
+                try testing.expectEqualStrings("Tree", app.constructor.identifier);
 
-    //             // Ensure 'Tree' is applied to one argument ('a')
-    //             try testing.expectEqual(@as(usize, 1), app.args.items.len);
-    //             try testing.expect(app.args.items[0].* == .lower_identifier);
-    //             try testing.expectEqualStrings("a", app.args.items[0].lower_identifier.identifier);
-    //         }
-    //     }
-    // }
+                // Ensure 'Tree' is applied to one argument ('a')
+                try testing.expectEqual(@as(usize, 1), app.args.items.len);
+                try testing.expect(app.args.items[0].* == .lower_identifier);
+                try testing.expectEqualStrings("a", app.args.items[0].lower_identifier.identifier);
+            }
+        }
+    }
 }
 
 test "[list]" {
@@ -4682,7 +4696,7 @@ test "[list]" {
         // Action
         const node = try parser.parseList();
         defer {
-            node.deinit(allocator);
+            node.release(allocator);
             allocator.destroy(node);
         }
 
@@ -4705,7 +4719,7 @@ test "[list]" {
         // Action
         const node = try parser.parseList();
         defer {
-            node.deinit(allocator);
+            node.release(allocator);
             allocator.destroy(node);
         }
 
@@ -4747,7 +4761,7 @@ test "[tuple]" {
         // Action
         const node = try parser.parseTuple();
         defer {
-            node.deinit(allocator);
+            node.release(allocator);
             allocator.destroy(node);
         }
 
@@ -4772,7 +4786,7 @@ test "[tuple]" {
         // Action
         const node = try parser.parseTuple();
         defer {
-            node.deinit(allocator);
+            node.release(allocator);
             allocator.destroy(node);
         }
 

--- a/compiler/frontend/parser.zig
+++ b/compiler/frontend/parser.zig
@@ -842,7 +842,7 @@ pub const Parser = struct {
             }
 
             if (try self.match(lexer.TokenKind{ .delimiter = .LeftParen })) {
-                const first_type = try self.parseSimpleType();
+                const first_type = try self.parseTypeExpr();
                 errdefer {
                     first_type.release(self.allocator);
                     self.allocator.destroy(first_type);
@@ -852,7 +852,7 @@ pub const Parser = struct {
 
                 if (try self.match(lexer.TokenKind{ .delimiter = .Comma })) {
                     while (true) {
-                        const next_type = try self.parseSimpleType();
+                        const next_type = try self.parseTypeExpr();
                         errdefer {
                             next_type.release(self.allocator);
                             self.allocator.destroy(next_type);
@@ -868,7 +868,7 @@ pub const Parser = struct {
 
                 _ = try self.expect(lexer.TokenKind{ .delimiter = .RightParen });
             } else {
-                const single_type = try self.parseSimpleType();
+                const single_type = try self.parseTypeExpr();
                 errdefer {
                     single_type.release(self.allocator);
                     self.allocator.destroy(single_type);
@@ -1920,98 +1920,7 @@ pub const Parser = struct {
     /// - `Int`
     /// - `Maybe(a)`
     /// - `List(String)`
-    // fn parseTypeExpr(self: *Parser) ParserError!*ast.Node {
-    //     const start_token = self.current_token;
-
-    //     var parameter_types = std.ArrayList(*ast.Node).init(self.allocator);
-    //     errdefer {
-    //         for (parameter_types.items) |param_type| {
-    //             param_type.release(self.allocator);
-    //             self.allocator.destroy(param_type);
-    //         }
-    //         parameter_types.deinit();
-    //     }
-
-    //     // Handle parenthesized parameter list: (a, b)
-    //     if (try self.match(lexer.TokenKind{ .delimiter = .LeftParen })) {
-    //         const first_type = try self.parseSimpleType();
-    //         errdefer {
-    //             first_type.release(self.allocator);
-    //             self.allocator.destroy(first_type);
-    //         }
-
-    //         try parameter_types.append(first_type);
-
-    //         if (try self.match(lexer.TokenKind{ .delimiter = .Comma })) {
-    //             while (true) {
-    //                 const next_type = try self.parseSimpleType();
-    //                 errdefer {
-    //                     next_type.release(self.allocator);
-    //                     self.allocator.destroy(next_type);
-    //                 }
-
-    //                 try parameter_types.append(next_type);
-
-    //                 if (!try self.match(lexer.TokenKind{ .delimiter = .Comma })) {
-    //                     break;
-    //                 }
-    //             }
-    //         }
-
-    //         _ = try self.expect(lexer.TokenKind{ .delimiter = .RightParen });
-    //     } else {
-    //         const single_type = try self.parseSimpleType();
-    //         errdefer {
-    //             single_type.release(self.allocator);
-    //             self.allocator.destroy(single_type);
-    //         }
-
-    //         try parameter_types.append(single_type);
-    //     }
-
-    //     if (!try self.match(lexer.TokenKind{ .symbol = .ArrowRight })) {
-    //         if (parameter_types.items.len == 1) {
-    //             const result = parameter_types.items[0];
-    //             parameter_types.deinit();
-
-    //             return result;
-    //         }
-
-    //         // For now, error if multiple types without arrow (future tuple support)
-    //         return error.UnexpectedToken;
-    //     }
-
-    //     const return_type = try self.parseTypeExpr();
-    //     errdefer {
-    //         return_type.release(self.allocator);
-    //         self.allocator.destroy(return_type);
-    //     }
-
-    //     const function_sig_node = try self.allocator.create(ast.FunctionSignatureNode);
-    //     errdefer function_sig_node.release(self.allocator);
-
-    //     function_sig_node.* = .{
-    //         .parameter_types = parameter_types,
-    //         .return_type = return_type,
-    //         .token = start_token,
-    //     };
-
-    //     const node = try self.allocator.create(ast.Node);
-    //     errdefer {
-    //         node.release(self.allocator);
-    //         self.allocator.destroy(node);
-    //     }
-
-    //     node.* = .{ .function_signature = function_sig_node };
-
-    //     return node;
-    // }
     fn parseTypeExpr(self: *Parser) ParserError!*ast.Node {
-        return try self.parseSimpleType();
-    }
-
-    /// Helper function to parse non-function types.
-    fn parseSimpleType(self: *Parser) ParserError!*ast.Node {
         if (self.check(lexer.TokenKind{ .identifier = .Upper })) {
             const start_token = self.current_token;
 

--- a/compiler/root.zig
+++ b/compiler/root.zig
@@ -39,7 +39,7 @@ pub fn compile(allocator: std.mem.Allocator, writer: anytype, filepath: []const 
 
         const ast = try parser.parseProgram();
         defer {
-            ast.deinit(allocator);
+            ast.release(allocator);
             allocator.destroy(ast);
         }
 

--- a/formatter/formatter.zig
+++ b/formatter/formatter.zig
@@ -194,7 +194,7 @@ pub const Formatter = struct {
 
             // Pattern Matching
             .pattern => |pat| {
-                switch (pat.*) {
+                switch (pat.inner) {
                     .wildcard => {
                         try self.write("_");
                     },
@@ -606,7 +606,7 @@ pub const Formatter = struct {
                             defer sorted.deinit();
 
                             for (sorted.items, 0..) |item, i| {
-                                switch (item.*) {
+                                switch (item.inner) {
                                     .function => |f| {
                                         try self.write(f.name);
 
@@ -655,7 +655,7 @@ pub const Formatter = struct {
                             defer sorted.deinit();
 
                             for (sorted.items, 0..) |item, i| {
-                                switch (item.*) {
+                                switch (item.inner) {
                                     .function => |f| {
                                         try self.write(f.name);
                                     },
@@ -844,20 +844,20 @@ pub const Formatter = struct {
     /// Example output: `[Maybe(..), filter, map]`
     fn sortExportItems(
         allocator: std.mem.Allocator,
-        items: std.ArrayList(ast.ExportItem),
-    ) !std.ArrayList(ast.ExportItem) {
-        var result = std.ArrayList(ast.ExportItem).init(allocator);
+        items: std.ArrayList(*ast.ExportItem),
+    ) !std.ArrayList(*ast.ExportItem) {
+        var result = std.ArrayList(*ast.ExportItem).init(allocator);
         errdefer result.deinit();
 
         try result.appendSlice(items.items);
 
         const customSort = struct {
-            fn lessThan(_: void, a: ast.ExportItem, b: ast.ExportItem) bool {
+            fn lessThan(_: void, a: *ast.ExportItem, b: *ast.ExportItem) bool {
                 return std.mem.lessThan(u8, a.name, b.name);
             }
         }.lessThan;
 
-        std.mem.sort(ast.ExportItem, result.items, {}, customSort);
+        std.mem.sort(*ast.ExportItem, result.items, {}, customSort);
 
         return result;
     }
@@ -886,7 +886,7 @@ pub const Formatter = struct {
         defer operators.deinit();
 
         for (items.items) |item| {
-            switch (item.*) {
+            switch (item.inner) {
                 .type => try types.append(item),
                 .function => try functions.append(item),
                 .operator => try operators.append(item),
@@ -895,19 +895,19 @@ pub const Formatter = struct {
 
         const typeSort = struct {
             fn lessThan(_: void, a: *ast.ImportItem, b: *ast.ImportItem) bool {
-                return std.mem.lessThan(u8, a.type.name, b.type.name);
+                return std.mem.lessThan(u8, a.inner.type.name, b.inner.type.name);
             }
         }.lessThan;
 
         const functionSort = struct {
             fn lessThan(_: void, a: *ast.ImportItem, b: *ast.ImportItem) bool {
-                return std.mem.lessThan(u8, a.function.name, b.function.name);
+                return std.mem.lessThan(u8, a.inner.function.name, b.inner.function.name);
             }
         }.lessThan;
 
         const operatorSort = struct {
             fn lessThan(_: void, a: *ast.ImportItem, b: *ast.ImportItem) bool {
-                return std.mem.lessThan(u8, a.operator.symbol, b.operator.symbol);
+                return std.mem.lessThan(u8, a.inner.operator.symbol, b.inner.operator.symbol);
             }
         }.lessThan;
 

--- a/formatter/formatter.zig
+++ b/formatter/formatter.zig
@@ -419,17 +419,22 @@ pub const Formatter = struct {
 
                 try self.write(atype.name.identifier);
 
-                try self.write(" ");
+                if (atype.type_params.items.len > 0) {
+                    try self.write("(");
 
-                for (atype.type_params.items) |param| {
-                    try self.write(param);
-                    try self.write(" ");
+                    for (atype.type_params.items, 0..) |param, i| {
+                        try self.write(param);
+
+                        if (i < atype.type_params.items.len - 1) {
+                            try self.write(", ");
+                        }
+                    }
+
+                    try self.write(")");
                 }
 
-                try self.write("= ");
-
+                try self.write(" = ");
                 try self.formatNode(atype.value);
-
                 try self.write("\n");
             },
             .variant_type => |vtype| {

--- a/formatter/root.zig
+++ b/formatter/root.zig
@@ -19,7 +19,7 @@ pub fn format(allocator: std.mem.Allocator, filepath: []const u8) ![]const u8 {
 
     const ast = try parser.parseProgram();
     defer {
-        ast.deinit(allocator);
+        ast.release(allocator);
         allocator.destroy(ast);
     }
 


### PR DESCRIPTION
# Investigate refactor to reference counters 

## Problem: 

Manual memory management is becoming problematic when writing the parser. Complex parsers have intermediate states which are currently resulting in memory leaks that are hard to handle properly. Consequently, adding new or updating current parser functionality has slowed down dramatically. Partly a skill issue, but my gut tells me this will continue to be a problem moving forward unless something is done to "tame" the complexity a bit. 

## Investigate:

Will using reference counters help reduce memory management complexity while providing acceptable trade-offs? 

Theoretically, it should:
- Reduce peak memory usage by freeing parts of the AST as soon as they're no longer needed in a multi-pass compiler
- Allow for a incremental compiler that reuses unmodified parts of the AST between edits
- Implement efficient AST transformations which is valuable for optimizations
- Provide safer memory management b/c it makes it harder to accidentally free memory that's still in use, as a node is only freed when its reference count reaches zero.
- The `errdefer` patterns are simpler with `release()` instead of explicit `deinit()` calls, reducing boilerplate in error recovery paths.

However, potential problems:
- Cycle Detection: need weak references to handle circular references

## Open questions:

- Performance impact of adding counters everywhere?
- How do you make these counters atomic as to not prevent multithreaded compilation? 
- How will this impact the type checker, performance optimizer and code generation steps? 
- Zig has several built-in memory management approaches - explore whether Arena Allocators might be a better fit for a compiler's AST than reference counting.

## Learnings:

- The type checker and semantic analyzer would be prime examples where reference counting becomes valuable. During these compilation phases, you typically need to:
  - Associate type information with AST nodes
  - Create cross-references between definitions and their uses
  - Track symbols across different scopes

  In these cases, you'd have structures (like symbol tables) that need to reference nodes without taking ownership. This is where explicit `retain()` calls become necessary - you'd retain a reference to an AST node when adding it to your symbol table, and the reference counting ensures it stays alive even if transformations happen to other parts of the tree.

  The semantic analyzer especially might need to maintain references to declaration nodes while analyzing their usages throughout the program, which creates exactly the kind of shared ownership scenario that reference counting helps manage.
- Since the Node union is just a thin wrapper around the actual node data, the current approach works fine. The union itself is never shared, only the contained nodes need reference counting. If the compiler grows more complex with transformations that need to share entire Node values, it might need to extend reference counting to the union type too. For now, this hybrid approach is a pragmatic middle ground.
- For now, atomic operations will be ignored. I have no way of measuring impact on the overall compiler so it would just be an unnecessary, eager optimization. But in the in the future should I need it:
```
pub const CommentNode = struct {
    text: []const u8,
    token: lexer.Token,
    ref_count: usize = 1,

    pub fn retain(self: *CommentNode) void {
        _ = @atomicRmw(usize, &self.ref_count, .Add, 1, .monotonic);
    }

    pub fn release(self: *CommentNode, allocator: std.mem.Allocator) void {
        const prev = @atomicRmw(usize, &self.ref_count, .Sub, 1, .acq_rel);

        if (prev == 1) {
            allocator.free(self.text);

            allocator.destroy(self);
        }
    }
};
```
- If the allocator isn’t thread-safe (e.g., a simple std.heap.GeneralPurposeAllocator), release will need a lock around free/destroy. Plan for a thread-safe allocator like `std.heap.ThreadSafeAllocator` when you go multi-threaded.