### PR TITLE
small syntax and formatter fixes

### DIFF
--- a/compiler/frontend/parser.zig
+++ b/compiler/frontend/parser.zig
@@ -1655,9 +1655,15 @@ pub const Parser = struct {
 
             switch (operator.kind) {
                 .operator => |op| {
-                    if (op == .Exp or op == .FloatAdd or op == .FloatDiv or
-                        op == .FloatMul or op == .FloatSub or op == .IntAdd or
-                        op == .IntDiv or op == .IntMul or op == .IntSub)
+                    if ((op == .Exp) or
+                        (op == .FloatAdd) or
+                        (op == .FloatDiv) or
+                        (op == .FloatMul) or
+                        (op == .FloatSub) or
+                        (op == .IntAdd) or
+                        (op == .IntDiv) or
+                        (op == .IntMul) or
+                        (op == .IntSub))
                     {
                         const arithmetic_node = try self.allocator.create(ast.ArithmeticExprNode);
                         errdefer arithmetic_node.release(self.allocator);
@@ -1680,8 +1686,12 @@ pub const Parser = struct {
                         };
 
                         node.* = .{ .logical_expr = logical_node };
-                    } else if (op == .Equality or op == .GreaterThan or op == .GreaterThanEqual or
-                        op == .LessThan or op == .LessThanEqual or op == .NotEqual)
+                    } else if ((op == .Equality) or
+                        (op == .GreaterThan) or
+                        (op == .GreaterThanEqual) or
+                        (op == .LessThan) or
+                        (op == .LessThanEqual) or
+                        (op == .NotEqual))
                     {
                         const comparison_node = try self.allocator.create(ast.ComparisonExprNode);
                         errdefer comparison_node.release(self.allocator);

--- a/compiler/frontend/parser.zig
+++ b/compiler/frontend/parser.zig
@@ -677,25 +677,49 @@ pub const Parser = struct {
             items = std.ArrayList(*ast.ExportItem).init(self.allocator);
 
             while (!self.check(lexer.TokenKind{ .delimiter = .RightParen })) {
-                const ident = try self.parseLowerIdentifier();
-                defer ident.release(self.allocator);
-
+                var name: []const u8 = undefined;
+                var token: lexer.Token = undefined;
                 var expose_constructors = false;
 
-                if (try self.match(lexer.TokenKind{ .delimiter = .LeftParen })) {
-                    _ = try self.expect(lexer.TokenKind{ .operator = .Expand });
-                    _ = try self.expect(lexer.TokenKind{ .delimiter = .RightParen });
+                switch (self.current_token.kind) {
+                    .identifier => |ident| switch (ident) {
+                        .Lower => {
+                            const ident_node = try self.parseLowerIdentifier();
+                            defer ident_node.release(self.allocator);
 
-                    expose_constructors = true;
+                            name = try self.allocator.dupe(u8, ident_node.identifier);
+                            token = ident_node.token;
+
+                            // Lowercase identifiers cannot have (..)
+                            if (self.check(lexer.TokenKind{ .delimiter = .LeftParen })) {
+                                return error.UnexpectedToken;
+                            }
+                        },
+                        .Upper => {
+                            const ident_node = try self.parseUpperIdentifier();
+                            defer ident_node.release(self.allocator);
+
+                            name = try self.allocator.dupe(u8, ident_node.identifier);
+                            token = ident_node.token;
+
+                            if (try self.match(lexer.TokenKind{ .delimiter = .LeftParen })) {
+                                _ = try self.expect(lexer.TokenKind{ .operator = .Expand });
+                                _ = try self.expect(lexer.TokenKind{ .delimiter = .RightParen });
+
+                                expose_constructors = true;
+                            }
+                        },
+                    },
+                    else => return error.UnexpectedToken,
                 }
 
                 const item = try self.allocator.create(ast.ExportItem);
                 errdefer item.release(self.allocator);
 
                 item.* = .{
-                    .name = try self.allocator.dupe(u8, ident.identifier),
+                    .name = name,
                     .expose_constructors = expose_constructors,
-                    .token = ident.token,
+                    .token = token,
                 };
 
                 try items.?.append(item);
@@ -1992,7 +2016,7 @@ pub const Parser = struct {
     fn parseParameter(self: *Parser) ParserError!*ast.ParamDeclNode {
         const param_token = self.current_token;
 
-        const name = try self.parseLowerIdentifier();
+        const name = try self.parseParamName(param_token);
         errdefer name.release(self.allocator);
 
         var type_annotation: ?*ast.Node = null;
@@ -2017,6 +2041,22 @@ pub const Parser = struct {
         };
 
         return node;
+    }
+
+    fn parseParamName(self: *Parser, param_token: lexer.Token) ParserError!*ast.LowerIdentifierNode {
+        if (try self.match(lexer.TokenKind{ .symbol = .Underscore })) {
+            const node = try self.allocator.create(ast.LowerIdentifierNode);
+            errdefer node.release(self.allocator);
+
+            node.* = .{
+                .identifier = try self.allocator.dupe(u8, "_"),
+                .token = param_token,
+            };
+
+            return node;
+        } else {
+            return try self.parseLowerIdentifier();
+        }
     }
 
     /// Parses a list expression surrounded by square brackets with comma-separated elements.
@@ -3973,6 +4013,51 @@ test "[function_decl]" {
 
         try testing.expectEqualStrings("x", value.identifier);
     }
+
+    {
+        // Test function declaration with type annotations
+        const source = "let ignore(_ : a) -> Unit = Unit";
+        var l = lexer.Lexer.init(source, TEST_FILE);
+        var parser = try Parser.init(allocator, &l);
+        defer parser.deinit();
+
+        // Action
+        const node = try parser.parseFunctionDecl();
+        defer {
+            node.release(allocator);
+            allocator.destroy(node);
+        }
+
+        // Assertions
+        // Verify the node is a function declaration
+        try testing.expect(node.* == .function_decl);
+
+        const decl = node.function_decl;
+
+        // Check the function name matches
+        try testing.expectEqualStrings("ignore", decl.name.identifier);
+
+        // Verify the fn has exactly one parameter
+        try testing.expectEqual(@as(usize, 1), decl.parameters.items.len);
+
+        const param1 = decl.parameters.items[0];
+
+        // Verify the parameter name is "_"
+        try testing.expectEqualStrings("_", param1.name.identifier);
+
+        // Verify paramater type is "a"
+        try testing.expectEqualStrings("a", param1.type_annotation.?.lower_identifier.identifier);
+
+        // Verify return type is "Unit"
+        try testing.expectEqualStrings("Unit", decl.return_type.?.upper_identifier.identifier);
+
+        // Verify the function's value is an identifier
+        try testing.expect(decl.value.* == .upper_identifier);
+
+        const value = decl.value.upper_identifier;
+
+        try testing.expectEqualStrings("Unit", value.identifier);
+    }
 }
 
 test "[function_call]" {
@@ -5230,6 +5315,141 @@ test "[tuple]" {
         try testing.expectEqual(@as(usize, 2), tuple.elements.items.len);
         try testing.expectEqualStrings("x", tuple.elements.items[0].lower_identifier.identifier);
         try testing.expectEqualStrings("True", tuple.elements.items[1].upper_identifier.identifier);
+    }
+}
+
+test "[export_spec]" {
+    // Setup
+    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    defer _ = gpa.deinit();
+    const allocator = gpa.allocator();
+
+    {
+        const source = "exposing (double)";
+        var l = lexer.Lexer.init(source, TEST_FILE);
+        var parser = try Parser.init(allocator, &l);
+        defer parser.deinit();
+
+        // Action
+        const node = try parser.parseExportSpec();
+        defer {
+            node.release(allocator);
+            allocator.destroy(node);
+        }
+
+        // Assertions
+        // Verify that the node type is an export spec
+        try testing.expect(node.* == .export_spec);
+
+        const export_spec = node.export_spec;
+
+        // Verify that we are not exposing all items
+        try testing.expect(!export_spec.exposing_all);
+
+        // Verify that the export spec has exactly one item
+        try testing.expectEqual(@as(usize, 1), export_spec.items.?.items.len);
+
+        // Check the exported item (double)
+        const item = export_spec.items.?.items[0];
+        try testing.expectEqualStrings("double", item.name);
+        try testing.expect(!item.expose_constructors);
+    }
+
+    {
+        const source = "exposing (..)";
+        var l = lexer.Lexer.init(source, TEST_FILE);
+        var parser = try Parser.init(allocator, &l);
+        defer parser.deinit();
+
+        // Action
+        const node = try parser.parseExportSpec();
+        defer {
+            node.release(allocator);
+            allocator.destroy(node);
+        }
+
+        // Assertions
+        // Verify that the node type is an export spec
+        try testing.expect(node.* == .export_spec);
+
+        const export_spec = node.export_spec;
+
+        // Verify that we are exposing all items
+        try testing.expect(export_spec.exposing_all);
+
+        // Verify that the export spec has no specific items
+        try testing.expect(export_spec.items == null);
+    }
+
+    {
+        const source = "exposing (Maybe(..), and_then)";
+        var l = lexer.Lexer.init(source, TEST_FILE);
+        var parser = try Parser.init(allocator, &l);
+        defer parser.deinit();
+
+        // Action
+        const node = try parser.parseExportSpec();
+        defer {
+            node.release(allocator);
+            allocator.destroy(node);
+        }
+
+        // Assertions
+        // Verify that the node type is an export spec
+        try testing.expect(node.* == .export_spec);
+
+        const export_spec = node.export_spec;
+
+        // Verify that we are not exposing all items
+        try testing.expect(!export_spec.exposing_all);
+
+        // Verify that the export spec has exactly two items
+        try testing.expectEqual(@as(usize, 2), export_spec.items.?.items.len);
+
+        // Check the first exported item (Maybe with constructors)
+        const type_item = export_spec.items.?.items[0];
+        try testing.expectEqualStrings("Maybe", type_item.name);
+        try testing.expect(type_item.expose_constructors);
+
+        // Check the second exported item (and_then function)
+        const func_item = export_spec.items.?.items[1];
+        try testing.expectEqualStrings("and_then", func_item.name);
+        try testing.expect(!func_item.expose_constructors);
+    }
+
+    {
+        const source = "exposing (Result, map, flatMap, withDefault)";
+        var l = lexer.Lexer.init(source, TEST_FILE);
+        var parser = try Parser.init(allocator, &l);
+        defer parser.deinit();
+
+        // Action
+        const node = try parser.parseExportSpec();
+        defer {
+            node.release(allocator);
+            allocator.destroy(node);
+        }
+
+        // Assertions
+        // Verify that the node type is an export spec
+        try testing.expect(node.* == .export_spec);
+
+        const export_spec = node.export_spec;
+
+        // Verify that we are not exposing all items
+        try testing.expect(!export_spec.exposing_all);
+
+        // Verify that the export spec has exactly four items
+        try testing.expectEqual(@as(usize, 4), export_spec.items.?.items.len);
+
+        // Check the first exported item (Result type without constructors)
+        try testing.expectEqualStrings("Result", export_spec.items.?.items[0].name);
+        try testing.expect(!export_spec.items.?.items[0].expose_constructors);
+
+        // Check the remaining function exports
+        try testing.expectEqualStrings("map", export_spec.items.?.items[1].name);
+        try testing.expectEqualStrings("flatMap", export_spec.items.?.items[2].name);
+        try testing.expectEqualStrings("withDefault", export_spec.items.?.items[3].name);
     }
 }
 

--- a/formatter/formatter.zig
+++ b/formatter/formatter.zig
@@ -387,7 +387,6 @@ pub const Formatter = struct {
 
                 try self.writeIndent();
                 try self.formatNode(stmt.else_branch);
-                try self.write("\n");
 
                 self.indent_level -= 1;
             },

--- a/stdlib/bitwise.mn
+++ b/stdlib/bitwise.mn
@@ -12,17 +12,38 @@ module Bitwise exposing
     , xor
     )
 
-    foreign bitwise_and(x : Int, y : Int) -> Int = "zig_bitwise_and"
-    foreign bitwise_or(x : Int, y : Int) -> Int = "zig_bitwise_or"
-    foreign bitwise_not(x : Int) -> Int = "zig_bitwise_not"
-    foreign bitwise_xor(x : Int, y : Int) -> Int = "zig_bitwise_xor"
-    foreign bitwise_shl(x : Int, y : Int) -> Int = "zig_bitwise_shl"
-    foreign bitwise_shr(x : Int, y : Int) -> Int = "zig_bitwise_shr"
-    foreign bitwise_lshr(x : Int, y : Int) -> Int = "zig_bitwise_lshr"
-    foreign bitwise_rotl(x : Int, y : Int) -> Int = "zig_bitwise_rotl"
-    foreign bitwise_rotr(x : Int, y : Int) -> Int = "zig_bitwise_rotr"
-    foreign bitwise_hw(x : Int) -> Int = "zig_bitwise_hamming_weight"
-    foreign bitwise_dist(x : Int, y : Int) -> Int = "zig_bitwise_distance"
+    foreign bitwise_and(x : Int, y : Int) -> Int =
+        "zig_bitwise_and"
+
+    foreign bitwise_or(x : Int, y : Int) -> Int =
+        "zig_bitwise_or"
+
+    foreign bitwise_not(x : Int) -> Int =
+        "zig_bitwise_not"
+
+    foreign bitwise_xor(x : Int, y : Int) -> Int =
+        "zig_bitwise_xor"
+
+    foreign bitwise_shl(x : Int, y : Int) -> Int =
+        "zig_bitwise_shl"
+
+    foreign bitwise_shr(x : Int, y : Int) -> Int =
+        "zig_bitwise_shr"
+
+    foreign bitwise_lshr(x : Int, y : Int) -> Int =
+        "zig_bitwise_lshr"
+
+    foreign bitwise_rotl(x : Int, y : Int) -> Int =
+        "zig_bitwise_rotl"
+
+    foreign bitwise_rotr(x : Int, y : Int) -> Int =
+        "zig_bitwise_rotr"
+
+    foreign bitwise_hw(x : Int) -> Int =
+        "zig_bitwise_hamming_weight"
+
+    foreign bitwise_dist(x : Int, y : Int) -> Int =
+        "zig_bitwise_distance"
 
     ## Performs a bitwise AND operation between two integers.
     ## Each bit in the result is 1 only if the corresponding

--- a/stdlib/comparable.mn
+++ b/stdlib/comparable.mn
@@ -2,7 +2,7 @@ module Comparable exposing
     ( Ordering(..)
     , compare
     , eq
-    , gt,
+    , gt
     , gte
     , lt
     , lte
@@ -17,7 +17,7 @@ module Comparable exposing
         | GT
 
     let eq(x : Bool, y : Bool) -> Bool =
-        if (x == True) && (y == True) then
+        if x == True && y == True then
             True
         else
             False
@@ -40,10 +40,11 @@ module Comparable exposing
     let compare(x : comparable, y : comparable) -> Ordering =
         if x == y then
             EQ
-        else if x < y then
-            LT
         else
-            GT
+            if x < y then
+                LT
+            else
+                GT
 
     let min(x : comparable, y : comparable) -> comparable =
         if lt(x, y) then

--- a/stdlib/date.mn
+++ b/stdlib/date.mn
@@ -30,12 +30,12 @@ module Date exposing
     let mk_date(month : Month, day : Int, year : Int) -> Date =
         Date({ month, day, year })
 
-    let today() -> Eff () Date =
+    let today() -> Eff((), Date) =
         todo("not implemented")
 
-    let map(f : (Date -> Date)), date : Date) -> Date =
+    let map(f : ((Date) -> Date)), date : Date) -> Date =
         f(date)
 
-    let and_then(mdate : Maybe(Date), f : (Date -> Maybe(Date))) -> Maybe(Date)
+    let and_then(mdate : Maybe(Date), f : ((Date) -> Maybe(Date))) -> Maybe(Date)
         Maybe.map(mdate, f)
 end

--- a/stdlib/date.mn
+++ b/stdlib/date.mn
@@ -33,7 +33,7 @@ module Date exposing
     let today() -> Eff () Date =
         todo("not implemented")
 
-    let map(f : (Date -> Date), date : Date) -> Date =
+    let map(f : (Date -> Date)), date : Date) -> Date =
         f(date)
 
     let and_then(mdate : Maybe(Date), f : (Date -> Maybe(Date))) -> Maybe(Date)

--- a/stdlib/non_empty.mn
+++ b/stdlib/non_empty.mn
@@ -1,4 +1,4 @@
-module NonEmpty where
+module NonEmpty exposing
     ( NonEmpty
     , drop_left
     , drop_while
@@ -30,7 +30,7 @@ module NonEmpty where
     let tail(list : NonEmpty(a)) -> a =
         todo("not implemented")
 
-    let map(f : (a -> b), list : NonEmpty(a)) -> NonEmpty(b) =
+    let map(f : ((a) -> b), list : NonEmpty(a)) -> NonEmpty(b) =
         todo("not implemented")
 
     let intersperse(x : a, list : NonEmpty(a)) -> NonEmpty(a) =
@@ -54,10 +54,10 @@ module NonEmpty where
     let drop_left(n : Int, list : NonEmpty(a)) -> List(a) =
         todo("not implemented")
 
-    let take_while(predicate : (a -> Bool), list : NonEmpty(a)) -> List(a) =
+    let take_while(predicate : ((a) -> Bool), list : NonEmpty(a)) -> List(a) =
         todo("not implemented")
 
-    let drop_while(predicate : (a -> Bool), list : NonEmpty(a)) -> List(a) =
+    let drop_while(predicate : ((a) -> Bool), list : NonEmpty(a)) -> List(a) =
         todo("not implemented")
 
     let from_list(list : List(a)) -> Maybe(NonEmpty(a)) =

--- a/stdlib/unit.mn
+++ b/stdlib/unit.mn
@@ -1,8 +1,4 @@
-module Unit exposing
-    ( Unit(..)
-    , ignore
-    )
-
+module Unit exposing (Unit(..), ignore)
     type Unit =
         Unit
 

--- a/stdlib/validation.mn
+++ b/stdlib/validation.mn
@@ -1,7 +1,4 @@
-module Validation exposing
-    ( Validation(..)
-    )
-
+module Validation exposing (Validation(..))
     ## Result type that accumulates errors
     type Validation(e, a) =
         Validation(e, a)


### PR DESCRIPTION
## Added:

- (Parser) Param functions now handle `_` => `let ignore(_ : a) -> Unit = Unit`
- (Formatter) Type Variants with only 1 constructor no longer add vertical pipe => `type Unit = Unit`
- (Parser) Export spec now handles upper identifiers with `(..)` => `exposing (Maybe(..), and_then)`
- (Parser) Added missing export spect tests
- (Parser) Added `_` param tests
- (Formatter) Removed weird/extra spaces w/ comments
- (StdLib) Ran formatter on a few files as a way to test how much is left with the parser
- (Formatter) Remove extra newline in if statements
- (Parser) Add support for pipe right operator => `list |> fold_left(0, fn(acc, _) => acc + 1)`