### PR TITLE
parser: add parse module decl

### DIFF
--- a/compiler/frontend/ast_printer.zig
+++ b/compiler/frontend/ast_printer.zig
@@ -1109,7 +1109,7 @@ pub const AstPrinter = struct {
                 self.indent_level += 1;
 
                 try self.printIndent();
-                try self.writer.styled(term.Color.Cyan, "path: [");
+                try self.writer.styled(term.Color.Cyan, "path: ");
 
                 for (decl.path.segments.items, 0..) |segment, i| {
                     if (i > 0) {
@@ -1119,7 +1119,7 @@ pub const AstPrinter = struct {
                     try self.writer.styled(term.Color.Magenta, segment.identifier);
                 }
 
-                try self.writer.plain("]\n");
+                try self.writer.plain("\n");
 
                 try self.printIndent();
                 try self.writer.styled(term.Color.Cyan, "exports: ");

--- a/compiler/frontend/parser.zig
+++ b/compiler/frontend/parser.zig
@@ -2329,13 +2329,13 @@ pub const Parser = struct {
             i += 1;
         }
 
-        const trimmed = std.mem.trimRight(u8, start_token.lexeme[i..], &std.ascii.whitespace);
+        const text = std.mem.trimRight(u8, start_token.lexeme[i..], &std.ascii.whitespace);
 
         const comment_node = try self.allocator.create(ast.CommentNode);
         errdefer comment_node.release(self.allocator);
 
         comment_node.* = .{
-            .text = try self.allocator.dupe(u8, trimmed),
+            .text = try self.allocator.dupe(u8, text),
             .token = start_token,
         };
 
@@ -2360,13 +2360,13 @@ pub const Parser = struct {
             i += 1;
         }
 
-        const trimmed = std.mem.trimRight(u8, start_token.lexeme[i..], &std.ascii.whitespace);
+        const text = std.mem.trimRight(u8, start_token.lexeme[i..], &std.ascii.whitespace);
 
         const comment_node = try self.allocator.create(ast.DocCommentNode);
         errdefer comment_node.release(self.allocator);
 
         comment_node.* = .{
-            .text = try self.allocator.dupe(u8, trimmed),
+            .text = try self.allocator.dupe(u8, text),
             .token = start_token,
         };
 

--- a/compiler/frontend/parser.zig
+++ b/compiler/frontend/parser.zig
@@ -441,10 +441,101 @@ pub const Parser = struct {
     fn parseTopLevel(self: *Parser) ParserError!*ast.Node {
         switch (self.current_token.kind) {
             .keyword => |kw| switch (kw) {
+                .Module => return self.parseModuleDecl(),
+                else => return error.UnexpectedToken,
+            },
+            .comment => |c| switch (c) {
+                .Doc => return self.parseDocComment(),
+                .Regular => return self.parseComment(),
+            },
+            else => return error.UnexpectedToken,
+        }
+    }
+
+    /// Parses a module declaration with its name, exports, and contents.
+    /// A module groups related declarations (functions, types, etc.) and controls
+    /// their visibility through an export specification. This is the top-level
+    /// construct for organizing code in a file.
+    ///
+    /// Examples:
+    /// - `module A exposing (..) ... end`
+    fn parseModuleDecl(self: *Parser) ParserError!*ast.Node {
+        const start_token = try self.expect(lexer.TokenKind{ .keyword = .Module });
+
+        const path_node = try self.parseModulePath();
+        errdefer {
+            path_node.release(self.allocator);
+            self.allocator.destroy(path_node);
+        }
+
+        const module_path = path_node.module_path;
+        self.allocator.destroy(path_node);
+
+        const exports_node = try self.parseExportSpec();
+        errdefer {
+            exports_node.release(self.allocator);
+            self.allocator.destroy(exports_node);
+        }
+
+        const exports = exports_node.export_spec;
+        self.allocator.destroy(exports_node);
+
+        var declarations = std.ArrayList(*ast.Node).init(self.allocator);
+        errdefer {
+            for (declarations.items) |decl| {
+                decl.release(self.allocator);
+                self.allocator.destroy(decl);
+            }
+            declarations.deinit();
+        }
+
+        while (!self.check(lexer.TokenKind{ .keyword = .End })) {
+            const decl = try self.parseModuleStmt();
+            errdefer {
+                decl.release(self.allocator);
+                self.allocator.destroy(decl);
+            }
+
+            try declarations.append(decl);
+        }
+
+        _ = try self.expect(lexer.TokenKind{ .keyword = .End });
+
+        const module_node = try self.allocator.create(ast.ModuleDeclNode);
+        errdefer module_node.release(self.allocator);
+
+        module_node.* = .{
+            .path = module_path,
+            .exports = exports,
+            .declarations = declarations,
+            .token = start_token,
+        };
+
+        const node = try self.allocator.create(ast.Node);
+        errdefer {
+            node.release(self.allocator);
+            self.allocator.destroy(node);
+        }
+
+        node.* = .{ .module_decl = module_node };
+
+        return node;
+    }
+
+    /// Parses a single statement within a module declaration.
+    /// Handles declarations such as functions, types, imports, and comments that
+    /// appear inside a module's body.
+    ///
+    /// Examples:
+    /// - `let double(x : Int) -> Int = x * 2`
+    /// - `type Maybe(a) = None | Some(a)`
+    /// - `open StdLib.List`
+    fn parseModuleStmt(self: *Parser) ParserError!*ast.Node {
+        switch (self.current_token.kind) {
+            .keyword => |kw| switch (kw) {
                 .Foreign => return self.parseForeignFunctionDecl(),
                 .Include => return self.parseInclude(),
                 .Let => return self.parseFunctionDecl(),
-                // .Module => return self.parseModuleDecl(),
                 .Open => return self.parseImportSpec(),
                 .Type => return self.parseTypeDecl(),
                 else => return error.UnexpectedToken,
@@ -455,6 +546,88 @@ pub const Parser = struct {
             },
             else => return error.UnexpectedToken,
         }
+    }
+
+    /// Parses an export specification that defines which items a module exposes.
+    /// Can specify all items with '..' or a list of specific items, optionally
+    /// exposing constructors for types with '(..)'.
+    ///
+    /// Examples:
+    /// - `exposing (double)`
+    /// - `exposing (..)`
+    /// - `exposing (Maybe(..), and_then)`
+    fn parseExportSpec(self: *Parser) ParserError!*ast.Node {
+        const start_token = try self.expect(lexer.TokenKind{ .keyword = .Exposing });
+
+        _ = try self.expect(lexer.TokenKind{ .delimiter = .LeftParen });
+
+        var exposing_all = false;
+
+        var items: ?std.ArrayList(*ast.ExportItem) = null;
+        errdefer {
+            if (items) |*list| {
+                for (list.items) |item| {
+                    item.release(self.allocator);
+                }
+                list.deinit();
+            }
+        }
+
+        if (try self.match(lexer.TokenKind{ .operator = .Expand })) {
+            exposing_all = true;
+        } else {
+            items = std.ArrayList(*ast.ExportItem).init(self.allocator);
+
+            while (!self.check(lexer.TokenKind{ .delimiter = .RightParen })) {
+                const ident = try self.parseLowerIdentifier();
+                defer ident.release(self.allocator);
+
+                var expose_constructors = false;
+
+                if (try self.match(lexer.TokenKind{ .delimiter = .LeftParen })) {
+                    _ = try self.expect(lexer.TokenKind{ .operator = .Expand });
+                    _ = try self.expect(lexer.TokenKind{ .delimiter = .RightParen });
+
+                    expose_constructors = true;
+                }
+
+                const item = try self.allocator.create(ast.ExportItem);
+                errdefer item.release(self.allocator);
+
+                item.* = .{
+                    .name = try self.allocator.dupe(u8, ident.identifier),
+                    .expose_constructors = expose_constructors,
+                    .token = ident.token,
+                };
+
+                try items.?.append(item);
+
+                if (!self.check(lexer.TokenKind{ .delimiter = .RightParen })) {
+                    _ = try self.expect(lexer.TokenKind{ .delimiter = .Comma });
+                }
+            }
+        }
+
+        _ = try self.expect(lexer.TokenKind{ .delimiter = .RightParen });
+
+        const export_node = try self.allocator.create(ast.ExportSpecNode);
+        errdefer export_node.release(self.allocator);
+
+        export_node.* = .{
+            .exposing_all = exposing_all,
+            .items = items,
+            .token = start_token,
+        };
+
+        const node = try self.allocator.create(ast.Node);
+        errdefer {
+            node.release(self.allocator);
+            self.allocator.destroy(node);
+        }
+
+        node.* = .{ .export_spec = export_node };
+
+        return node;
     }
 
     /// Parses an import specification that controls how a module is imported.
@@ -1293,9 +1466,14 @@ pub const Parser = struct {
     fn parseInclude(self: *Parser) ParserError!*ast.Node {
         const start_token = try self.expect(lexer.TokenKind{ .keyword = .Include });
 
-        const path_node = try self.parseModulePath();
-        const module_path = path_node.module_path;
-        self.allocator.destroy(path_node);
+        const path = try self.parseModulePath();
+        errdefer {
+            path.release(self.allocator);
+            self.allocator.destroy(path);
+        }
+
+        const module_path = path.module_path;
+        self.allocator.destroy(path);
 
         const include_node = try self.allocator.create(ast.IncludeNode);
         errdefer include_node.release(self.allocator);

--- a/formatter/formatter.zig
+++ b/formatter/formatter.zig
@@ -816,17 +816,18 @@ pub const Formatter = struct {
                 try self.write(" ");
 
                 try self.formatNode(&.{ .export_spec = decl.exports });
-                try self.write("\n\n");
+                try self.write("\n");
 
                 self.indent_level += 1;
 
-                for (decl.declarations.items) |declaration| {
+                for (decl.declarations.items, 0..) |declaration, i| {
+                    try self.writeIndent();
                     try self.formatNode(declaration);
-                    try self.write("\n");
 
-                    // Add extra newline between declarations for readability
-                    if (declaration.* != .comment and declaration.* != .doc_comment and declaration.* != .foreign_function_decl) {
-                        try self.write("\n");
+                    if (i < decl.declarations.items.len - 1) {
+                        if (declaration.* != .comment or declaration.* != .doc_comment) {
+                            try self.write("\n");
+                        }
                     }
                 }
 
@@ -837,7 +838,10 @@ pub const Formatter = struct {
             .program => |prog| {
                 for (prog.statements.items) |stmt| {
                     try self.formatNode(stmt);
-                    try self.write("\n");
+
+                    if (stmt.* == .comment or stmt.* == .doc_comment) {
+                        try self.write("\n");
+                    }
                 }
             },
         }


### PR DESCRIPTION
This approach will work for now. Just need something moving forward. 

```
## some doc comment
module A exposing (double)
    type alias Seconds =
        Int

    ## another doc comment
    let double(x : Seconds) -> Seconds =
        x * 2
end
```
```
=== Tokens ===
Token(## some doc comment) (.comment = Doc) (0,19) (1,1)
Token(module) (.keyword = Module) (20,26) (2,1)
Token(A) (.identifier = Upper) (27,28) (2,8)
Token(exposing) (.keyword = Exposing) (29,37) (2,10)
Token(() (.delimiter = LeftParen) (38,39) (2,19)
Token(double) (.identifier = Lower) (39,45) (2,20)
Token()) (.delimiter = RightParen) (45,46) (2,26)
Token(type) (.keyword = Type) (51,55) (3,5)
Token(alias) (.keyword = Alias) (56,61) (3,10)
Token(Seconds) (.identifier = Upper) (62,69) (3,16)
Token(=) (.operator = Equal) (70,71) (3,24)
Token(Int) (.identifier = Upper) (80,83) (4,9)
Token(## another doc comment) (.comment = Doc) (89,111) (6,5)
Token(let) (.keyword = Let) (116,119) (7,5)
Token(double) (.identifier = Lower) (120,126) (7,9)
Token(() (.delimiter = LeftParen) (126,127) (7,15)
Token(x) (.identifier = Lower) (127,128) (7,16)
Token(:) (.delimiter = Colon) (129,130) (7,18)
Token(Seconds) (.identifier = Upper) (131,138) (7,20)
Token()) (.delimiter = RightParen) (138,139) (7,27)
Token(->) (.symbol = ArrowRight) (140,142) (7,29)
Token(Seconds) (.identifier = Upper) (143,150) (7,32)
Token(=) (.operator = Equal) (151,152) (7,40)
Token(x) (.identifier = Lower) (161,162) (8,9)
Token(*) (.operator = IntMul) (163,164) (8,11)
Token(2) (.literal = Int) (165,166) (8,13)
Token(end) (.keyword = End) (167,170) (9,1)

=== AST ===
Program {
    DocComment(some doc comment)
    ModuleDecl {
        path: A
        exports: ExportSpec {
            exposing_all: false
            items: [
                ExportItem {
                    name: double
                    expose_constructors: false
                }
            ]
        }
        declarations: [
            TypeAlias {
                name: Seconds
                type_params: []
                value: UpperIdent(Int)
            }
            DocComment(another doc comment)
            FunctionDecl {
                name: double
                parameters: [
                    Parameter {
                        name: x
                        type: UpperIdent(Seconds)
                    }
                ]
                return_type: UpperIdent(Seconds)
                value: ArithmeticExpr {
                    operator: operator (*)
                    left: LowerIdent(x)
                    right: IntegerLiteral(2)
                }
            }
        ]
    }
}
```