### PR TITLE
remove keyword ‘end’

### DIFF
--- a/compiler/frontend/lexer.zig
+++ b/compiler/frontend/lexer.zig
@@ -7,7 +7,6 @@ pub const KeywordKind = enum {
     Alias,
     As,
     Else,
-    End,
     Exposing,
     Fn,
     Foreign,
@@ -1336,7 +1335,6 @@ pub const Lexer = struct {
                 if (self.checkExactMatch(span_start, "alias", .{ .keyword = .Alias })) |token| return token;
                 if (self.checkExactMatch(span_start, "as", .{ .keyword = .As })) |token| return token;
                 if (self.checkExactMatch(span_start, "else", .{ .keyword = .Else })) |token| return token;
-                if (self.checkExactMatch(span_start, "end", .{ .keyword = .End })) |token| return token;
                 if (self.checkExactMatch(span_start, "exposing", .{ .keyword = .Exposing })) |token| return token;
                 if (self.checkExactMatch(span_start, "fn", .{ .keyword = .Fn })) |token| return token;
                 if (self.checkExactMatch(span_start, "foreign", .{ .keyword = .Foreign })) |token| return token;
@@ -1789,14 +1787,6 @@ test "[keyword]" {
             .token = Token.init(.{ .keyword = .Else }, "else", .{
                 .filename = TEST_FILE,
                 .span = .{ .start = 0, .end = 4 },
-                .src = .{ .line = 1, .col = 1 },
-            }),
-        },
-        .{
-            .source = "end",
-            .token = Token.init(.{ .keyword = .End }, "end", .{
-                .filename = TEST_FILE,
-                .span = .{ .start = 0, .end = 3 },
                 .src = .{ .line = 1, .col = 1 },
             }),
         },
@@ -3736,9 +3726,9 @@ test "[record type]" {
     }
 }
 
-test "[module definition]" {
+test "[module declaration]" {
     // Setup
-    const source = "module Foo exposing (Foo(..), bar) end";
+    const source = "module Foo exposing (Foo(..), bar)";
 
     const expected_tokens = [_]Token{
         Token.init(.{ .keyword = .Module }, "module", .{
@@ -3796,15 +3786,10 @@ test "[module definition]" {
             .span = .{ .start = 33, .end = 34 },
             .src = .{ .line = 1, .col = 34 },
         }),
-        Token.init(.{ .keyword = .End }, "end", .{
-            .filename = TEST_FILE,
-            .span = .{ .start = 35, .end = 38 },
-            .src = .{ .line = 1, .col = 36 },
-        }),
         Token.init(.{ .special = .Eof }, "", .{
             .filename = TEST_FILE,
-            .span = .{ .start = 38, .end = 38 },
-            .src = .{ .line = 1, .col = 39 },
+            .span = .{ .start = 34, .end = 34 },
+            .src = .{ .line = 1, .col = 35 },
         }),
     };
 

--- a/compiler/frontend/parser.zig
+++ b/compiler/frontend/parser.zig
@@ -587,7 +587,7 @@ pub const Parser = struct {
             declarations.deinit();
         }
 
-        while (!self.check(lexer.TokenKind{ .keyword = .End })) {
+        while (!self.check(lexer.TokenKind{ .special = .Eof })) {
             const decl = try self.parseModuleStmt();
             errdefer {
                 decl.release(self.allocator);
@@ -597,7 +597,7 @@ pub const Parser = struct {
             try declarations.append(decl);
         }
 
-        _ = try self.expect(lexer.TokenKind{ .keyword = .End });
+        _ = try self.expect(lexer.TokenKind{ .special = .Eof });
 
         const module_node = try self.allocator.create(ast.ModuleDeclNode);
         errdefer module_node.release(self.allocator);
@@ -5655,7 +5655,7 @@ test "[module_decl]" {
     const allocator = gpa.allocator();
 
     {
-        const source = "module Foo exposing (double)\n" ++ "let double(x : Int) -> Int = x * 2\n" ++ "end";
+        const source = "module Foo exposing (double)\n" ++ "let double(x : Int) -> Int = x * 2\n";
         var l = lexer.Lexer.init(source, TEST_FILE);
         var parser = try Parser.init(allocator, &l);
         defer parser.deinit();
@@ -5693,7 +5693,7 @@ test "[program]" {
     const allocator = gpa.allocator();
 
     {
-        const source = "## some doc comment\n" ++ "module Foo exposing (double)\n" ++ "let double(x : Int) -> Int = x * 2\n" ++ "end";
+        const source = "## some doc comment\n" ++ "module Foo exposing (double)\n" ++ "let double(x : Int) -> Int = x * 2\n";
         var l = lexer.Lexer.init(source, TEST_FILE);
         var parser = try Parser.init(allocator, &l);
         defer parser.deinit();

--- a/docs/spec/features/modules.md
+++ b/docs/spec/features/modules.md
@@ -10,8 +10,8 @@ Modules are used to group functions around related types. Functions are private 
 
 ```mn
 module MyModule exposing (..)
-    # module contents here
-end
+
+# module contents here
 ```
 
 ### Access Control
@@ -75,10 +75,10 @@ Modules can be used to create opaque types by controlling what constructors are 
 ```mn
 # In MyModule.mn
 module MyModule exposing (MyType)  # Type but not constructors
-    type MyType = 
-        | Constructor1 
-        | Constructor2
-end
+
+type MyType = 
+    | Constructor1 
+    | Constructor2
 ```
 
 ## Best Practices

--- a/docs/spec/syntax.md
+++ b/docs/spec/syntax.md
@@ -10,7 +10,6 @@ The following are reserved keywords in the language:
 alias,
 as,
 else,
-end,
 exposing,
 foreign,
 fn,

--- a/formatter/formatter.zig
+++ b/formatter/formatter.zig
@@ -839,7 +839,7 @@ pub const Formatter = struct {
                 try self.formatNode(&.{ .export_spec = decl.exports });
                 try self.write("\n");
 
-                self.indent_level += 1;
+                // self.indent_level += 1;
 
                 for (decl.declarations.items, 0..) |declaration, i| {
                     try self.writeIndent();
@@ -852,9 +852,9 @@ pub const Formatter = struct {
                     }
                 }
 
-                self.indent_level -= 1;
+                // self.indent_level -= 1;
 
-                try self.write("end");
+                // try self.write("end");
             },
             .program => |prog| {
                 for (prog.statements.items) |stmt| {

--- a/stdlib/aff.mn
+++ b/stdlib/aff.mn
@@ -11,108 +11,107 @@ module Aff exposing
     , succeed
     )
 
-    ## Model asynchroneous effects.
-    ##
-    ## @since 0.1.0
-    ##
-    ## ```
-    ## ➢
-    ## :
-    ## ```
-    type alias Aff(e, a) =
-        AsyncEffect(e, a)
+## Model asynchroneous effects.
+##
+## @since 0.1.0
+##
+## ```
+## ➢
+## :
+## ```
+type alias Aff(e, a) =
+    AsyncEffect(e, a)
 
-    ## Lifts an error into a failed `Aff`.
-    ##
-    ## @since 0.1.0
-    ##
-    ## ```
-    ## ➢ Aff.fail("foobar!") : Aff(String, String)
-    ## : Aff(String, String)
-    ## ```
-    let fail(err : e) -> Aff(e, Unit) =
-        Scheduler.Async.fail(err)
+## Lifts an error into a failed `Aff`.
+##
+## @since 0.1.0
+##
+## ```
+## ➢ Aff.fail("foobar!") : Aff(String, String)
+## : Aff(String, String)
+## ```
+let fail(err : e) -> Aff(e, Unit) =
+    Scheduler.Async.fail(err)
 
-    ## Lifts a value into a successful `Aff`.
-    ##
-    ## @since 0.1.0
-    ##
-    ## ```
-    ## ➢ Aff.success("foobar") : Aff(String, String)
-    ## : Aff(String, String)
-    ## ```
-    let succeed(value : a) -> Aff(Unit, a) =
-        Scheduler.Async.succeed(value)
+## Lifts a value into a successful `Aff`.
+##
+## @since 0.1.0
+##
+## ```
+## ➢ Aff.success("foobar") : Aff(String, String)
+## : Aff(String, String)
+## ```
+let succeed(value : a) -> Aff(Unit, a) =
+    Scheduler.Async.succeed(value)
 
-    let map(aff_a : Aff(e, a), f : (a -> b)) =
-        match run(aff_a) on
-        | Err(ea) => fail(ea)
-        | Ok(a) => succeed(f(a))
+let map(aff_a : Aff(e, a), f : (a -> b)) =
+    match run(aff_a) on
+    | Err(ea) => fail(ea)
+    | Ok(a) => succeed(f(a))
 
-    let map2(
-        aff_a: Aff(e, a),
-        aff_b: Aff(e, b),
-        f: ((a, b) -> c)
-    ) -> Aff(e, c) =
-        match run(aff_a) on
-        | Err(ea) => fail(ea)
-        | Ok(a) =>
-            match run(aff_b) on
-            | Err(eb) => fail(eb)
-            | Ok(b) => succeed(f(a, b))
+let map2(
+    aff_a: Aff(e, a),
+    aff_b: Aff(e, b),
+    f: ((a, b) -> c)
+) -> Aff(e, c) =
+    match run(aff_a) on
+    | Err(ea) => fail(ea)
+    | Ok(a) =>
+        match run(aff_b) on
+        | Err(eb) => fail(eb)
+        | Ok(b) => succeed(f(a, b))
 
-    let map3(
-        aff_a: Aff(e, a),
-        aff_b: Aff(e, b),
-        aff_c: Aff(e, c),
-        f: ((a, b, c) -> d)
-    ) -> Aff(e, d) =
-        match run(aff_a) on
-        | Err(ea) => fail(ea)
-        | Ok(a) =>
-            match run(aff_b) on
-            | Err(eb) => fail(eb)
-            | Ok(b) =>
-                match run(aff_c) on
-                | Err(ec) => fail(ec)
-                | Ok(c) => succeed(f(a, b, c))
+let map3(
+    aff_a: Aff(e, a),
+    aff_b: Aff(e, b),
+    aff_c: Aff(e, c),
+    f: ((a, b, c) -> d)
+) -> Aff(e, d) =
+    match run(aff_a) on
+    | Err(ea) => fail(ea)
+    | Ok(a) =>
+        match run(aff_b) on
+        | Err(eb) => fail(eb)
+        | Ok(b) =>
+            match run(aff_c) on
+            | Err(ec) => fail(ec)
+            | Ok(c) => succeed(f(a, b, c))
 
-    let map4(
-        aff_a: Aff(e, a),
-        aff_b: Aff(e, b),
-        aff_c: Aff(e, c),
-        aff_d: Aff(e, d),
-        f: ((a, b, c, d) -> e)
-    ) -> Aff(e, e) =
-        match run(aff_a) on
-        | Err(ea) => fail(ea)
-        | Ok(a) =>
-            match run(aff_b) on
-            | Err(eb) => fail(eb)
-            | Ok(b) =>
-                match run(aff_c) on
-                | Err(ec) => fail(ec)
-                | Ok(c) =>
-                    match run(aff_d) on
-                    | Err(ed) => fail(ed)
-                    | Ok(d) => succeed(f(a, b, c, d))
+let map4(
+    aff_a: Aff(e, a),
+    aff_b: Aff(e, b),
+    aff_c: Aff(e, c),
+    aff_d: Aff(e, d),
+    f: ((a, b, c, d) -> e)
+) -> Aff(e, e) =
+    match run(aff_a) on
+    | Err(ea) => fail(ea)
+    | Ok(a) =>
+        match run(aff_b) on
+        | Err(eb) => fail(eb)
+        | Ok(b) =>
+            match run(aff_c) on
+            | Err(ec) => fail(ec)
+            | Ok(c) =>
+                match run(aff_d) on
+                | Err(ed) => fail(ed)
+                | Ok(d) => succeed(f(a, b, c, d))
 
-    ## Equivalent of `>>=` from the `Monad` typeclass.
-    ##
-    ## @since 0.1.0
-    ##
-    ## ```
-    ## ➢ Aff.and_then ...
-    ## ...
-    ## ```
-    let and_then(aff: Aff(e, a), f: (a) -> Aff(e, b)) -> Aff(e, b) =
-        todo("not implemented")
+## Equivalent of `>>=` from the `Monad` typeclass.
+##
+## @since 0.1.0
+##
+## ```
+## ➢ Aff.and_then ...
+## ...
+## ```
+let and_then(aff: Aff(e, a), f: (a) -> Aff(e, b)) -> Aff(e, b) =
+    todo("not implemented")
 
-    let run(aff: Aff(e, a)) -> Result(e, a) =
-        todo("not implemented")
+let run(aff: Aff(e, a)) -> Result(e, a) =
+    todo("not implemented")
 
-    let from_result(result: Result(e, a)) -> Aff(e, a) =
-        match result on
-        | Err(e) => fail(e)
-        | Ok(a) => succeed(a)
-end
+let from_result(result: Result(e, a)) -> Aff(e, a) =
+    match result on
+    | Err(e) => fail(e)
+    | Ok(a) => succeed(a)

--- a/stdlib/bitwise.mn
+++ b/stdlib/bitwise.mn
@@ -12,175 +12,175 @@ module Bitwise exposing
     , xor
     )
 
-    foreign bitwise_and(x : Int, y : Int) -> Int =
-        "zig_bitwise_and"
+foreign bitwise_and(x : Int, y : Int) -> Int =
+    "zig_bitwise_and"
 
-    foreign bitwise_or(x : Int, y : Int) -> Int =
-        "zig_bitwise_or"
+foreign bitwise_or(x : Int, y : Int) -> Int =
+    "zig_bitwise_or"
 
-    foreign bitwise_not(x : Int) -> Int =
-        "zig_bitwise_not"
+foreign bitwise_not(x : Int) -> Int =
+    "zig_bitwise_not"
 
-    foreign bitwise_xor(x : Int, y : Int) -> Int =
-        "zig_bitwise_xor"
+foreign bitwise_xor(x : Int, y : Int) -> Int =
+    "zig_bitwise_xor"
 
-    foreign bitwise_shl(x : Int, y : Int) -> Int =
-        "zig_bitwise_shl"
+foreign bitwise_shl(x : Int, y : Int) -> Int =
+    "zig_bitwise_shl"
 
-    foreign bitwise_shr(x : Int, y : Int) -> Int =
-        "zig_bitwise_shr"
+foreign bitwise_shr(x : Int, y : Int) -> Int =
+    "zig_bitwise_shr"
 
-    foreign bitwise_lshr(x : Int, y : Int) -> Int =
-        "zig_bitwise_lshr"
+foreign bitwise_lshr(x : Int, y : Int) -> Int =
+    "zig_bitwise_lshr"
 
-    foreign bitwise_rotl(x : Int, y : Int) -> Int =
-        "zig_bitwise_rotl"
+foreign bitwise_rotl(x : Int, y : Int) -> Int =
+    "zig_bitwise_rotl"
 
-    foreign bitwise_rotr(x : Int, y : Int) -> Int =
-        "zig_bitwise_rotr"
+foreign bitwise_rotr(x : Int, y : Int) -> Int =
+    "zig_bitwise_rotr"
 
-    foreign bitwise_hw(x : Int) -> Int =
-        "zig_bitwise_hamming_weight"
+foreign bitwise_hw(x : Int) -> Int =
+    "zig_bitwise_hamming_weight"
 
-    foreign bitwise_dist(x : Int, y : Int) -> Int =
-        "zig_bitwise_distance"
+foreign bitwise_dist(x : Int, y : Int) -> Int =
+    "zig_bitwise_distance"
 
-    ## Performs a bitwise AND operation between two integers.
-    ## Each bit in the result is 1 only if the corresponding
-    ## bits in both operands are 1.
-    ##
-    ## @since 0.1.0
-    ##
-    ## ```
-    ## ➢ Bitwise.and(9, 3)
-    ## 1 : Int
-    ## ```
-    let and(x : Int, y : Int) -> Int =
-        bitwise_and(x, y)
+## Performs a bitwise AND operation between two integers.
+## Each bit in the result is 1 only if the corresponding
+## bits in both operands are 1.
+##
+## @since 0.1.0
+##
+## ```
+## ➢ Bitwise.and(9, 3)
+## 1 : Int
+## ```
+let and(x : Int, y : Int) -> Int =
+    bitwise_and(x, y)
 
-    ## Performs a bitwise OR operation between two integers.
-    ## Each bit in the result is 1 if at least one of the corresponding
-    ## bits in either operand is 1.
-    ##
-    ## @since 0.1.0
-    ##
-    ## ```
-    ## ➢ Bitwise.or(9, 3)
-    ## 11 : Int
-    ## ```
-    let or(x : Int, y : Int) -> Int =
-        bitwise_or(x, y)
+## Performs a bitwise OR operation between two integers.
+## Each bit in the result is 1 if at least one of the corresponding
+## bits in either operand is 1.
+##
+## @since 0.1.0
+##
+## ```
+## ➢ Bitwise.or(9, 3)
+## 11 : Int
+## ```
+let or(x : Int, y : Int) -> Int =
+    bitwise_or(x, y)
 
-    ## Performs a bitwise NOT operation on an integer, inverting all bits.
-    ## Each 0 becomes 1 and each 1 becomes 0 in the binary representation.
-    ##
-    ## @since 0.1.0
-    ##
-    ## ```
-    ## ➢ Bitwise.not(2)
-    ## -3 : Int
-    ## ```
-    let not(x : Int) -> Int =
-        bitwise_not(x)
+## Performs a bitwise NOT operation on an integer, inverting all bits.
+## Each 0 becomes 1 and each 1 becomes 0 in the binary representation.
+##
+## @since 0.1.0
+##
+## ```
+## ➢ Bitwise.not(2)
+## -3 : Int
+## ```
+let not(x : Int) -> Int =
+    bitwise_not(x)
 
-    ## Performs a bitwise XOR (exclusive OR) operation between two integers.
-    ## Each bit in the result is 1 only if the corresponding bits in the
-    ## operands are different.
-    ##
-    ## @since 0.1.0
-    ##
-    ## ```
-    ## ➢ Bitwise.xor(9, 3)
-    ## 10 : Int
-    ## ```
-    let xor(x : Int, y : Int) -> Int =
-        bitwise_xor(x, y)
+## Performs a bitwise XOR (exclusive OR) operation between two integers.
+## Each bit in the result is 1 only if the corresponding bits in the
+## operands are different.
+##
+## @since 0.1.0
+##
+## ```
+## ➢ Bitwise.xor(9, 3)
+## 10 : Int
+## ```
+let xor(x : Int, y : Int) -> Int =
+    bitwise_xor(x, y)
 
-    ## Shifts all bits in the first integer to the left by the number of
-    ## positions specified by the second integer. New bits are filled with zeros.
-    ##
-    ## @since 0.1.0
-    ##
-    ## ```
-    ## ➢ Bitwise.shift_left(1, 2)
-    ## 4 : Int
-    ## ```
-    let shift_left(x : Int, y : Int) -> Int =
-        bitwise_shl(x, y)
+## Shifts all bits in the first integer to the left by the number of
+## positions specified by the second integer. New bits are filled with zeros.
+##
+## @since 0.1.0
+##
+## ```
+## ➢ Bitwise.shift_left(1, 2)
+## 4 : Int
+## ```
+let shift_left(x : Int, y : Int) -> Int =
+    bitwise_shl(x, y)
 
-    ## Performs an arithmetic right shift, preserving the sign bit. All
-    ## bits are shifted right by the specified number of positions, with
-    ## the sign bit being copied into the newly vacated bit positions.
-    ##
-    ## @since 0.1.0
-    ##
-    ## ```
-    ## ➢ Bitwise.shift_right(1, 2)
-    ## 0 : Int
-    ## ```
-    let shift_right(x : Int, y : Int) -> Int =
-        bitwise_shr(x, y)
+## Performs an arithmetic right shift, preserving the sign bit. All
+## bits are shifted right by the specified number of positions, with
+## the sign bit being copied into the newly vacated bit positions.
+##
+## @since 0.1.0
+##
+## ```
+## ➢ Bitwise.shift_right(1, 2)
+## 0 : Int
+## ```
+let shift_right(x : Int, y : Int) -> Int =
+    bitwise_shr(x, y)
 
-    ## Performs a logical right shift, filling new bits with zeros
-    ## regardless of the sign bit. This differs from `shift_right` in how
-    ## it handles negative numbers.
-    ##
-    ## @since 0.1.0
-    ##
-    ## ```
-    ## ➢ Bitwise.logical_shift_right(1, 32)
-    ## 16 : Int
-    ## ```
-    let logical_shift_right(x : Int, y : Int) -> Int =
-        bitwise_lshr(x, y)
+## Performs a logical right shift, filling new bits with zeros
+## regardless of the sign bit. This differs from `shift_right` in how
+## it handles negative numbers.
+##
+## @since 0.1.0
+##
+## ```
+## ➢ Bitwise.logical_shift_right(1, 32)
+## 16 : Int
+## ```
+let logical_shift_right(x : Int, y : Int) -> Int =
+    bitwise_lshr(x, y)
 
-    ## Rotates all bits to the left by the specified number of positions.
-    ## Unlike shifting, bits that would be shifted out are wrapped around
-    ## to the rightmost positions.
-    ##
-    ## @since 0.1.0
-    ##
-    ## ```
-    ## ➢ Bitwise.rotate_left(11, 2)
-    ## 14 : Int
-    ## ```
-    let rotate_left(x : Int, y : Int) -> Int =
-        bitwise_rotl(x, y)
+## Rotates all bits to the left by the specified number of positions.
+## Unlike shifting, bits that would be shifted out are wrapped around
+## to the rightmost positions.
+##
+## @since 0.1.0
+##
+## ```
+## ➢ Bitwise.rotate_left(11, 2)
+## 14 : Int
+## ```
+let rotate_left(x : Int, y : Int) -> Int =
+    bitwise_rotl(x, y)
 
-    ## Rotates all bits to the right by the specified number of positions.
-    ## Unlike shifting, bits that would be shifted out are wrapped around
-    ## to the leftmost positions.
-    ##
-    ## @since 0.1.0
-    ##
-    ## ```
-    ## ➢ Bitwise.rotate_right(11, 2)
-    ## 14 : Int
-    ## ```
-    let rotate_right(x : Int, y : Int) -> Int =
-        bitwise_rotr(x, y)
+## Rotates all bits to the right by the specified number of positions.
+## Unlike shifting, bits that would be shifted out are wrapped around
+## to the leftmost positions.
+##
+## @since 0.1.0
+##
+## ```
+## ➢ Bitwise.rotate_right(11, 2)
+## 14 : Int
+## ```
+let rotate_right(x : Int, y : Int) -> Int =
+    bitwise_rotr(x, y)
 
-    ## Returns the Hamming weight (population count) of an integer - the
-    ## number of 1s in its binary representation.
-    ##
-    ## @since 0.1.0
-    ##
-    ## ```
-    ## ➢ Bitwise.hamming_weight(29)
-    ## 4 : Int
-    ## ```
-    let hamming_weight(x : Int) -> Int =
-        bitwise_hw(x)
+## Returns the Hamming weight (population count) of an integer - the
+## number of 1s in its binary representation.
+##
+## @since 0.1.0
+##
+## ```
+## ➢ Bitwise.hamming_weight(29)
+## 4 : Int
+## ```
+let hamming_weight(x : Int) -> Int =
+    bitwise_hw(x)
 
-    ## Calculates the Hamming distance between two integers - the number of
-    ## positions at which their binary representations differ.
-    ##
-    ## @since 0.1.0
-    ##
-    ## ```
-    ## ➢ Bitwise.distance(29, 21)
-    ## 1 : Int
-    ## ```
-    let distance(x : Int, y : Int) -> Int =
-        bitwise_dist(x, y)
-end
+## Calculates the Hamming distance between two integers - the number of
+## positions at which their binary representations differ.
+##
+## @since 0.1.0
+##
+## ```
+## ➢ Bitwise.distance(29, 21)
+## 1 : Int
+## ```
+let distance(x : Int, y : Int) -> Int =
+    bitwise_dist(x, y)
+

--- a/stdlib/boolean.mn
+++ b/stdlib/boolean.mn
@@ -8,104 +8,103 @@ module Boolean exposing
     , xor
     )
 
-    ## The `Bool` type represents binary true/false values used for logical operations.
-    type Bool =
-        | False
-        | True
+## The `Bool` type represents binary true/false values used for logical operations.
+type Bool =
+    | False
+    | True
 
-    ## Negates a boolean value.
-    ## Returns `True` for `False` input and `False` for `True` input.
-    ##
-    ## @since 0.1.0
-    ##
-    ## ```
-    ## ➢ Boolean.not(True)
-    ## False : Bool
-    ## ```
-    let not(x : Bool) -> Bool =
-        match x on
-        | False => True
-        | True => False
+## Negates a boolean value.
+## Returns `True` for `False` input and `False` for `True` input.
+##
+## @since 0.1.0
+##
+## ```
+## ➢ Boolean.not(True)
+## False : Bool
+## ```
+let not(x : Bool) -> Bool =
+    match x on
+    | False => True
+    | True => False
 
-    ## Returns `True` only if both inputs are `True`.
-    ## Classic logical AND operation from boolean algebra.
-    ##
-    ## @since 0.1.0
-    ##
-    ## ```
-    ## ➢ Boolean.and(True, False)
-    ## False : Bool
-    ##
-    ## ➢ Boolean.and(True, True)
-    ## True : Bool
-    ## ```
-    let and(x : Bool, y : Bool) -> Bool =
-        match (x, y) on
-        | (True, True) => True
-        | _ => False
+## Returns `True` only if both inputs are `True`.
+## Classic logical AND operation from boolean algebra.
+##
+## @since 0.1.0
+##
+## ```
+## ➢ Boolean.and(True, False)
+## False : Bool
+##
+## ➢ Boolean.and(True, True)
+## True : Bool
+## ```
+let and(x : Bool, y : Bool) -> Bool =
+    match (x, y) on
+    | (True, True) => True
+    | _ => False
 
-    ## Returns `False` only if both inputs are `True`.
-    ## Equivalent to negating the AND of both inputs.
-    ##
-    ## @since 0.1.0
-    ##
-    ## ```
-    ## ➢ Boolean.nand(True, False)
-    ## True : Bool
-    ##
-    ## ➢ Boolean.nand(True, True)
-    ## False : Bool
-    ## ```
-    let nand(x : Bool, y : Bool) -> Bool =
-        not(and(x, y))
+## Returns `False` only if both inputs are `True`.
+## Equivalent to negating the AND of both inputs.
+##
+## @since 0.1.0
+##
+## ```
+## ➢ Boolean.nand(True, False)
+## True : Bool
+##
+## ➢ Boolean.nand(True, True)
+## False : Bool
+## ```
+let nand(x : Bool, y : Bool) -> Bool =
+    not(and(x, y))
 
-    ## Returns `True` if either input is `True`.
-    ## Classic logical OR operation from boolean algebra.
-    ##
-    ## @since 0.1.0
-    ##
-    ## ```
-    ## ➢ Boolean.or(True, False)
-    ## True : Bool
-    ##
-    ## ➢ Boolean.or(False, False)
-    ## False : Bool
-    ## ```
-    let or(x : Bool, y : Bool) -> Bool =
-        match (x, y) on
-        | (False, False) => False
-        | _ => True
+## Returns `True` if either input is `True`.
+## Classic logical OR operation from boolean algebra.
+##
+## @since 0.1.0
+##
+## ```
+## ➢ Boolean.or(True, False)
+## True : Bool
+##
+## ➢ Boolean.or(False, False)
+## False : Bool
+## ```
+let or(x : Bool, y : Bool) -> Bool =
+    match (x, y) on
+    | (False, False) => False
+    | _ => True
 
-    ## Returns `True` only if both inputs are `False`.
-    ## Equivalent to negating the OR of both inputs.
-    ##
-    ## @since 0.1.0
-    ##
-    ## ```
-    ## ➢ Boolean.nor(False, False)
-    ## True : Bool
-    ##
-    ## ➢ Boolean.nor(True, False)
-    ## False : Bool
-    ## ```
-    let nor(x : Bool, y : Bool) -> Bool =
-        not(or(x, y))
+## Returns `True` only if both inputs are `False`.
+## Equivalent to negating the OR of both inputs.
+##
+## @since 0.1.0
+##
+## ```
+## ➢ Boolean.nor(False, False)
+## True : Bool
+##
+## ➢ Boolean.nor(True, False)
+## False : Bool
+## ```
+let nor(x : Bool, y : Bool) -> Bool =
+    not(or(x, y))
 
-    ## Returns `True` if exactly one input is `True`.
-    ## Also known as "exclusive or" - `True` when inputs differ.
-    ##
-    ## @since 0.1.0
-    ##
-    ## ```
-    ## ➢ Boolean.xor(True, False)
-    ## True : Bool
-    ##
-    ## ➢ Boolean.xor(True, True)
-    ## False : Bool
-    ## ```
-    let xor(x : Bool, y : Bool) -> Bool =
-        match (x, y) on
-        | (False, False) => False
-        | (True, True) => False
-        | _ => True
-end
+## Returns `True` if exactly one input is `True`.
+## Also known as "exclusive or" - `True` when inputs differ.
+##
+## @since 0.1.0
+##
+## ```
+## ➢ Boolean.xor(True, False)
+## True : Bool
+##
+## ➢ Boolean.xor(True, True)
+## False : Bool
+## ```
+let xor(x : Bool, y : Bool) -> Bool =
+    match (x, y) on
+    | (False, False) => False
+    | (True, True) => False
+    | _ => True

--- a/stdlib/comparable.mn
+++ b/stdlib/comparable.mn
@@ -11,50 +11,50 @@ module Comparable exposing
     , neq
     )
 
-    type Ordering =
-        | EQ
-        | LT
-        | GT
+type Ordering =
+    | EQ
+    | LT
+    | GT
 
-    let eq(x : Bool, y : Bool) -> Bool =
-        if x == True && y == True then
-            True
+let eq(x : Bool, y : Bool) -> Bool =
+    if x == True && y == True then
+        True
+    else
+        False
+
+let neq(x : Bool, y : Bool) -> Bool =
+    not(eq(x, y))
+
+let lt(x : comparable, y : comparable) -> Bool =
+    todo("not implemented")
+
+let gt(x : comparable, y : comparable) -> Bool =
+    todo("not implemented")
+
+let lte(x : comparable, y : comparable) -> Bool =
+    todo("not implemented")
+
+let gte(x : comparable, y : comparable) -> Bool =
+    todo("not implemented")
+
+let compare(x : comparable, y : comparable) -> Ordering =
+    if x == y then
+        EQ
+    else
+        if x < y then
+            LT
         else
-            False
+            GT
 
-    let neq(x : Bool, y : Bool) -> Bool =
-        not(eq(x, y))
+let min(x : comparable, y : comparable) -> comparable =
+    if lt(x, y) then
+        x
+    else
+        y
 
-    let lt(x : comparable, y : comparable) -> Bool =
-        todo("not implemented")
+let max(x : comparable, y : comparable) -> comparable =
+    if gt(x, y) then
+        x
+    else
+        y
 
-    let gt(x : comparable, y : comparable) -> Bool =
-        todo("not implemented")
-
-    let lte(x : comparable, y : comparable) -> Bool =
-        todo("not implemented")
-
-    let gte(x : comparable, y : comparable) -> Bool =
-        todo("not implemented")
-
-    let compare(x : comparable, y : comparable) -> Ordering =
-        if x == y then
-            EQ
-        else
-            if x < y then
-                LT
-            else
-                GT
-
-    let min(x : comparable, y : comparable) -> comparable =
-        if lt(x, y) then
-            x
-        else
-            y
-
-    let max(x : comparable, y : comparable) -> comparable =
-        if gt(x, y) then
-            x
-        else
-            y
-end

--- a/stdlib/date.mn
+++ b/stdlib/date.mn
@@ -7,35 +7,34 @@ module Date exposing
     , today
     )
 
-    type Date = Date
-        { month : Month
-        , day : Int
-        , year : Int
-        }
+type Date = Date
+    { month : Month
+    , day : Int
+    , year : Int
+    }
 
-    type Month =
-        | January
-        | February
-        | March
-        | April
-        | May
-        | June
-        | July
-        | August
-        | September
-        | October
-        | November
-        | December
+type Month =
+    | January
+    | February
+    | March
+    | April
+    | May
+    | June
+    | July
+    | August
+    | September
+    | October
+    | November
+    | December
 
-    let mk_date(month : Month, day : Int, year : Int) -> Date =
-        Date({ month, day, year })
+let mk_date(month : Month, day : Int, year : Int) -> Date =
+    Date({ month, day, year })
 
-    let today() -> Eff((), Date) =
-        todo("not implemented")
+let today() -> Eff((), Date) =
+    todo("not implemented")
 
-    let map(f : ((Date) -> Date)), date : Date) -> Date =
-        f(date)
+let map(f : ((Date) -> Date)), date : Date) -> Date =
+    f(date)
 
-    let and_then(mdate : Maybe(Date), f : ((Date) -> Maybe(Date))) -> Maybe(Date)
-        Maybe.map(mdate, f)
-end
+let and_then(mdate : Maybe(Date), f : ((Date) -> Maybe(Date))) -> Maybe(Date)
+    Maybe.map(mdate, f)

--- a/stdlib/eff.mn
+++ b/stdlib/eff.mn
@@ -11,108 +11,107 @@ module Eff exposing
     , succeed
     )
 
-    ## Model synchroneous effects.
-    ##
-    ## @since 0.1.0
-    ##
-    ## ```
-    ## ➢
-    ## :
-    ## ```
-    type alias Eff(e, a) =
-        SyncEffect(e, a)
+## Model synchroneous effects.
+##
+## @since 0.1.0
+##
+## ```
+## ➢
+## :
+## ```
+type alias Eff(e, a) =
+    SyncEffect(e, a)
 
-    ## Lifts an error into a failed `Eff`.
-    ##
-    ## @since 0.1.0
-    ##
-    ## ```
-    ## ➢ Eff.fail("foobar!") : Eff(String, String)
-    ## :
-    ## ```
-    let fail(err : e) -> Eff(e, Unit) =
-        Scheduler.Sync.fail(err)
+## Lifts an error into a failed `Eff`.
+##
+## @since 0.1.0
+##
+## ```
+## ➢ Eff.fail("foobar!") : Eff(String, String)
+## :
+## ```
+let fail(err : e) -> Eff(e, Unit) =
+    Scheduler.Sync.fail(err)
 
-    ## Lifts a value into a successful `#ff`.
-    ##
-    ## @since 0.1.0
-    ##
-    ## ```
-    ## ➢ Eff.success("foobar") : Eff(String, String)
-    ## :
-    ## ```
-    let succeed(value : a) -> Eff(Unit, a) =
-        Scheduler.Sync.succeed(value)
+## Lifts a value into a successful `#ff`.
+##
+## @since 0.1.0
+##
+## ```
+## ➢ Eff.success("foobar") : Eff(String, String)
+## :
+## ```
+let succeed(value : a) -> Eff(Unit, a) =
+    Scheduler.Sync.succeed(value)
 
-    let map(eff_a : Eff(e, a), f : (a -> value)) -> Eff(e, value) =
-        match run(eff_a) on
-        | Err ea => fail(ea)
-        | Ok a => succeed(f(a))
+let map(eff_a : Eff(e, a), f : (a -> value)) -> Eff(e, value) =
+    match run(eff_a) on
+    | Err ea => fail(ea)
+    | Ok a => succeed(f(a))
 
-    let map2(
-        eff_a : Eff(e, a),
-        eff_b : Eff(e, b),
-        f : ((a, b) -> value)
-    ) -> Eff(e, value) =
-        match run(eff_a) on
-        | Err(ea) => fail(ea)
-        | Ok(a) =>
-            match run(eff_b) on
-            | Err(eb) => fail(eb)
-            | Ok(b) => succeed(f(a, b))
+let map2(
+    eff_a : Eff(e, a),
+    eff_b : Eff(e, b),
+    f : ((a, b) -> value)
+) -> Eff(e, value) =
+    match run(eff_a) on
+    | Err(ea) => fail(ea)
+    | Ok(a) =>
+        match run(eff_b) on
+        | Err(eb) => fail(eb)
+        | Ok(b) => succeed(f(a, b))
 
-    let map3(
-        eff_a : Eff(e, a),
-        eff_b : Eff(e, b),
-        eff_c : Eff(e, c),
-        f : ((a, b, c) -> value)
-    ) -> Eff(e, value) =
-        match run(eff_a) on
-        | Err(ea) => fail(ea)
-        | Ok(a) =>
-            match run(eff_b) on
-            | Err(eb) => fail(eb)
-            | Ok(b) =>
-                match run(eff_c) on
-                | Err(ec) => fail(ec)
-                | Ok(c) => succeed(f(a, b, c))
+let map3(
+    eff_a : Eff(e, a),
+    eff_b : Eff(e, b),
+    eff_c : Eff(e, c),
+    f : ((a, b, c) -> value)
+) -> Eff(e, value) =
+    match run(eff_a) on
+    | Err(ea) => fail(ea)
+    | Ok(a) =>
+        match run(eff_b) on
+        | Err(eb) => fail(eb)
+        | Ok(b) =>
+            match run(eff_c) on
+            | Err(ec) => fail(ec)
+            | Ok(c) => succeed(f(a, b, c))
 
-    let map4(
-        eff_a : Eff(e, a),
-        eff_b : Eff(e, b),
-        eff_c : Eff(e, c),
-        eff_d : Eff(e, d),
-        f : ((a, b, c, d) -> value)
-    ) -> Eff(e, value) =
-        match run(eff_a) on
-        | Err(ea) => fail(ea)
-        | Ok(a) =>
-            match run(eff_b) on
-            | Err(eb) => fail(eb)
-            | Ok(b) =>
-                match run(eff_c) on
-                | Err(ec) => fail(ec)
-                | Ok(c) =>
-                    match run(eff_d) on
-                    | Err(ed) => fail(ed)
-                    | Ok(d) => succeed(f(a, b, c, d))
+let map4(
+    eff_a : Eff(e, a),
+    eff_b : Eff(e, b),
+    eff_c : Eff(e, c),
+    eff_d : Eff(e, d),
+    f : ((a, b, c, d) -> value)
+) -> Eff(e, value) =
+    match run(eff_a) on
+    | Err(ea) => fail(ea)
+    | Ok(a) =>
+        match run(eff_b) on
+        | Err(eb) => fail(eb)
+        | Ok(b) =>
+            match run(eff_c) on
+            | Err(ec) => fail(ec)
+            | Ok(c) =>
+                match run(eff_d) on
+                | Err(ed) => fail(ed)
+                | Ok(d) => succeed(f(a, b, c, d))
 
-    ## Equivalent of `>>=` from the `Monad` typeclass.
-    ##
-    ## @since 0.1.0
-    ##
-    ## ```
-    ## ➢ Eff.and_then ...
-    ## ...
-    ## ```
-    let and_then(eff : Eff(e, a), f : (a -> Eff(e, value))) -> Eff(e, value) =
-        todo("not implemented")
+## Equivalent of `>>=` from the `Monad` typeclass.
+##
+## @since 0.1.0
+##
+## ```
+## ➢ Eff.and_then ...
+## ...
+## ```
+let and_then(eff : Eff(e, a), f : (a -> Eff(e, value))) -> Eff(e, value) =
+    todo("not implemented")
 
-    let run(eff : Eff(e, a)) -> Result(e, a) =
-        todo("not implemented")
+let run(eff : Eff(e, a)) -> Result(e, a) =
+    todo("not implemented")
 
-    let from_result(result : Result(e, a)) -> Eff(e, a) =
-        match result on
-        | Err(e) => fail(e)
-        | Ok(a) => succeed(a)
-end
+let from_result(result : Result(e, a)) -> Eff(e, a) =
+    match result on
+    | Err(e) => fail(e)
+    | Ok(a) => succeed(a)

--- a/stdlib/float.mn
+++ b/stdlib/float.mn
@@ -41,372 +41,430 @@ module Float exposing
     , trunc
     )
 
-    type alias Radians =
-        Float
+type alias Radians =
+    Float
 
-    type alias Degrees =
-        Float
+type alias Degrees =
+    Float
 
-    foreign float_sqrt(x : Float) -> Float = "zig_float_sqrt"
-    foreign float_log(x : Float, y : Float) -> Float = "zig_float_log"
-    foreign float_e() -> Float = "zig_float_e"
-    foreign float_pi() -> Float = "zig_float_pi"
-    foreign float_cos(x : Float) -> Float = "zig_float_cos"
-    foreign float_sin(x : Float) -> Float = "zig_float_sin"
-    foreign float_tan(x : Float) -> Float = "zig_float_tan"
-    foreign float_acos(x : Float) -> Float = "zig_float_acos"
-    foreign float_asin(x : Float) -> Float = "zig_float_asin"
-    foreign float_atan(x : Float) -> Float = "zig_float_atan"
-    foreign float_atan2(x : Float, y : Float) -> Float = "zig_float_atan2"
-    foreign float_trunc(x : Float) -> Int = "zig_float_trunc"
-    foreign float_ceil(x : Float) -> Int = "zig_float_ceil"
-    foreign float_floor(x : Float) -> Int = "zig_float_floor"
-    foreign float_round(x : Float) -> Int = "zig_float_round"
-    foreign float_cosh(x : Float) -> Float = "zig_float_cosh"
-    foreign float_sinh(x : Float) -> Float = "zig_float_sinh"
-    foreign float_tanh(x : Float) -> Float = "zig_float_tanh"
-    foreign float_sech(x : Float) -> Float = "zig_float_sech"
-    foreign float_cosech(x : Float) -> Float = "zig_float_cosech"
-    foreign float_acosh(x : Float) -> Float = "zig_float_acosh"
-    foreign float_asinh(x : Float) -> Float = "zig_float_asinh"
-    foreign float_atanh(x : Float) -> Float = "zig_float_atanh"
-    foreign float_acoth(x : Float) -> Float = "zig_float_acoth"
-    foreign float_asech(x : Float) -> Float = "zig_float_asech"
-    foreign float_acosech(x : Float) -> Float = "zig_float_acosech"
-    foreign float_min() -> Float = "zig_float_min"
-    foreign float_max() -> Float = "zig_float_max"
-    foreign float_from_int(x : Int) -> Float = "zig_float_from_int"
+foreign float_sqrt(x : Float) -> Float =
+    "zig_float_sqrt"
 
-    ## Get the absolute value of a number.
-    ##
-    ## @since 0.1.0
-    ##
-    ## ```
-    ## ➢ Float.abs(-42.0)
-    ## 42.0 : Float
-    ## ```
-    let abs(x : Float) -> Float =
-        if x < 0 then
-            -x
-        else
-            x
+foreign float_log(x : Float, y : Float) -> Float =
+    "zig_float_log"
 
-    ## Calculates the value of *x* to the power of *y*.
-    ##
-    ## @since 0.1.0
-    ##
-    ## ```
-    ## ➢ Float.pow(9.0, 3.0)
-    ## 729.0 : Float
-    ## ```
-    let pow(x : Float, y : Float) -> Float =
-        todo("not implemented")
+foreign float_e() -> Float =
+    "zig_float_e"
 
-    ## Integer remainder.
-    ##
-    ## @since 0.1.0
-    ##
-    ## ```
-    ## ➢ Float.mod(42, 8)
-    ## 2 : Int
-    ## ```
-    let mod(x : Float, y : Float) -> Float =
-        todo("not implemented")
+foreign float_pi() -> Float =
+    "zig_float_pi"
 
-    ## Clamps a number within a given range.
-    ##
-    ## @since 0.1.0
-    ##
-    ## ```
-    ## ➢ Float.clamp(100.0, 200.0, 99.0)
-    ## 100.0 : Float
-    ## ```
-    let clamp(low : Float, hight : Float, n : Float) -> Float =
-        if n < low then
-            low
-        else if n > high then
+foreign float_cos(x : Float) -> Float =
+    "zig_float_cos"
+
+foreign float_sin(x : Float) -> Float =
+    "zig_float_sin"
+
+foreign float_tan(x : Float) -> Float =
+    "zig_float_tan"
+
+foreign float_acos(x : Float) -> Float =
+    "zig_float_acos"
+
+foreign float_asin(x : Float) -> Float =
+    "zig_float_asin"
+
+foreign float_atan(x : Float) -> Float =
+    "zig_float_atan"
+
+foreign float_atan2(x : Float, y : Float) -> Float =
+    "zig_float_atan2"
+
+foreign float_trunc(x : Float) -> Int =
+    "zig_float_trunc"
+
+foreign float_ceil(x : Float) -> Int =
+    "zig_float_ceil"
+
+foreign float_floor(x : Float) -> Int =
+    "zig_float_floor"
+
+foreign float_round(x : Float) -> Int =
+    "zig_float_round"
+
+foreign float_cosh(x : Float) -> Float =
+    "zig_float_cosh"
+
+foreign float_sinh(x : Float) -> Float =
+    "zig_float_sinh"
+
+foreign float_tanh(x : Float) -> Float =
+    "zig_float_tanh"
+
+foreign float_sech(x : Float) -> Float =
+    "zig_float_sech"
+
+foreign float_cosech(x : Float) -> Float =
+    "zig_float_cosech"
+
+foreign float_acosh(x : Float) -> Float =
+    "zig_float_acosh"
+
+foreign float_asinh(x : Float) -> Float =
+    "zig_float_asinh"
+
+foreign float_atanh(x : Float) -> Float =
+    "zig_float_atanh"
+
+foreign float_acoth(x : Float) -> Float =
+    "zig_float_acoth"
+
+foreign float_asech(x : Float) -> Float =
+    "zig_float_asech"
+
+foreign float_acosech(x : Float) -> Float =
+    "zig_float_acosech"
+
+foreign float_min() -> Float =
+    "zig_float_min"
+
+foreign float_max() -> Float =
+    "zig_float_max"
+
+foreign float_from_int(x : Int) -> Float =
+    "zig_float_from_int"
+
+## Get the absolute value of a number.
+##
+## @since 0.1.0
+##
+## ```
+## ➢ Float.abs(-42.0)
+## 42.0 : Float
+## ```
+let abs(x : Float) -> Float =
+    if x < 0 then
+        -x
+    else
+        x
+
+## Calculates the value of *x* to the power of *y*.
+##
+## @since 0.1.0
+##
+## ```
+## ➢ Float.pow(9.0, 3.0)
+## 729.0 : Float
+## ```
+let pow(x : Float, y : Float) -> Float =
+    todo("not implemented")
+
+## Integer remainder.
+##
+## @since 0.1.0
+##
+## ```
+## ➢ Float.mod(42, 8)
+## 2 : Int
+## ```
+let mod(x : Float, y : Float) -> Float =
+    todo("not implemented")
+
+## Clamps a number within a given range.
+##
+## @since 0.1.0
+##
+## ```
+## ➢ Float.clamp(100.0, 200.0, 99.0)
+## 100.0 : Float
+## ```
+let clamp(low : Float, hight : Float, n : Float) -> Float =
+    if n < low then
+        low
+    else
+        if n > high then
             high
         else
             n
 
-    ## Negate a number.
-    ##
-    ## @since 0.1.0
-    ##
-    ## ```
-    ## ➢ Float.negate(42.0)
-    ## -42.0 : Float
-    ## ```
-    let negate(x : Float) -> Float =
-        -x
+## Negate a number.
+##
+## @since 0.1.0
+##
+## ```
+## ➢ Float.negate(42.0)
+## -42.0 : Float
+## ```
+let negate(x : Float) -> Float =
+    -x
 
-    ## Calculate the square root of a number.
-    ##
-    ## @since 0.1.0
-    ##
-    ## ```
-    ## ➢ Float.sqrt(16.0)
-    ## 4.0 : Float
-    ## ```
-    let sqrt(x : Float, y : Float) -> Float =
-        float_sqrt(x, y)
-        # Unsafe for: Negative inputs (x < 0)
-        # Reason: The square root of a negative number is undefined for real numbers. It typically results in NaN (Not-a-Number) or an error.
+## Calculate the square root of a number.
+##
+## @since 0.1.0
+##
+## ```
+## ➢ Float.sqrt(16.0)
+## 4.0 : Float
+## ```
+let sqrt(x : Float, y : Float) -> Float =
+    float_sqrt(x, y)
 
-    ## Calculate the logarithm of a number with a given base.
-    ##
-    ## @since 0.1.0
-    ##
-    ## ```
-    ## ➢ Float.log(2.0, 256.0)
-    ## 8.0 : Float
-    ## ```
-    let log(x : Float, y : Float) -> Float =
-        float_log(x, y)
-        # x <= 0 for log x (undefined for non-positive inputs).
-        # log base x where base <= 0 or base == 1 (invalid base).
-        # log(0) approaches negative infinity, and log(x) for x < 0 is undefined.
-        # The logarithm base must be greater than 0 and not equal to 1.
+# Unsafe for: Negative inputs (x < 0)
+# Reason: The square root of a negative number is undefined for real numbers. It typically results in NaN (Not-a-Number) or an error.
+## Calculate the logarithm of a number with a given base.
+##
+## @since 0.1.0
+##
+## ```
+## ➢ Float.log(2.0, 256.0)
+## 8.0 : Float
+## ```
+let log(x : Float, y : Float) -> Float =
+    float_log(x, y)
 
-    ##
-    let log2(x : Float) -> Float =
-        log(2, x)
+# x <= 0 for log x (undefined for non-positive inputs).
+# log base x where base <= 0 or base == 1 (invalid base).
+# log(0) approaches negative infinity, and log(x) for x < 0 is undefined.
+# The logarithm base must be greater than 0 and not equal to 1.
+##
+let log2(x : Float) -> Float =
+    log(2, x)
 
-    ##
-    let log10(x : Float) -> Float =
-        log(10, x)
+##
+let log10(x : Float) -> Float =
+    log(10, x)
 
-    ## An approximation of *e*.
-    ##
-    ## @since 0.1.0
-    ##
-    ## ```
-    ## ➢ Float.e()
-    ## 3.141592653589793 : Float
-    ## ```
-    let e() -> Float =
-        float_e()
+## An approximation of *e*.
+##
+## @since 0.1.0
+##
+## ```
+## ➢ Float.e()
+## 3.141592653589793 : Float
+## ```
+let e() -> Float =
+    float_e()
 
-    ## An approximation of pie.
-    ##
-    ## @since 0.1.0
-    ##
-    ## ```
-    ## ➢ Float.pi()
-    ## 3.141592653589793 : Float
-    ## ```
-    let pi() -> Float =
-        float_pi()
+## An approximation of pie.
+##
+## @since 0.1.0
+##
+## ```
+## ➢ Float.pi()
+## 3.141592653589793 : Float
+## ```
+let pi() -> Float =
+    float_pi()
 
-    ## Calculate the cosine given an angle in radians.
-    ##
-    ## @since 0.1.0
-    ##
-    ## ```
-    ## ➢ Float.cos(3.141592653589793)
-    ## -1.0 : Float
-    ## ```
-    let cos(x : Float) -> Float =
-        float_cos(x)
+## Calculate the cosine given an angle in radians.
+##
+## @since 0.1.0
+##
+## ```
+## ➢ Float.cos(3.141592653589793)
+## -1.0 : Float
+## ```
+let cos(x : Float) -> Float =
+    float_cos(x)
 
-    ## Calculate the sine given an angle in radians.
-    ##
-    ## @since 0.1.0
-    ##
-    ## ```
-    ## ➢ Float.sin(90.0)
-    ## 0.8939966636005579 : Float
-    ## ```
-    let sin(x : Float) -> Float =
-        float_sin(x)
+## Calculate the sine given an angle in radians.
+##
+## @since 0.1.0
+##
+## ```
+## ➢ Float.sin(90.0)
+## 0.8939966636005579 : Float
+## ```
+let sin(x : Float) -> Float =
+    float_sin(x)
 
-    ## Calculate the tangent given an angle in radians.
-    ##
-    ## @since 0.1.0
-    ##
-    ## ```
-    ## ➢ Float.tan(90.0)
-    ## -1.995200412208242 : Float
-    ## ```
-    let tan(x : Float) -> Float =
-        float_tan(x)
-        # Unsafe for: Inputs near (pi/2 + n*pi) where n is an integer.
-        # Reason: Tangent is undefined at odd multiples of pi/2 and results in NaN or large values.
+## Calculate the tangent given an angle in radians.
+##
+## @since 0.1.0
+##
+## ```
+## ➢ Float.tan(90.0)
+## -1.995200412208242 : Float
+## ```
+let tan(x : Float) -> Float =
+    float_tan(x)
 
-    ## ??
-    ##
-    ## @since 0.1.0
-    ##
-    ## ```
-    ## ➢
-    ## :
-    ## ```
-    let acos(x : Float) -> Float =
-        float_acos(x)
-        # Unsafe for: Inputs outside the range [-1, 1]
-        # Reason: The inverse cosine is only defined for values between -1 and 1. Outside this range, it results in NaN.
+# Unsafe for: Inputs near (pi/2 + n*pi) where n is an integer.
+# Reason: Tangent is undefined at odd multiples of pi/2 and results in NaN or large values.
+## ??
+##
+## @since 0.1.0
+##
+## ```
+## ➢
+## :
+## ```
+let acos(x : Float) -> Float =
+    float_acos(x)
 
-    ## ??
-    ##
-    ## @since 0.1.0
-    ##
-    ## ```
-    ## ➢
-    ## :
-    ## ```
-    let asin(x : Float) -> Float =
-        float_asin(x)
-        # Unsafe for: Inputs outside the range [-1, 1].
-        # Reason: Similar to acos, asin is only defined for inputs between -1 and 1.
+# Unsafe for: Inputs outside the range [-1, 1]
+# Reason: The inverse cosine is only defined for values between -1 and 1. Outside this range, it results in NaN.
+## ??
+##
+## @since 0.1.0
+##
+## ```
+## ➢
+## :
+## ```
+let asin(x : Float) -> Float =
+    float_asin(x)
 
-    ## ??
-    ##
-    ## @since 0.1.0
-    ##
-    ## ```
-    ## ➢
-    ## :
-    ## ```
-    let atan(x : Float) -> Float =
-        float_atan(x)
+# Unsafe for: Inputs outside the range [-1, 1].
+# Reason: Similar to acos, asin is only defined for inputs between -1 and 1.
+## ??
+##
+## @since 0.1.0
+##
+## ```
+## ➢
+## :
+## ```
+let atan(x : Float) -> Float =
+    float_atan(x)
 
-    ## ??
-    ##
-    ## @since 0.1.0
-    ##
-    ## ```
-    ## ➢
-    ## :
-    ## ```
-    let atan2(x : Float, y : Float) -> Float =
-        float_atan2(x, y)
+## ??
+##
+## @since 0.1.0
+##
+## ```
+## ➢
+## :
+## ```
+let atan2(x : Float, y : Float) -> Float =
+    float_atan2(x, y)
 
-    ## Converts a degree value into radians.
-    ##
-    ## @since 0.1.0
-    ##
-    ## ```
-    ## ➢ Float.radians(Float.pi)
-    ## 3.141592653589793 : Float
-    ## ```
-    let to_radians(deg : Degrees) -> Radians =
-        deg *. (pi /. 180.0)
+## Converts a degree value into radians.
+##
+## @since 0.1.0
+##
+## ```
+## ➢ Float.radians(Float.pi)
+## 3.141592653589793 : Float
+## ```
+let to_radians(deg : Degrees) -> Radians =
+    deg *. pi /. 180.0
 
-    ## Converts an angle from radians to degrees.
-    ##
-    ## @since 0.1.0
-    ##
-    ## ```
-    ## ➢ Float.degrees(180.0)
-    ## 3.141592653589793 : Float
-    ## ```
-    let to_degrees(rad : Radians) -> Degrees =
-        rad *. (180.0 /. pi)
+## Converts an angle from radians to degrees.
+##
+## @since 0.1.0
+##
+## ```
+## ➢ Float.degrees(180.0)
+## 3.141592653589793 : Float
+## ```
+let to_degrees(rad : Radians) -> Degrees =
+    rad *. 180.0 /. pi
 
-    ## Truncate a number, rounding towards zero.
-    ##
-    ## @since 0.1.0
-    ##
-    ## ```
-    ## ➢ Float.trunc(-99.29)
-    ## -99 : Int
-    ## ```
-    let trunc(x : Float) -> Int =
-        float_trunc(x)
+## Truncate a number, rounding towards zero.
+##
+## @since 0.1.0
+##
+## ```
+## ➢ Float.trunc(-99.29)
+## -99 : Int
+## ```
+let trunc(x : Float) -> Int =
+    float_trunc(x)
 
-    ## Rounds a number up to the nearest integer.
-    ##
-    ## @since 0.1.0
-    ##
-    ## ```
-    ## ➢ Float.ceil(1.4)
-    ## 2 : Int
-    ## ```
-    let ceil(x : Float) -> Int =
-        float_ceil(x)
+## Rounds a number up to the nearest integer.
+##
+## @since 0.1.0
+##
+## ```
+## ➢ Float.ceil(1.4)
+## 2 : Int
+## ```
+let ceil(x : Float) -> Int =
+    float_ceil(x)
 
-    ## Rounds a number down to the nearest integer.
-    ##
-    ## @since 0.1.0
-    ##
-    ## ```
-    ## ➢ Float.floor(1.2)
-    ## 1 : Int
-    ## ```
-    let floor(x : Float) -> Int =
-        float_floor(x)
+## Rounds a number down to the nearest integer.
+##
+## @since 0.1.0
+##
+## ```
+## ➢ Float.floor(1.2)
+## 1 : Int
+## ```
+let floor(x : Float) -> Int =
+    float_floor(x)
 
-    ## Round a number to the nearest integer.
-    ##
-    ## @since 0.1.0
-    ##
-    ## ```
-    ## ➢ Float.round(1.2)
-    ## 1 : Int
-    ##
-    ## ➢ Float.round(1.5)
-    ## 2 : Int
-    ## ```
-    let round(x : Float) -> Int =
-        float_round(x)
+## Round a number to the nearest integer.
+##
+## @since 0.1.0
+##
+## ```
+## ➢ Float.round(1.2)
+## 1 : Int
+##
+## ➢ Float.round(1.5)
+## 2 : Int
+## ```
+let round(x : Float) -> Int =
+    float_round(x)
 
-    ## Hyperbolic cosine. Argument is in radians.
-    let cosh(x : Radians) -> Float =
-        float_cosh(x)
+## Hyperbolic cosine. Argument is in radians.
+let cosh(x : Radians) -> Float =
+    float_cosh(x)
 
-    ## Hyperbolic sine. Argument is in radians.
-    let sinh(x : Radians) -> Float =
-        float_sinh(x)
+## Hyperbolic sine. Argument is in radians.
+let sinh(x : Radians) -> Float =
+    float_sinh(x)
 
-    ## Hyperbolic tangent. Argument is in radians.
-    let tanh(x : Radians) -> Float =
-        float_tanh(x)
+## Hyperbolic tangent. Argument is in radians.
+let tanh(x : Radians) -> Float =
+    float_tanh(x)
 
-    ## Hyperbolic cotangent. Argument is in radians.
-    let coth(x : Radians) -> Float =
-        float_coth(x)
+## Hyperbolic cotangent. Argument is in radians.
+let coth(x : Radians) -> Float =
+    float_coth(x)
 
-    ## Hyperbolic secant. Argument is in radians.
-    let sech(x : Radians) -> Float =
-        float_sech(x)
+## Hyperbolic secant. Argument is in radians.
+let sech(x : Radians) -> Float =
+    float_sech(x)
 
-    ## Hyperbolic cosecant. Argument is in radians.
-    let cosech(x : Radians) -> Float =
-        float_cosech(x)
+## Hyperbolic cosecant. Argument is in radians.
+let cosech(x : Radians) -> Float =
+    float_cosech(x)
 
-    ## Hyperbolic arc cosine.
-    let acosh(x : Float) -> Float =
-        float_acosh(x)
+## Hyperbolic arc cosine.
+let acosh(x : Float) -> Float =
+    float_acosh(x)
 
-    ## Hyperbolic arc sine.
-    let asinh(x : Float) -> Float =
-        float_asinh(x)
+## Hyperbolic arc sine.
+let asinh(x : Float) -> Float =
+    float_asinh(x)
 
-    ## Hyperbolic arc cotangent.
-    let acoth(x : Float) -> Float =
-        float_acoth(x)
+## Hyperbolic arc cotangent.
+let acoth(x : Float) -> Float =
+    float_acoth(x)
 
-    ## Hyperbolic arc tangent.
-    let atanh(x : Float) -> Float =
-        float_atanh(x)
+## Hyperbolic arc tangent.
+let atanh(x : Float) -> Float =
+    float_atanh(x)
 
-    ## Hyperbolic arc secant.
-    let asech(x : Float) -> Float =
-        float_asech(x)
+## Hyperbolic arc secant.
+let asech(x : Float) -> Float =
+    float_asech(x)
 
-    ## Hyperbolic arc cosecant.
-    let acosech(x : Float) -> Float =
-        float_acosech(x)
+## Hyperbolic arc cosecant.
+let acosech(x : Float) -> Float =
+    float_acosech(x)
 
-    ##
-    let from_int(x : Int) -> Float =
-        float_from_int(x)
+##
+let from_int(x : Int) -> Float =
+    float_from_int(x)
 
-    ##
-    let max() -> Float =
-        float_max()
+##
+let max() -> Float =
+    float_max()
 
-    ##
-    let min() -> Float =
-        float_min()
-end
+##
+let min() -> Float =
+    float_min()
+

--- a/stdlib/list.mn
+++ b/stdlib/list.mn
@@ -29,312 +29,311 @@ module List exposing
     , tail
     )
 
-    type List(a) =
-        | Nil
-        | a :: List(a)
+type List(a) =
+    | Nil
+    | a :: List(a)
 
-    let cons(xs : List(a), x : a) -> List(a) =
-        x :: xs
+let cons(xs : List(a), x : a) -> List(a) =
+    x :: xs
 
-    ## Create a list with only one element.
-    ##
-    ## @since 0.1.0
-    ##
-    ## ```
-    ## ➢ List.singleton(42)
-    ## [42] : List(Int)
-    ## ```
-    let singleton(x : a) -> List(a) =
-        x :: Nil
+## Create a list with only one element.
+##
+## @since 0.1.0
+##
+## ```
+## ➢ List.singleton(42)
+## [42] : List(Int)
+## ```
+let singleton(x : a) -> List(a) =
+    x :: Nil
 
-    ## Test whether a list is empty.
-    ##
-    ## @since 0.1.0
-    ##
-    ## ```
-    ## ➢ List.empty?([42])
-    ## False : Bool
-    ##
-    ## ➢ List.empty?(Nil)
-    ## True : Bool
-    ## ```
-    let empty?(list : List(a)) -> Bool =
-        match list on
-        | Nil => True
-        | _ => False
+## Test whether a list is empty.
+##
+## @since 0.1.0
+##
+## ```
+## ➢ List.empty?([42])
+## False : Bool
+##
+## ➢ List.empty?(Nil)
+## True : Bool
+## ```
+let empty?(list : List(a)) -> Bool =
+    match list on
+    | Nil => True
+    | _ => False
 
-    ## Get the size of a list.
-    ##
-    ## @since 0.1.0
-    ##
-    ## ```
-    ## ➢ List.size([42])
-    ## 1 : Int
-    ##
-    ## ➢ List.size(Nil)
-    ## 0 : Int
-    ## ```
-    let size(list : List(a)) -> Int =
-        list
-        |> fold_left(0, fn(acc, _) => acc + 1)
+## Get the size of a list.
+##
+## @since 0.1.0
+##
+## ```
+## ➢ List.size([42])
+## 1 : Int
+##
+## ➢ List.size(Nil)
+## 0 : Int
+## ```
+let size(list : List(a)) -> Int =
+    list
+    |> fold_left(0, fn(acc, _) => acc + 1)
 
-    ## Determine if a list contains a value.
-    ##
-    ## @since 0.1.0
-    ##
-    ## ```
-    ## ➢ List.member?([42], 42)
-    ## True : Bool
-    ##
-    ## ➢ List.member?(Nil, 0)
-    ## False : Bool
-    ## ```
-    let member?(list : List(a), elem : a) -> Bool =
-        any?(list, fn(x) => x == elem)
+## Determine if a list contains a value.
+##
+## @since 0.1.0
+##
+## ```
+## ➢ List.member?([42], 42)
+## True : Bool
+##
+## ➢ List.member?(Nil, 0)
+## False : Bool
+## ```
+let member?(list : List(a), elem : a) -> Bool =
+    any?(list, fn(x) => x == elem)
 
-    ## Determine if all elements satisfy some test.
-    ##
-    ## @since 0.1.0
-    ##
-    ## ```
-    ## ➢ List.all?([2, 4, 6], fn(x) => Math.even?(x))
-    ## True : Bool
-    ## ```
-    let all?(list : List(a), predicate : (a -> Bool)) -> Bool =
-        not(any?(list, fn(x) => not(predicate(x))))
+## Determine if all elements satisfy some test.
+##
+## @since 0.1.0
+##
+## ```
+## ➢ List.all?([2, 4, 6], fn(x) => Math.even?(x))
+## True : Bool
+## ```
+let all?(list : List(a), predicate : (a -> Bool)) -> Bool =
+    not(any?(list, fn(x) => not(predicate(x))))
 
-    ## Determine if any elements satisfy some test.
-    ##
-    ## @since 0.1.0
-    ##
-    ## ```
-    ## ➢ List.any?([2, 4, 6] fn(x) => x == 4)
-    ## True : Bool
-    ## ```
-    let any?(list : List(a), predicate : (a -> Bool)) -> Bool =
-        match list on
-        | Nil => False
-        | x :: xs =>
-            if predicate(x) then
-                True
-            else
-                any?(xs, predicate)
-
-    ## Reduce a list from the left.
-    let fold_left(list : List(a), acc : b, f : (b, a) -> b) -> b =
-        match list on
-        | Nil => acc
-        | x :: xs => fold_left(xs, f(acc, x), f)
-
-    ## Reduce a list from the right.
-    let fold_right(list : List(a), acc : b, f : (a, b) -> b) -> b =
-        match list on
-        | Nil => acc
-        | x :: xs => f(x, fold_right(xs, acc, f))
-
-    ## Get the first element in a list, or `None` if the list is empty.
-    ##
-    ## @since 0.1.0
-    ##
-    ## ```
-    ## ➢ List.head([1, 2, 3])
-    ## Some(1) : Maybe(Int)
-    ##
-    ## ➢ List.head(Nil : List(Int))
-    ## None : Maybe(Int)
-    ## ```
-    let head(list : List(a)) -> Maybe(a) =
-        match list on
-        | Nil => None
-        | x :: _ => Some(x)
-
-    ## Get all but the first element of a list, or `None` if the list is empty.
-    ##
-    ## @since 0.1.0
-    ##
-    ## ```
-    ## ➢ List.tail([1, 2, 3])
-    ## Some([2, 3]) : Maybe(List(Int))
-    ##
-    ## ➢ List.tail(Nil : List(Int))
-    ## None : Maybe(List(Int))
-    ## ```
-    let tail(list : List(a)) -> Maybe(List(a)) =
-        match list on
-        | Nil => None
-        | _ :: xs => Some(xs)
-
-    ## Get the last element in a list, or `None` if the list is empty.
-    ##
-    ## @since 0.1.0
-    ##
-    ## ```
-    ## ➢ List.last([1, 2, 3])
-    ## Some(3) : Maybe(Int)
-    ##
-    ## ➢ List.last(Nil : List(Int))
-    ## None : Maybe(Int)
-    ## ```
-    let last(list : List(a)) -> Maybe(a) =
-        match list on
-        | x :: Nil => Some(x)
-        | _ :: xs => last(xs)
-        | _ => None
-
-    ## Reverse a list.
-    ##
-    ## @since 0.1.0
-    ##
-    ## ```
-    ## ➢ List.reverse([1, 2, 3])
-    ## [3, 2, 1] : List(Int)
-    ## ```
-    let reverse(list : List(a)) -> List(a) =
-        fold_left(list, Nil, fn(xs, x) => cons(xs, x))
-
-    ## Apply a function to every element in a list.
-    ##
-    ## @since 0.1.0
-    ##
-    ## ```
-    ## ➢ List.map([1, 2, 3], fn(x) => x * 2)
-    ## [2, 4, 6] : List(Int)
-    ## ```
-    let map(list : List(a), f : (a -> b)) -> List(b) =
-        fold_right(list, Nil, fn(x, acc) => cons(acc, f(x)))
-
-    ## Keep elements that satisfy the given predicate.
-    let keep(list : List(a), predicate : (a -> Bool)) -> List(a) =
-        list
-        |> fold_right(
-            Nil,
-            fn(x, xs) =>
-                if predicate(x) then
-                    cons(xs, x)
-                else
-                    xs
-        )
-
-    ## Exclude elements that satisfy the given predicate.
-    let reject(list : List(a), predicate : (a -> Bool)) -> List(a) =
-        keep(list, fn(x) => not(predicate(x)))
-
-    ## Applies filter and map simultaneously.
-    let collect_map(list : List(a), f : (a -> Maybe(b))) -> List(b) =
-        list
-        |> fold_right(
-            Nil,
-            fn(x, xs) =>
-                match f(x) on
-                | None => xs
-                | Some(y) => cons(xs, y)
-        )
-
-    ## Create a list of numbers, every element increasing by one.
-    let range(start : Int, end : Int) -> List(Int) =
-        if start > end then
-            Nil
+## Determine if any elements satisfy some test.
+##
+## @since 0.1.0
+##
+## ```
+## ➢ List.any?([2, 4, 6] fn(x) => x == 4)
+## True : Bool
+## ```
+let any?(list : List(a), predicate : (a -> Bool)) -> Bool =
+    match list on
+    | Nil => False
+    | x :: xs =>
+        if predicate(x) then
+            True
         else
-            cons(range(start + 1, end), start)
+            any?(xs, predicate)
 
-    let insert_at(list : List(a), index : Int, elem : a) -> Maybe(List(a)) =
+## Reduce a list from the left.
+let fold_left(list : List(a), acc : b, f : (b, a) -> b) -> b =
+    match list on
+    | Nil => acc
+    | x :: xs => fold_left(xs, f(acc, x), f)
+
+## Reduce a list from the right.
+let fold_right(list : List(a), acc : b, f : (a, b) -> b) -> b =
+    match list on
+    | Nil => acc
+    | x :: xs => f(x, fold_right(xs, acc, f))
+
+## Get the first element in a list, or `None` if the list is empty.
+##
+## @since 0.1.0
+##
+## ```
+## ➢ List.head([1, 2, 3])
+## Some(1) : Maybe(Int)
+##
+## ➢ List.head(Nil : List(Int))
+## None : Maybe(Int)
+## ```
+let head(list : List(a)) -> Maybe(a) =
+    match list on
+    | Nil => None
+    | x :: _ => Some(x)
+
+## Get all but the first element of a list, or `None` if the list is empty.
+##
+## @since 0.1.0
+##
+## ```
+## ➢ List.tail([1, 2, 3])
+## Some([2, 3]) : Maybe(List(Int))
+##
+## ➢ List.tail(Nil : List(Int))
+## None : Maybe(List(Int))
+## ```
+let tail(list : List(a)) -> Maybe(List(a)) =
+    match list on
+    | Nil => None
+    | _ :: xs => Some(xs)
+
+## Get the last element in a list, or `None` if the list is empty.
+##
+## @since 0.1.0
+##
+## ```
+## ➢ List.last([1, 2, 3])
+## Some(3) : Maybe(Int)
+##
+## ➢ List.last(Nil : List(Int))
+## None : Maybe(Int)
+## ```
+let last(list : List(a)) -> Maybe(a) =
+    match list on
+    | x :: Nil => Some(x)
+    | _ :: xs => last(xs)
+    | _ => None
+
+## Reverse a list.
+##
+## @since 0.1.0
+##
+## ```
+## ➢ List.reverse([1, 2, 3])
+## [3, 2, 1] : List(Int)
+## ```
+let reverse(list : List(a)) -> List(a) =
+    fold_left(list, Nil, fn(xs, x) => cons(xs, x))
+
+## Apply a function to every element in a list.
+##
+## @since 0.1.0
+##
+## ```
+## ➢ List.map([1, 2, 3], fn(x) => x * 2)
+## [2, 4, 6] : List(Int)
+## ```
+let map(list : List(a), f : (a -> b)) -> List(b) =
+    fold_right(list, Nil, fn(x, acc) => cons(acc, f(x)))
+
+## Keep elements that satisfy the given predicate.
+let keep(list : List(a), predicate : (a -> Bool)) -> List(a) =
+    list
+    |> fold_right(
+        Nil,
+        fn(x, xs) =>
+            if predicate(x) then
+                cons(xs, x)
+            else
+                xs
+    )
+
+## Exclude elements that satisfy the given predicate.
+let reject(list : List(a), predicate : (a -> Bool)) -> List(a) =
+    keep(list, fn(x) => not(predicate(x)))
+
+## Applies filter and map simultaneously.
+let collect_map(list : List(a), f : (a -> Maybe(b))) -> List(b) =
+    list
+    |> fold_right(
+        Nil,
+        fn(x, xs) =>
+            match f(x) on
+            | None => xs
+            | Some(y) => cons(xs, y)
+    )
+
+## Create a list of numbers, every element increasing by one.
+let range(start : Int, end : Int) -> List(Int) =
+    if start > end then
+        Nil
+    else
+        cons(range(start + 1, end), start)
+
+let insert_at(list : List(a), index : Int, elem : a) -> Maybe(List(a)) =
+    match list on
+    | _ when index == 0 => Some(cons(list, elem))
+    | x :: xs =>
+        insert_at(xs, index - 1, elem)
+        |> Maybe.map(fn(rest) => cons(rest, x))
+    | _ => None
+
+let delete_at(list : List(a), index : Int) -> Maybe(List(a)) =
+    match list on
+    | _ when index == 0 =>
         match list on
-        | _ when index == 0 => Some(cons(list, elem))
+        | _ :: xs => Some(xs)
+        | _ => None
+    | x :: xs =>
+        delete_at(xs, index - 1)
+        |> Maybe.map(fn(rest) => cons(rest, x))
+    | _ => None
+
+let modify_at(list : List(a), index : Int, f : (a -> a)) -> Maybe(List(a)) =
+    alter_at(list, index, fn(x) => Some(f(x)))
+
+let alter_at(list : List(a), index : Int, f : (a -> Maybe(a))) -> Maybe(List(a)) =
+    match list on
+    | _ when index == 0 =>
+        match list on
         | x :: xs =>
-            insert_at(xs, index - 1, elem)
-            |> Maybe.map(fn(rest) => cons(rest, x))
+            f(x)
+            |> Maybe.map(fn(y) => cons(xs, y))
         | _ => None
+    | x :: xs =>
+        alter_at(xs, index - 1, f)
+        |> Maybe.map(fn(rest) => cons(rest, x))
+    | _ => None
 
-    let delete_at(list : List(a), index : Int) -> Maybe(List(a)) =
-        match list on
-        | _ when index == 0 =>
-            match list on
-            | _ :: xs => Some(xs)
-            | _ => None
-        | x :: xs =>
-            delete_at(xs, index - 1)
-            |> Maybe.map(fn(rest) => cons(rest, x))
-        | _ => None
+let flatten(list : List(List(a))) -> List(a) =
+    list
+    |> fold_right(Nil, fn(xs, acc) => fold_right(xs, acc, cons))
 
-    let modify_at(list : List(a), index : Int, f : (a -> a)) -> Maybe(List(a)) =
-        alter_at(list, index, fn(x) => Some(f(x)))
+## Find the maximum element in a list.
+##
+## @since 0.1.0
+##
+## ```
+## ➢ List.maximum([1, 4, 2])
+## Some(4) : Maybe(Int)
+##
+## ➢ List.maximum(Nil : Maybe(Int))
+## None : Maybe(Int)
+## ```
+let maximum(list : List(Comparable)) -> Maybe(Comparable) =
+    match list on
+    | x :: xs => Some(fold_left(xs, x, max))
+    | _ => None
 
-    let alter_at(list : List(a), index : Int, f : (a -> Maybe(a))) -> Maybe(List(a)) =
-        match list on
-        | _ when index == 0 =>
-            match list on
-            | x :: xs =>
-                f(x)
-                |> Maybe.map(fn(y) => cons(xs, y))
-            | _ => None
-        | x :: xs =>
-            alter_at(xs, index - 1, f)
-            |> Maybe.map(fn(rest) => cons(rest, x))
-        | _ => None
+## Find the minimum element in a non-empty list.
+##
+## @since 0.1.0
+##
+## ```
+## ➢ List.minimum([3, 2, 1])
+## Some(1) : Maybe(Int)
+##
+## ➢ List.minimum(Nil : Maybe(Int))
+## None : Maybe(Int)
+## ```
+let minimum(list : List(Comparable)) -> Maybe(Comparable) =
+    match list on
+    | x :: xs => Some(fold_left(xs, x, min))
+    | _ => None
 
-    let flatten(list : List(List(a))) -> List(a) =
-        list
-        |> fold_right(Nil, fn(xs, acc) => fold_right(xs, acc, cons))
+## Get the sum of the list elements.
+##
+## @since 0.1.0
+##
+## ```
+## ➢ List.sum([3, 2, 1])
+## 6.0 : Double
+##
+## ➢ List.sum Nil
+## 0.0 : Double
+## ```
+let sum(list : List(Number)) -> Number =
+    list
+    |> fold_left(0, fn(acc, x) => acc + x)
 
-    ## Find the maximum element in a list.
-    ##
-    ## @since 0.1.0
-    ##
-    ## ```
-    ## ➢ List.maximum([1, 4, 2])
-    ## Some(4) : Maybe(Int)
-    ##
-    ## ➢ List.maximum(Nil : Maybe(Int))
-    ## None : Maybe(Int)
-    ## ```
-    let maximum(list : List(Comparable)) -> Maybe(Comparable) =
-        match list on
-        | x :: xs => Some(fold_left(xs, x, max))
-        | _ => None
-
-    ## Find the minimum element in a non-empty list.
-    ##
-    ## @since 0.1.0
-    ##
-    ## ```
-    ## ➢ List.minimum([3, 2, 1])
-    ## Some(1) : Maybe(Int)
-    ##
-    ## ➢ List.minimum(Nil : Maybe(Int))
-    ## None : Maybe(Int)
-    ## ```
-    let minimum(list : List(Comparable)) -> Maybe(Comparable) =
-        match list on
-        | x :: xs => Some(fold_left(xs, x, min))
-        | _ => None
-
-    ## Get the sum of the list elements.
-    ##
-    ## @since 0.1.0
-    ##
-    ## ```
-    ## ➢ List.sum([3, 2, 1])
-    ## 6.0 : Double
-    ##
-    ## ➢ List.sum Nil
-    ## 0.0 : Double
-    ## ```
-    let sum(list : List(Number)) -> Number =
-        list
-        |> fold_left(0, fn(acc, x) => acc + x)
-
-    ## Get the product of the list elements.
-    ##
-    ## @since 0.1.0
-    ##
-    ## ```
-    ## ➢ List.product [2, 4, 6]
-    ## 48 : Int
-    ##
-    ## ➢ List.product Nil : Int
-    ## 1 : Int
-    ## ```
-    let product(list : List(Number)) -> Number =
-        list
-        |> fold_left(1, fn(acc, x) => acc * x)
-end
+## Get the product of the list elements.
+##
+## @since 0.1.0
+##
+## ```
+## ➢ List.product [2, 4, 6]
+## 48 : Int
+##
+## ➢ List.product Nil : Int
+## 1 : Int
+## ```
+let product(list : List(Number)) -> Number =
+    list
+    |> fold_left(1, fn(acc, x) => acc * x)

--- a/stdlib/maybe.mn
+++ b/stdlib/maybe.mn
@@ -23,365 +23,364 @@ module Maybe exposing
     , zip
     )
 
-    ## Represent values that may or may not exist.
-    ##
-    ## @since 0.1.0
-    ##
-    ## ```
-    ## ➢ Some(42)
-    ## Some(42) : Maybe(Int)
-    ## ```
-    type Maybe(a) =
-        | None
-        | Some(a)
+## Represent values that may or may not exist.
+##
+## @since 0.1.0
+##
+## ```
+## ➢ Some(42)
+## Some(42) : Maybe(Int)
+## ```
+type Maybe(a) =
+    | None
+    | Some(a)
 
-    ## Returns `True` when the `Maybe` value was constructed with `Some`.
-    ##
-    ## @since 0.1.0
-    ##
-    ## ```
-    ## ➢ Maybe.some?(Some(42))
-    ## True : Bool
-    ## ```
-    let some?(ma : Maybe(a)) -> Bool =
-        match ma on
-        | None => False
-        | Some(_) => True
+## Returns `True` when the `Maybe` value was constructed with `Some`.
+##
+## @since 0.1.0
+##
+## ```
+## ➢ Maybe.some?(Some(42))
+## True : Bool
+## ```
+let some?(ma : Maybe(a)) -> Bool =
+    match ma on
+    | None => False
+    | Some(_) => True
 
-    ## Returns `True` when the `Maybe` value is `None`.
-    ##
-    ## @since 0.1.0
-    ##
-    ## ```
-    ## ➢ Maybe.none?(Some(42))
-    ## False : Bool
-    ## ```
-    let none?(ma : Maybe(a)) -> Bool =
-        match ma on
-        | None => True
-        | Some(_) => False
+## Returns `True` when the `Maybe` value is `None`.
+##
+## @since 0.1.0
+##
+## ```
+## ➢ Maybe.none?(Some(42))
+## False : Bool
+## ```
+let none?(ma : Maybe(a)) -> Bool =
+    match ma on
+    | None => True
+    | Some(_) => False
 
-    ## Unwrap a value while providing a default value.
-    ## Useful for pipelines, otherwise use a `match` expr instead.
-    ## Default value is lazy and will only be computed if the `Maybe` is `None`.
-    ##
-    ## @since 0.1.0
-    ##
-    ## ```
-    ## ➢ Maybe.with_default(Some(42), 100)
-    ## 42 : Int
-    ##
-    ## ➢ Maybe.with_default(None, 100)
-    ## 100 : Int
-    ## ```
-    let with_default(ma : Maybe(a), default : a) -> a =
-        match ma on
-        | None => default
-        | Some(a) => a
+## Unwrap a value while providing a default value.
+## Useful for pipelines, otherwise use a `match` expr instead.
+## Default value is lazy and will only be computed if the `Maybe` is `None`.
+##
+## @since 0.1.0
+##
+## ```
+## ➢ Maybe.with_default(Some(42), 100)
+## 42 : Int
+##
+## ➢ Maybe.with_default(None, 100)
+## 100 : Int
+## ```
+let with_default(ma : Maybe(a), default : a) -> a =
+    match ma on
+    | None => default
+    | Some(a) => a
 
-    ## Applies the predicate to a value and lifts the result into a `Maybe`.
-    ##
-    ## @since 0.1.0
-    ##
-    ## ```
-    ## ➢ Maybe.from_predicate(42, fn(x) => x == 42)
-    ## Some(42) : Maybe(Int)
-    ## ```
-    let from_predicate(x : a, predicate : (a -> Bool)) -> Maybe(a) =
-        if predicate(x) then
-            Some(x)
-        else
-            None
+## Applies the predicate to a value and lifts the result into a `Maybe`.
+##
+## @since 0.1.0
+##
+## ```
+## ➢ Maybe.from_predicate(42, fn(x) => x == 42)
+## Some(42) : Maybe(Int)
+## ```
+let from_predicate(x : a, predicate : (a -> Bool)) -> Maybe(a) =
+    if predicate(x) then
+        Some(x)
+    else
+        None
 
-    ## Determines if the wrapped value satisfies a predicate.
-    ##
-    ## @since 0.1.0
-    ##
-    ## ```
-    ## ➢ Maybe.satisfy?(Some(15), fn(x) => x > 10)
-    ## True : Bool
-    ## ```
-    let satisfy?(ma : Maybe(a), predicate : (a -> Bool)) -> Bool =
-        match ma on
-        | None => False
-        | Some(a) => predicate(a)
+## Determines if the wrapped value satisfies a predicate.
+##
+## @since 0.1.0
+##
+## ```
+## ➢ Maybe.satisfy?(Some(15), fn(x) => x > 10)
+## True : Bool
+## ```
+let satisfy?(ma : Maybe(a), predicate : (a -> Bool)) -> Bool =
+    match ma on
+    | None => False
+    | Some(a) => predicate(a)
 
-    ## Apply a function to value wrapped by a `Maybe`.
-    ## Equivalent of `<$>` from the `Functor` typeclass.
-    ##
-    ## @since 0.1.0
-    ##
-    ## ```
-    ## ➢ Maybe.map(Some(21), fn(x) => x * 2)
-    ## Some(42) : Maybe(Int)
-    ## ```
-    let map(Maybe(a), (a -> value)) -> Maybe(value) =
-        match ma on
-        | None => None
-        | Some(a) => Some(f(a))
+## Apply a function to value wrapped by a `Maybe`.
+## Equivalent of `<$>` from the `Functor` typeclass.
+##
+## @since 0.1.0
+##
+## ```
+## ➢ Maybe.map(Some(21), fn(x) => x * 2)
+## Some(42) : Maybe(Int)
+## ```
+let map(Maybe(a), (a -> value)) -> Maybe(value) =
+    match ma on
+    | None => None
+    | Some(a) => Some(f(a))
 
-    ## Apply a function if all the arguments are `Some`'s.
-    ##
-    ## @since 0.1.0
-    ##
-    ## ```
-    ## ➢ Maybe.map2(Some(21), Some(21), fn(x, y) => x + y)
-    ## Some(42) : Maybe(Int)
-    ## ```
-    let map2(
-        ma : Maybe(a),
-        mb : Maybe(b)
-        f : ((a, b) -> value),
-    ) -> Maybe(value) =
-        match ma on
-        | None => None
-        | Some(a) =>
-            match mb on
-            | None => None
-            | Some(b) => Some(f(a, b))
-
-    ## Apply a function if all the arguments are `Some`'s.
-    ##
-    ## @since 0.1.0
-    ##
-    ## ```
-    ## ➢ Some(14) |> Maybe.map3(Some(14), Some(14), fn(x, y, z) => x + y + z)
-    ## Some(42) : Maybe(Int)
-    ## ```
-    let map3(
-        ma : Maybe(a),
-        mb : Maybe(b),
-        mc : Maybe(c),
-        f : ((a, b, c) -> value)
-    ) -> Maybe(value) =
-        match ma on
-        | None => None
-        | Some(a) =>
-            match mb on
-            | None => None
-            | Some(b) =>
-                match mc on
-                | None => None
-                | Some(c) => Some(f(a, b, c))
-
-    ## Apply a function if all the arguments are `Some`s.
-    ##
-    ## @since 0.1.0
-    ##
-    ## ```
-    ## ➢ Some(10) |> Maybe.map4(Some(11), Some(12), Some(13), fn(w, x, y, z) => w + x + y + z)
-    ## Some(46) : Maybe(Int)
-    ## ```
-    let map4(
-        ma : Maybe(a),
-        mb : Maybe(b),
-        mc : Maybe(c),
-        md : Maybe(d),
-        f : ((a, b, c, d) -> value)
-    ) -> Maybe(value) =
-        match ma on
-        | None => None
-        | Some(a) =>
-            match mb on
-            | None => None
-            | Some(b) =>
-                match mc on
-                | None => None
-                | Some(c) =>
-                    match md on
-                    | None => None
-                    | Some(d) => Some(f(a, b, c, d))
-
-    ## Removes one level of nesting.
-    ##
-    ## @since 0.1.0
-    ##
-    ## ```
-    ## ➢ Maybe.flatten(Some(Some(42)))
-    ## Some(42) : Maybe(Int)
-    ## ```
-    let flatten(mma : Maybe(Maybe(a)) -> Maybe(a) =
-        match mma on
-        | None => None
-        | Some(ma) => ma
-
-    ## Combines two `Maybe` values into a tuple, if both are `Some`.
-    ##
-    ## @since 0.1.0
-    ##
-    ## ```
-    ## ➢ Maybe.zip(Some("hello world"), Some(42))
-    ## Some("hello world", 42) : Maybe(String, Int)
-    ## ```
-    let zip(ma : Maybe(a), mb : Maybe(b)) -> Maybe((a, b)) =
-        match (ma, mb) on
-        | (Some(a), Some(b)) => Some((a, b))
-        | _ => None
-
-    ## Equivalent of `<|>` from the `Alternative` typeclass.
-    ##
-    ## @since 0.1.0
-    ##
-    ## ```
-    ## ➢ Maybe.or(None, Some(42))
-    ## Some(42) : Maybe(Int)
-    ## ```
-    let or(ma : Maybe(a), mb : Maybe(a)) -> Maybe(a) =
-        match ma on
-        | None => mb
-        | Some(_) => ma
-
-    ## Equivalent of `>>=` from the `Monad` typeclass.
-    ##
-    ## @since 0.1.0
-    ##
-    ## ```
-    ## ➢ Maybe.and_then(Some(21), fn(x) => Some(x * 2))
-    ## Some(42) : Maybe(Int)
-    ## ```
-    let and_then(ma : Maybe(a), f : (a -> Maybe(value))) -> Maybe(value) =
-        match ma on
-        | None => None
-        | Some(a) => f(a)
-
-    ## Equivalent of `>>=` from the `Monad` typeclass.
-    ##
-    ## @since 0.1.0
-    let and_then2(
-        ma : Maybe(a),
-        mb : Maybe(b),
-        f : ((a, b) -> Maybe(value))
-    ) -> Maybe(value) =
-        match ma on
-        | None => None
-        | Some(a) =>
-            match mb on
-            | None => None
-            | Some(b) => f(a, b)
-
-    ## Equivalent of `>>=` from the `Monad` typeclass.
-    ##
-    ## @since 0.1.0
-    let and_then3(
-        ma : Maybe(a),
-        mb : Maybe(b),
-        mc : Maybe(c),
-        f : ((a, b, c) -> Maybe(value))
-    ) -> Maybe(value) =
-        match ma on
-        | None => None
-        | Some(a) =>
-            match mb on
-            | None => None
-            | Some(b) =>
-                match mc on
-                | None => None
-                | Some(c) => f(a, b, c)
-
-    ## Equivalent of `>>=` from the `Monad` typeclass.
-    ##
-    ## @since 0.1.0
-    let and_then4(
-        ma : Maybe(a),
-        mb : Maybe(b),
-        mc : Maybe(c),
-        md : Maybe(d),
-        f : ((a, b, c, d) -> Maybe(value))
-    ) -> Maybe(value) =
-        match ma on
-        | None => None
-        | Some(a) =>
-            match mb on
-            | None => None
-            | Some(b) =>
-                match mc on
-                | None => None
-                | Some(c) =>
-                    match md on
-                    | None => None
-                    | Some(d) => f(a, b, c, d)
-
-    ## Try a list of functions against a value. Return the value of the first call that succeeds (returns `Some`).
-    ##
-    ## @since 0.1.0
-    ##
-    ## ```
-    ## ➢ Maybe.one_of("42.0", [String.to_int, String.to_float])
-    ## Some(42.0) : Maybe(Float)
-    ## ```
-    let one_of(default : a, fmbs : List((a -> Maybe(b)))) -> Maybe(b) =
-        match fmbs on
-        | Nil => None
-        | fmb :: rest =>
-            match fmb(default) on
-            | None => one_of(default, rest)
-            | Some(b) => Some(b)
-
-    ## Removes `None` values from a collection while unwrapping all present values.
-    ##
-    ## @since 0.1.0
-    ##
-    ## ```
-    ## ➢ Maybe.compact([Some(1), None, Some(2)])
-    ## [1, 2] : List(Int)
-    ## ```
-    let compact(maybes : List(Maybe(a))) -> List(a) =
-        List.collect_map(identity, maybes)
-
-    ## Take two `Maybe` values. If the first one equals `None`, return `None`. Otherwise return the second value.
-    ## Allows for chaining `Maybe` computations, with a possible "early return" in case of `None`.
-    ## Equivalent of `*>` from the `Applicative` typeclass.
-    ##
-    ## @since 0.1.0
-    ##
-    ## ```
-    ## ➢ Maybe.next(Some(1), Some(2))
-    ## Some(2) : Maybe(Int)
-    ##
-    ## ➢ Maybe.next(None, Some(2))
-    ## None : Maybe(Int)
-    ##
-    ## ➢ Maybe.next(Some(1), None)
-    ## None : Maybe(Int)
-    ## ```
-    let next(ma : Maybe(a), mb : Maybe(b)) -> Maybe(b) =
-        match ma on
-        | None => None
-        | Some(_) => mb
-
-    ## Take two `Maybe` values. If the second one equals `None`, return `None`. Otherwise return the first value.
-    ## Equivalent of `<*` from the `Applicative` typeclass.
-    ##
-    ## @since 0.1.0
-    ##
-    ## ```
-    ## ➢ Maybe.prev(Some(1), Some(2))
-    ## Some(1) : Maybe(Int)
-    ##
-    ## ➢ Maybe.prev(None, Some(2))
-    ## None : Maybe(Int)
-    ##
-    ## ➢ Maybe.prev(Some(1), None)
-    ## None : Maybe(Int)
-    ## ```
-    let prev(ma : Maybe(a), mb : Maybe(b)) -> Maybe(a) =
+## Apply a function if all the arguments are `Some`'s.
+##
+## @since 0.1.0
+##
+## ```
+## ➢ Maybe.map2(Some(21), Some(21), fn(x, y) => x + y)
+## Some(42) : Maybe(Int)
+## ```
+let map2(
+    ma : Maybe(a),
+    mb : Maybe(b)
+    f : ((a, b) -> value),
+) -> Maybe(value) =
+    match ma on
+    | None => None
+    | Some(a) =>
         match mb on
         | None => None
-        | Some(_) => ma
+        | Some(b) => Some(f(a, b))
 
-    ## Converts a `Result` to `Maybe`, dropping the error.
-    ##
-    ## @since 0.1.0
-    ##
-    ## ```
-    ## ➢ Maybe.from_result(Ok(42))
-    ## Some(42) : Maybe(Int)
-    ##
-    ## ➢ Maybe.from_result(Err("uh oh!"))
-    ## None : Maybe(Int)
-    ## ```
-    let from_result(result : Result(e, a)) -> Maybe(a) =
-        match result on
-        | Err(_) => None
-        | Ok(a) => Some(a)
-end
+## Apply a function if all the arguments are `Some`'s.
+##
+## @since 0.1.0
+##
+## ```
+## ➢ Some(14) |> Maybe.map3(Some(14), Some(14), fn(x, y, z) => x + y + z)
+## Some(42) : Maybe(Int)
+## ```
+let map3(
+    ma : Maybe(a),
+    mb : Maybe(b),
+    mc : Maybe(c),
+    f : ((a, b, c) -> value)
+) -> Maybe(value) =
+    match ma on
+    | None => None
+    | Some(a) =>
+        match mb on
+        | None => None
+        | Some(b) =>
+            match mc on
+            | None => None
+            | Some(c) => Some(f(a, b, c))
+
+## Apply a function if all the arguments are `Some`s.
+##
+## @since 0.1.0
+##
+## ```
+## ➢ Some(10) |> Maybe.map4(Some(11), Some(12), Some(13), fn(w, x, y, z) => w + x + y + z)
+## Some(46) : Maybe(Int)
+## ```
+let map4(
+    ma : Maybe(a),
+    mb : Maybe(b),
+    mc : Maybe(c),
+    md : Maybe(d),
+    f : ((a, b, c, d) -> value)
+) -> Maybe(value) =
+    match ma on
+    | None => None
+    | Some(a) =>
+        match mb on
+        | None => None
+        | Some(b) =>
+            match mc on
+            | None => None
+            | Some(c) =>
+                match md on
+                | None => None
+                | Some(d) => Some(f(a, b, c, d))
+
+## Removes one level of nesting.
+##
+## @since 0.1.0
+##
+## ```
+## ➢ Maybe.flatten(Some(Some(42)))
+## Some(42) : Maybe(Int)
+## ```
+let flatten(mma : Maybe(Maybe(a)) -> Maybe(a) =
+    match mma on
+    | None => None
+    | Some(ma) => ma
+
+## Combines two `Maybe` values into a tuple, if both are `Some`.
+##
+## @since 0.1.0
+##
+## ```
+## ➢ Maybe.zip(Some("hello world"), Some(42))
+## Some("hello world", 42) : Maybe(String, Int)
+## ```
+let zip(ma : Maybe(a), mb : Maybe(b)) -> Maybe((a, b)) =
+    match (ma, mb) on
+    | (Some(a), Some(b)) => Some((a, b))
+    | _ => None
+
+## Equivalent of `<|>` from the `Alternative` typeclass.
+##
+## @since 0.1.0
+##
+## ```
+## ➢ Maybe.or(None, Some(42))
+## Some(42) : Maybe(Int)
+## ```
+let or(ma : Maybe(a), mb : Maybe(a)) -> Maybe(a) =
+    match ma on
+    | None => mb
+    | Some(_) => ma
+
+## Equivalent of `>>=` from the `Monad` typeclass.
+##
+## @since 0.1.0
+##
+## ```
+## ➢ Maybe.and_then(Some(21), fn(x) => Some(x * 2))
+## Some(42) : Maybe(Int)
+## ```
+let and_then(ma : Maybe(a), f : (a -> Maybe(value))) -> Maybe(value) =
+    match ma on
+    | None => None
+    | Some(a) => f(a)
+
+## Equivalent of `>>=` from the `Monad` typeclass.
+##
+## @since 0.1.0
+let and_then2(
+    ma : Maybe(a),
+    mb : Maybe(b),
+    f : ((a, b) -> Maybe(value))
+) -> Maybe(value) =
+    match ma on
+    | None => None
+    | Some(a) =>
+        match mb on
+        | None => None
+        | Some(b) => f(a, b)
+
+## Equivalent of `>>=` from the `Monad` typeclass.
+##
+## @since 0.1.0
+let and_then3(
+    ma : Maybe(a),
+    mb : Maybe(b),
+    mc : Maybe(c),
+    f : ((a, b, c) -> Maybe(value))
+) -> Maybe(value) =
+    match ma on
+    | None => None
+    | Some(a) =>
+        match mb on
+        | None => None
+        | Some(b) =>
+            match mc on
+            | None => None
+            | Some(c) => f(a, b, c)
+
+## Equivalent of `>>=` from the `Monad` typeclass.
+##
+## @since 0.1.0
+let and_then4(
+    ma : Maybe(a),
+    mb : Maybe(b),
+    mc : Maybe(c),
+    md : Maybe(d),
+    f : ((a, b, c, d) -> Maybe(value))
+) -> Maybe(value) =
+    match ma on
+    | None => None
+    | Some(a) =>
+        match mb on
+        | None => None
+        | Some(b) =>
+            match mc on
+            | None => None
+            | Some(c) =>
+                match md on
+                | None => None
+                | Some(d) => f(a, b, c, d)
+
+## Try a list of functions against a value. Return the value of the first call that succeeds (returns `Some`).
+##
+## @since 0.1.0
+##
+## ```
+## ➢ Maybe.one_of("42.0", [String.to_int, String.to_float])
+## Some(42.0) : Maybe(Float)
+## ```
+let one_of(default : a, fmbs : List((a -> Maybe(b)))) -> Maybe(b) =
+    match fmbs on
+    | Nil => None
+    | fmb :: rest =>
+        match fmb(default) on
+        | None => one_of(default, rest)
+        | Some(b) => Some(b)
+
+## Removes `None` values from a collection while unwrapping all present values.
+##
+## @since 0.1.0
+##
+## ```
+## ➢ Maybe.compact([Some(1), None, Some(2)])
+## [1, 2] : List(Int)
+## ```
+let compact(maybes : List(Maybe(a))) -> List(a) =
+    List.collect_map(identity, maybes)
+
+## Take two `Maybe` values. If the first one equals `None`, return `None`. Otherwise return the second value.
+## Allows for chaining `Maybe` computations, with a possible "early return" in case of `None`.
+## Equivalent of `*>` from the `Applicative` typeclass.
+##
+## @since 0.1.0
+##
+## ```
+## ➢ Maybe.next(Some(1), Some(2))
+## Some(2) : Maybe(Int)
+##
+## ➢ Maybe.next(None, Some(2))
+## None : Maybe(Int)
+##
+## ➢ Maybe.next(Some(1), None)
+## None : Maybe(Int)
+## ```
+let next(ma : Maybe(a), mb : Maybe(b)) -> Maybe(b) =
+    match ma on
+    | None => None
+    | Some(_) => mb
+
+## Take two `Maybe` values. If the second one equals `None`, return `None`. Otherwise return the first value.
+## Equivalent of `<*` from the `Applicative` typeclass.
+##
+## @since 0.1.0
+##
+## ```
+## ➢ Maybe.prev(Some(1), Some(2))
+## Some(1) : Maybe(Int)
+##
+## ➢ Maybe.prev(None, Some(2))
+## None : Maybe(Int)
+##
+## ➢ Maybe.prev(Some(1), None)
+## None : Maybe(Int)
+## ```
+let prev(ma : Maybe(a), mb : Maybe(b)) -> Maybe(a) =
+    match mb on
+    | None => None
+    | Some(_) => ma
+
+## Converts a `Result` to `Maybe`, dropping the error.
+##
+## @since 0.1.0
+##
+## ```
+## ➢ Maybe.from_result(Ok(42))
+## Some(42) : Maybe(Int)
+##
+## ➢ Maybe.from_result(Err("uh oh!"))
+## None : Maybe(Int)
+## ```
+let from_result(result : Result(e, a)) -> Maybe(a) =
+    match result on
+    | Err(_) => None
+    | Ok(a) => Some(a)

--- a/stdlib/non_empty.mn
+++ b/stdlib/non_empty.mn
@@ -17,52 +17,51 @@ module NonEmpty exposing
     , to_list
     )
 
-    type NonEmpty(a) =
-        | [a]
-        | a :: List(a)
+type NonEmpty(a) =
+    | [a]
+    | a :: List(a)
 
-    let singleton(x : a) -> NonEmpty(a) =
-        todo("not implemented")
+let singleton(x : a) -> NonEmpty(a) =
+    todo("not implemented")
 
-    let head(list : NonEmpty(a)) -> a =
-        todo("not implemented")
+let head(list : NonEmpty(a)) -> a =
+    todo("not implemented")
 
-    let tail(list : NonEmpty(a)) -> a =
-        todo("not implemented")
+let tail(list : NonEmpty(a)) -> a =
+    todo("not implemented")
 
-    let map(f : ((a) -> b), list : NonEmpty(a)) -> NonEmpty(b) =
-        todo("not implemented")
+let map(f : ((a) -> b), list : NonEmpty(a)) -> NonEmpty(b) =
+    todo("not implemented")
 
-    let intersperse(x : a, list : NonEmpty(a)) -> NonEmpty(a) =
-        todo("not implemented")
+let intersperse(x : a, list : NonEmpty(a)) -> NonEmpty(a) =
+    todo("not implemented")
 
-    let size(list : NonEmpty(a)) -> Int =
-        todo("not implemented")
+let size(list : NonEmpty(a)) -> Int =
+    todo("not implemented")
 
-    let sort(list : NonEmpty(comparable)) -> NonEmpty(comparable) =
-        todo("not implemented")
+let sort(list : NonEmpty(comparable)) -> NonEmpty(comparable) =
+    todo("not implemented")
 
-    let reverse(list : NonEmpty(a)) -> NonEmpty(a) =
-        todo("not implemented")
+let reverse(list : NonEmpty(a)) -> NonEmpty(a) =
+    todo("not implemented")
 
-    let repeat(x : a) -> NonEmpty(a) =
-        todo("not implemented")
+let repeat(x : a) -> NonEmpty(a) =
+    todo("not implemented")
 
-    let take_left(n : Int, list : NonEmpty(a)) -> List(a) =
-        todo("not implemented")
+let take_left(n : Int, list : NonEmpty(a)) -> List(a) =
+    todo("not implemented")
 
-    let drop_left(n : Int, list : NonEmpty(a)) -> List(a) =
-        todo("not implemented")
+let drop_left(n : Int, list : NonEmpty(a)) -> List(a) =
+    todo("not implemented")
 
-    let take_while(predicate : ((a) -> Bool), list : NonEmpty(a)) -> List(a) =
-        todo("not implemented")
+let take_while(predicate : ((a) -> Bool), list : NonEmpty(a)) -> List(a) =
+    todo("not implemented")
 
-    let drop_while(predicate : ((a) -> Bool), list : NonEmpty(a)) -> List(a) =
-        todo("not implemented")
+let drop_while(predicate : ((a) -> Bool), list : NonEmpty(a)) -> List(a) =
+    todo("not implemented")
 
-    let from_list(list : List(a)) -> Maybe(NonEmpty(a)) =
-        todo("not implemented")
+let from_list(list : List(a)) -> Maybe(NonEmpty(a)) =
+    todo("not implemented")
 
-    let to_list(list : NonEmpty(a)) -> List(a) =
-        todo("not implemented")
-end
+let to_list(list : NonEmpty(a)) -> List(a) =
+    todo("not implemented")

--- a/stdlib/prelude.mn
+++ b/stdlib/prelude.mn
@@ -40,234 +40,233 @@ module Prelude exposing
     , (.~.)
     )
 
-    include Boolean
-    include Compareable
+include Boolean
+include Compareable
 
-    foreign int_add(x : Int, y : Int) -> Int = "zig_int_add"
-    foreign int_sub(x : Int, y : Int) -> Int = "zig_int_sub"
-    foreign int_mul(x : Int, y : Int) -> Int = "zig_int_mul"
-    foreign int_div(x : Int, y : Int) -> Int = "zig_int_div"
-    foreign int_pow(x : Int, y : Int) -> Int = "zig_int_pow"
-    foreign int_min(x : Int, y : Int) -> Int = "zig_int_min"
-    foreign int_max(x : Int, y : Int) -> Int = "zig_int_max"
+foreign int_add(x : Int, y : Int) -> Int = "zig_int_add"
+foreign int_sub(x : Int, y : Int) -> Int = "zig_int_sub"
+foreign int_mul(x : Int, y : Int) -> Int = "zig_int_mul"
+foreign int_div(x : Int, y : Int) -> Int = "zig_int_div"
+foreign int_pow(x : Int, y : Int) -> Int = "zig_int_pow"
+foreign int_min(x : Int, y : Int) -> Int = "zig_int_min"
+foreign int_max(x : Int, y : Int) -> Int = "zig_int_max"
 
-    # =============================
-    #      HELPFUL FUNCTIONS
-    # =============================
+# =============================
+#      HELPFUL FUNCTIONS
+# =============================
 
-    ## ??
-    ##
-    ## @since 0.1.0
-    ##
-    ## ```
-    ## ➢ identity(42)
-    ## 42 : Int
-    ## ```
-    let identity(x : a) -> a =
-        x
+## ??
+##
+## @since 0.1.0
+##
+## ```
+## ➢ identity(42)
+## 42 : Int
+## ```
+let identity(x : a) -> a =
+    x
 
-    ## ??
-    ##
-    ## @since 0.1.0
-    ##
-    ## ```
-    ## ➢ always(42, 0)
-    ## 42 : Int
-    ## ```
-    let always(x : a, _ : b) -> a =
-        x
+## ??
+##
+## @since 0.1.0
+##
+## ```
+## ➢ always(42, 0)
+## 42 : Int
+## ```
+let always(x : a, _ : b) -> a =
+    x
 
-    ## Reverse-application operator: `x |> f |> g` is exactly equivalent to `g(f(x))`
-    let ap_right(x : a, f : (a -> b)) -> b =
-        f(x)
+## Reverse-application operator: `x |> f |> g` is exactly equivalent to `g(f(x))`
+let ap_right(x : a, f : (a -> b)) -> b =
+    f(x)
 
-    # =============================
-    #      INTEGER ARITHMETIC
-    # =============================
+# =============================
+#      INTEGER ARITHMETIC
+# =============================
 
-    ## Calculates the addition of two integers.
-    ##
-    ## @since 0.1.0
-    ##
-    ## ```
-    ## ➢ add(40, 2)
-    ## 42 : Int
-    ## ```
-    let add(x : Int, y : Int) -> Int =
-        int_add(x, y)
+## Calculates the addition of two integers.
+##
+## @since 0.1.0
+##
+## ```
+## ➢ add(40, 2)
+## 42 : Int
+## ```
+let add(x : Int, y : Int) -> Int =
+    int_add(x, y)
 
-    ## Calculates the subtraction of two integers.
-    ##
-    ## @since 0.1.0
-    ##
-    ## ```
-    ## ➢ sub(44, 2)
-    ## 42 : Int
-    ## ```
-    let sub(x : Int, y : Int) -> Int =
-        int_sub(x, y)
+## Calculates the subtraction of two integers.
+##
+## @since 0.1.0
+##
+## ```
+## ➢ sub(44, 2)
+## 42 : Int
+## ```
+let sub(x : Int, y : Int) -> Int =
+    int_sub(x, y)
 
-    ## Calculates the multiplication of two integers.
-    ##
-    ## @since 0.1.0
-    ##
-    ## ```
-    ## ➢ mul(2, 21)
-    ## 42 : Int
-    ## ```
-    let mul(x : Int, y : Int) -> Int =
-        int_mul(x, y)
+## Calculates the multiplication of two integers.
+##
+## @since 0.1.0
+##
+## ```
+## ➢ mul(2, 21)
+## 42 : Int
+## ```
+let mul(x : Int, y : Int) -> Int =
+    int_mul(x, y)
 
-    ## Calculates the division of two integers.
-    ##
-    ## @since 0.1.0
-    ##
-    ## ```
-    ## ➢ div(2, 84)
-    ## 42 : Int
-    ## ```
-    let div(x : Int, y : Int) -> Int =
-        int_div(x, y)
+## Calculates the division of two integers.
+##
+## @since 0.1.0
+##
+## ```
+## ➢ div(2, 84)
+## 42 : Int
+## ```
+let div(x : Int, y : Int) -> Int =
+    int_div(x, y)
 
-    ## Determines if a number is even.
-    ##
-    ## @since 0.1.0
-    ##
-    ## ```
-    ## ➢ even?(4)
-    ## True : Bool
-    ## ```
-    let even?(n : Int) -> Bool =
-        mod(n, 2) == 0
+## Determines if a number is even.
+##
+## @since 0.1.0
+##
+## ```
+## ➢ even?(4)
+## True : Bool
+## ```
+let even?(n : Int) -> Bool =
+    mod(n, 2) == 0
 
-    ## Determines if a number is odd.
-    ##
-    ## @since 0.1.0
-    ##
-    ## ```
-    ## ➢ odd?(3)
-    ## True : Bool
-    ## ```
-    let odd?(n : Int) -> Bool =
-        mod(n, 2) /= 0
+## Determines if a number is odd.
+##
+## @since 0.1.0
+##
+## ```
+## ➢ odd?(3)
+## True : Bool
+## ```
+let odd?(n : Int) -> Bool =
+    mod(n, 2) /= 0
 
-    ## Returns the greatest common divisor of the two integers.
-    ##
-    ## @since 0.1.0
-    ##
-    ## ```
-    ## ➢ gcd(8, 12)
-    ## 4 : Int
-    ## ```
-    let gcd(a : Int, b : Int) -> Int =
-        if b == 0 then
-            a
-        else
-            gcd(b, mod(a, b))
+## Returns the greatest common divisor of the two integers.
+##
+## @since 0.1.0
+##
+## ```
+## ➢ gcd(8, 12)
+## 4 : Int
+## ```
+let gcd(a : Int, b : Int) -> Int =
+    if b == 0 then
+        a
+    else
+        gcd(b, mod(a, b))
 
-    ## Determines the smallest positive integer that is divisible by both *a* and *b*
-    ##
-    ## @since 0.1.0
-    ##
-    ## ```
-    ## ➢ lcm(21, 6)
-    ## 42 : Int
-    ## ```
-    let lcm(a : Int, b : Int) -> Int =
-        abs(a * b) / gcd(a, b)
+## Determines the smallest positive integer that is divisible by both *a* and *b*
+##
+## @since 0.1.0
+##
+## ```
+## ➢ lcm(21, 6)
+## 42 : Int
+## ```
+let lcm(a : Int, b : Int) -> Int =
+    abs(a * b) / gcd(a, b)
 
-    ## Calculates the value of *a* to the power of *b*.
-    ##
-    ## @since 0.1.0
-    ##
-    ## ```
-    ## ➢ pow(9, 3)
-    ## 729 : Int
-    ## ```
-    let pow(x : Int, y : Int) -> Int =
-        int_pow(x, y)
+## Calculates the value of *a* to the power of *b*.
+##
+## @since 0.1.0
+##
+## ```
+## ➢ pow(9, 3)
+## 729 : Int
+## ```
+let pow(x : Int, y : Int) -> Int =
+    int_pow(x, y)
 
-    ## Integer remainder.
-    ##
-    ## @since 0.1.0
-    ##
-    ## ```
-    ## ➢ mod(42, 8)
-    ## 2 : Int
-    ## ```
-    let mod(a : Int, b : Int) -> Int =
-        a - b * (a / b)
+## Integer remainder.
+##
+## @since 0.1.0
+##
+## ```
+## ➢ mod(42, 8)
+## 2 : Int
+## ```
+let mod(a : Int, b : Int) -> Int =
+    a - b * (a / b)
 
-    ## Negate a number.
-    ##
-    ## @since 0.1.0
-    ##
-    ## ```
-    ## ➢ negate(42)
-    ## -42 : Int
-    ## ```
-    let negate(n : Int) -> Int =
+## Negate a number.
+##
+## @since 0.1.0
+##
+## ```
+## ➢ negate(42)
+## -42 : Int
+## ```
+let negate(n : Int) -> Int =
+    -n
+
+## Get the absolute value of a number.
+##
+## @since 0.1.0
+##
+## ```
+## ➢ abs(-42)
+## 42 : Int
+## ```
+let abs(n : Int) -> Int =
+    if x < 0 then
         -n
+    else
+        n
 
-    ## Get the absolute value of a number.
-    ##
-    ## @since 0.1.0
-    ##
-    ## ```
-    ## ➢ abs(-42)
-    ## 42 : Int
-    ## ```
-    let abs(n : Int) -> Int =
-        if x < 0 then
-            -n
-        else
-            n
+## Clamps a number within a given range.
+##
+## @since 0.1.0
+##
+## ```
+## ➢ clamp(100, 200, 99)
+## 100 : Int
+## ```
+let clamp(low : Int, high : Int, n : Int) -> Int =
+    if n < low then
+        low
+    else if n > high then
+        high
+    else
+        n
 
-    ## Clamps a number within a given range.
-    ##
-    ## @since 0.1.0
-    ##
-    ## ```
-    ## ➢ clamp(100, 200, 99)
-    ## 100 : Int
-    ## ```
-    let clamp(low : Int, high : Int, n : Int) -> Int =
-        if n < low then
-            low
-        else if n > high then
-            high
-        else
-            n
+let max() -> Int =
+    int_max()
 
-    let max() -> Int =
-        int_max()
+let min() -> Int =
+    int_min()
 
-    let min() -> Int =
-        int_min()
+# =============================
+#        INFIX OPERATORS
+# =============================
 
-    # =============================
-    #        INFIX OPERATORS
-    # =============================
-
-    infixl 2  (|>)  = pipe_right
-    infixr 3  (||)  = logical_or
-    infixr 4  (&&)  = logical_and
-    infixn 5  (==)  = eq
-    infixn 5  (/=)  = neq
-    infixn 5  (<)   = lt
-    infixn 5  (>)   = gt
-    infixn 5  (<=)  = lte
-    infixn 5  (>=)  = gte
-    infixr 6  (++)  = List.concat
-    infixr 7  (<>)  = Str.concat
-    infixr 8  (..)  = range
-    infixl 9  (+)   = add
-    infixl 9  (-)   = sub
-    infixl 9  (+.)  = Float.add
-    infixl 9  (-.)  = Float.sub
-    infixl 10 (*)   = mul
-    infixl 10 (/)   = div
-    infixl 10 (*.)  = Float.mul
-    infixl 10 (/.)  = Float.div
-    infixl 11 (**)  = Float.pow
-end
+infixl 2  (|>)  = pipe_right
+infixr 3  (||)  = logical_or
+infixr 4  (&&)  = logical_and
+infixn 5  (==)  = eq
+infixn 5  (/=)  = neq
+infixn 5  (<)   = lt
+infixn 5  (>)   = gt
+infixn 5  (<=)  = lte
+infixn 5  (>=)  = gte
+infixr 6  (++)  = List.concat
+infixr 7  (<>)  = Str.concat
+infixr 8  (..)  = range
+infixl 9  (+)   = add
+infixl 9  (-)   = sub
+infixl 9  (+.)  = Float.add
+infixl 9  (-.)  = Float.sub
+infixl 10 (*)   = mul
+infixl 10 (/)   = div
+infixl 10 (*.)  = Float.mul
+infixl 10 (/.)  = Float.div
+infixl 11 (**)  = Float.pow

--- a/stdlib/result.mn
+++ b/stdlib/result.mn
@@ -16,152 +16,151 @@ module Result exposing
     , with_default
     )
 
-    ## A `Result` is either `Ok` meaning the computation succeeded,
-    ## or it is an `Err` meaning that there was some failure.
-    ##
-    ## @since 0.1.0
-    ##
-    ## ```
-    ## ➢ Ok(42) : Result(String, Int)
-    ## Ok(42) : Result(String, Int)
-    ## ```
-    type Result(e, a) =
-        | Err(e)
-        | Ok(a)
+## A `Result` is either `Ok` meaning the computation succeeded,
+## or it is an `Err` meaning that there was some failure.
+##
+## @since 0.1.0
+##
+## ```
+## ➢ Ok(42) : Result(String, Int)
+## Ok(42) : Result(String, Int)
+## ```
+type Result(e, a) =
+    | Err(e)
+    | Ok(a)
 
-    ## Check whether the result is `Ok` without unwrapping it.
-    let ok?(ra : Result(e, a)) -> Bool =
-        match ra on
-        | Err(_) => False
-        | Ok(_) => True
+## Check whether the result is `Ok` without unwrapping it.
+let ok?(ra : Result(e, a)) -> Bool =
+    match ra on
+    | Err(_) => False
+    | Ok(_) => True
 
-    ## Check whether the result is `Err` without unwrapping it.
-    let err?(ra : Result(e, a)) -> Bool =
-        match ra on
-        | Err(_)  => True
-        | Ok(_)  => False
+## Check whether the result is `Err` without unwrapping it.
+let err?(ra : Result(e, a)) -> Bool =
+    match ra on
+    | Err(_)  => True
+    | Ok(_)  => False
 
-    let with_default(ra : Result(e, a), default : a) -> a =
-        match ra on
-        | Err(_) => default
-        | Ok(a) => a
+let with_default(ra : Result(e, a), default : a) -> a =
+    match ra on
+    | Err(_) => default
+    | Ok(a) => a
 
-    let map(ra : Result(e, a), f : (a -> value)) -> Result(e, value) =
-        match ra on
+let map(ra : Result(e, a), f : (a -> value)) -> Result(e, value) =
+    match ra on
+    | Err(e) => Err(e)
+    | Ok(a) => Ok(f(a))
+
+let map2(
+    ra : Result(e, a),
+    rb : Result(e, b),
+    f : ((a, b) -> value)
+) -> Result(e, value) =
+    match ra on
+    | Err(e) => Err(e)
+    | Ok(a) =>
+        match rb on
         | Err(e) => Err(e)
-        | Ok(a) => Ok(f(a))
+        | Ok(b) => Ok(f(a, b))
 
-    let map2(
-        ra : Result(e, a),
-        rb : Result(e, b),
-        f : ((a, b) -> value)
-    ) -> Result(e, value) =
-        match ra on
+let map3(
+    ra : Result(e, a),
+    rb : Result(e, b),
+    rc : Result(e, c),
+    f : ((a, b, c) -> value)
+) -> Result(e, value) =
+    match ra on
+    | Err(e) => Err(e)
+    | Ok(a) =>
+        match rb on
         | Err(e) => Err(e)
-        | Ok(a) =>
-            match rb on
+        | Ok(b) =>
+            match rc on
             | Err(e) => Err(e)
-            | Ok(b) => Ok(f(a, b))
+            | Ok(c) => Ok(f(a, b, c))
 
-    let map3(
-        ra : Result(e, a),
-        rb : Result(e, b),
-        rc : Result(e, c),
-        f : ((a, b, c) -> value)
-    ) -> Result(e, value) =
-        match ra on
+
+let map4(
+    ra : Result(e, a),
+    rb : Result(e, b),
+    rc : Result(e, c),
+    rd : Result(e, d),
+    f : ((a, b, c, d) -> value)
+) -> Result(e, value) =
+    match ra on
+    | Err(e) => Err(e)
+    | Ok(a) =>
+        match rb on
         | Err(e) => Err(e)
-        | Ok(a) =>
-            match rb on
+        | Ok(b) =>
+            match rc on
             | Err(e) => Err(e)
-            | Ok(b) =>
-                match rc on
+            | Ok(c) =>
+                match rd on
                 | Err(e) => Err(e)
-                | Ok(c) => Ok(f(a, b, c))
+                | Ok(d) => Ok(f(a, b, c, d))
 
+let and_then(ra : Result(e, a), f : (a -> Result(e, b))) -> Result(e, b) =
+    match ra on
+    | Err(e) => Err(e)
+    | Ok(a) => f(a)
 
-    let map4(
-        ra : Result(e, a),
-        rb : Result(e, b),
-        rc : Result(e, c),
-        rd : Result(e, d),
-        f : ((a, b, c, d) -> value)
-    ) -> Result(e, value) =
-        match ra on
-        | Err(e) => Err(e)
-        | Ok(a) =>
-            match rb on
-            | Err(e) => Err(e)
-            | Ok(b) =>
-                match rc on
-                | Err(e) => Err(e)
-                | Ok(c) =>
-                    match rd on
-                    | Err(e) => Err(e)
-                    | Ok(d) => Ok(f(a, b, c, d))
+let or(ra : Result(e, a), rb : Result(e, a)) -> Result(e, a) =
+    match ra on
+    | Err(_) => rb
+    | Ok(_) => ra
 
-    let and_then(ra : Result(e, a), f : (a -> Result(e, b))) -> Result(e, b) =
-        match ra on
-        | Err(e) => Err(e)
-        | Ok(a) => f(a)
+let map_error(ra : Result(x, a), f : (x -> y)) -> Result(y, a) =
+    match ra on
+    | Err(e) => Err(f(e))
+    | Ok(a) => Ok(a)
 
-    let or(ra : Result(e, a), rb : Result(e, a)) -> Result(e, a) =
-        match ra on
-        | Err(_) => rb
-        | Ok(_) => ra
+let from_maybe(ma : Maybe(a), err : e) -> Result(e, a) =
+    match ma on
+    | None => Err(err)
+    | Some(a) => Ok(a)
 
-    let map_error(ra : Result(x, a), f : (x -> y)) -> Result(y, a) =
-        match ra on
-        | Err(e) => Err(f(e))
-        | Ok(a) => Ok(a)
+## Combine a list of results into a single result (holding a list).
+##
+## @since 0.1.0
+##
+## ```
+## ➢ Result.compact([Ok(1), Ok(2)])
+## [1, 2] : List(Int)
+## ```
+let compact(results : List(Result(e, a)) -> List(a) =
+    List.collect_map(results, identity)
 
-    let from_maybe(ma : Maybe(a), err : e) -> Result(e, a) =
-        match ma on
-        | None => Err(err)
-        | Some(a) => Ok(a)
+## Combine a list of results into a single result (holding a list).
+## Also known as `sequence` on lists.
+##
+## @since 0.1.0
+##
+## ```
+## ➢ Result.combine([Ok(1), Ok(2)])
+## Ok([1, 2]) : List(Int)
+## ```
+let combine(results : List(Result(e, a))) -> Result(e, List(a)) =
+    results
+    |> List.fold_right(
+        fn(r, acc) => map2(r, acc, fn(x, xs) => x :: xs),
+        Ok(Nil)
+    )
 
-    ## Combine a list of results into a single result (holding a list).
-    ##
-    ## @since 0.1.0
-    ##
-    ## ```
-    ## ➢ Result.compact([Ok(1), Ok(2)])
-    ## [1, 2] : List(Int)
-    ## ```
-    let compact(results : List(Result(e, a)) -> List(a) =
-        List.collect_map(results, identity)
-
-    ## Combine a list of results into a single result (holding a list).
-    ## Also known as `sequence` on lists.
-    ##
-    ## @since 0.1.0
-    ##
-    ## ```
-    ## ➢ Result.combine([Ok(1), Ok(2)])
-    ## Ok([1, 2]) : List(Int)
-    ## ```
-    let combine(results : List(Result(e, a))) -> Result(e, List(a)) =
-        results
-        |> List.fold_right(
-            fn(r, acc) => map2(r, acc, fn(x, xs) => x :: xs),
-            Ok(Nil)
-        )
-
-    ## Partition a list of Results into two lists of values (successes and failures).
-    ##
-    ## @since 0.1.0
-    ##
-    ## ```
-    ## ➢ Result.paritition([Ok(1), Err("uh no!"), Ok(2)]
-    ## (["uh oh!"], [1, 2]) : (List(String), List(Int))
-    ## ```
-    let partition(results : List(Result(e, a))) -> (List(e), List(a)) =
-        results
-        |> List.fold_right(
-            fn(r, (err, succ)) =>
-                match r on
-                | Err(v) => (v :: err, succ)
-                | Ok(v) => (err, v :: succ),
-            (Nil, Nil)
-        )
-end
+## Partition a list of Results into two lists of values (successes and failures).
+##
+## @since 0.1.0
+##
+## ```
+## ➢ Result.paritition([Ok(1), Err("uh no!"), Ok(2)]
+## (["uh oh!"], [1, 2]) : (List(String), List(Int))
+## ```
+let partition(results : List(Result(e, a))) -> (List(e), List(a)) =
+    results
+    |> List.fold_right(
+        fn(r, (err, succ)) =>
+            match r on
+            | Err(v) => (v :: err, succ)
+            | Ok(v) => (err, v :: succ),
+        (Nil, Nil)
+    )

--- a/stdlib/set.mn
+++ b/stdlib/set.mn
@@ -20,81 +20,80 @@ module Set exposing
     , union
     )
 
-    ## A collection of unique values without any particular order.
-    type Set(a) =
-        ...
+## A collection of unique values without any particular order.
+type Set(a) =
+    ...
 
-    ## Create an empty set.
-    let empty() -> Set(a) =
-        todo("not implemented")
+## Create an empty set.
+let empty() -> Set(a) =
+    todo("not implemented")
 
-    ## Determine if a set is empty.
-    let empty?(set : Set(a)) -> Bool =
-        todo("not implemented")
+## Determine if a set is empty.
+let empty?(set : Set(a)) -> Bool =
+    todo("not implemented")
 
-    ## Create a set with one value.
-    let singleton(value : comparable) -> Set(comparable) =
-        todo("not implemented")
+## Create a set with one value.
+let singleton(value : comparable) -> Set(comparable) =
+    todo("not implemented")
 
-    ## Insert a value into a set.
-    let insert(set : Set(comparable), value : comparable) -> Set(comparable) =
-        todo("not implemented")
+## Insert a value into a set.
+let insert(set : Set(comparable), value : comparable) -> Set(comparable) =
+    todo("not implemented")
 
-    ## Remove a value from a set. If the value is not found, no changes are made.
-    let remove(set : Set(comparable), value : comparable) -> Set(comparable) =
-        todo("not implemented")
+## Remove a value from a set. If the value is not found, no changes are made.
+let remove(set : Set(comparable), value : comparable) -> Set(comparable) =
+    todo("not implemented")
 
-    ## Determine if a value is in a set.
-    let member?(set : Set(comparable), value : comparable) -> Bool =
-        todo("not implemented")
+## Determine if a value is in a set.
+let member?(set : Set(comparable), value : comparable) -> Bool =
+    todo("not implemented")
 
-    ## Determine the number of elements in a set.
-    let size(set : Set(a)) -> Int =
-        todo("not implemented")
+## Determine the number of elements in a set.
+let size(set : Set(a)) -> Int =
+    todo("not implemented")
 
-    ## Get the union of two sets. Keep all values.
-    let union(set1 : Set(comparable), set2 : Set(comparable)) -> Set(comparable) =
-        todo("not implemented")
+## Get the union of two sets. Keep all values.
+let union(set1 : Set(comparable), set2 : Set(comparable)) -> Set(comparable) =
+    todo("not implemented")
 
-    ## Get the intersection of two sets. Keeps values that appear in both sets.
-    let intersect(set1 : Set(comparable), set2 : Set(comparable)) -> Set(comparable) =
-        todo("not implemented")
+## Get the intersection of two sets. Keeps values that appear in both sets.
+let intersect(set1 : Set(comparable), set2 : Set(comparable)) -> Set(comparable) =
+    todo("not implemented")
 
-    ## Get the difference between the first set and the second. Keeps values
-    that do not appear in the second set.
-    let diff(set1 : Set(comparable), set2 : Set(comparable)) -> Set(comparable) =
-        todo("not implemented")
+## Get the difference between the first set and the second. Keeps values
+that do not appear in the second set.
+let diff(set1 : Set(comparable), set2 : Set(comparable)) -> Set(comparable) =
+    todo("not implemented")
 
-    ## Convert a set into a list, sorted from lowest to highest.
-    let to_list(set : Set(a)) -> List(a) =
-        todo("not implemented")
+## Convert a set into a list, sorted from lowest to highest.
+let to_list(set : Set(a)) -> List(a) =
+    todo("not implemented")
 
-    ## Convert a list into a set, removing any duplicates.
-    let from_list(list : List(comparable)) -> Set(comparable) =
-        todo("not implemented")
+## Convert a list into a set, removing any duplicates.
+let from_list(list : List(comparable)) -> Set(comparable) =
+    todo("not implemented")
 
-    ## Fold over the values in a set, in order from lowest to highest.
-    let fold_left(set : Set(a), f : (a, b -> b), init : b) -> b =
-        todo("not implemented")
+## Fold over the values in a set, in order from lowest to highest.
+let fold_left(set : Set(a), f : (a, b -> b), init : b) -> b =
+    todo("not implemented")
 
-    ## Fold over the values in a set, in order from highest to lowest.
-    let fold_right(set : Set(a), f : (a, b -> b), init : b) -> b =
-        todo("not implemented")
+## Fold over the values in a set, in order from highest to lowest.
+let fold_right(set : Set(a), f : (a, b -> b), init : b) -> b =
+    todo("not implemented")
 
-    ## Map a function onto a set, creating a new set with no duplicates.
-    let map(set : Set(comparable), f : (comparable -> comparable2)) -> Set(comparable2) =
-        todo("not implemented")
+## Map a function onto a set, creating a new set with no duplicates.
+let map(set : Set(comparable), f : (comparable -> comparable2)) -> Set(comparable2) =
+    todo("not implemented")
 
-    ## Only keep elements that satisfy the given predicate
-    let keep(set : Set(comparable), pred : (comparable -> Bool)) -> Set(comparable) =
-        todo("not implemented")
+## Only keep elements that satisfy the given predicate
+let keep(set : Set(comparable), pred : (comparable -> Bool)) -> Set(comparable) =
+    todo("not implemented")
 
-    # Returns a set by excluding the elements which satisfy the given predicate
-    let reject(set : Set(comparable), pred : (comparable -> Bool)) -> Set(comparable) =
-        todo("not implemented")
+# Returns a set by excluding the elements which satisfy the given predicate
+let reject(set : Set(comparable), pred : (comparable -> Bool)) -> Set(comparable) =
+    todo("not implemented")
 
-    ## Create two new sets. The first contains all the elements that passed the
-    ## given test, and the second contains all the elements that did not.
-    let partition(set : Set(comparable), pred : (comparable -> Bool)) -> (Set(comparable), Set(comparable)) =
-        todo("not implemented")
-end
+## Create two new sets. The first contains all the elements that passed the
+## given test, and the second contains all the elements that did not.
+let partition(set : Set(comparable), pred : (comparable -> Bool)) -> (Set(comparable), Set(comparable)) =
+    todo("not implemented")

--- a/stdlib/string.mn
+++ b/stdlib/string.mn
@@ -46,417 +46,416 @@ module String exposing
     , words
     )
 
-    type Pattern =
-        Pattern(String)
+type Pattern =
+    Pattern(String)
 
-    ## Calculate the number of characters in a string.
-    ##
-    ## @since 0.1.0
-    ##
-    ## ```
-    ## ➢ String.size("foobar")
-    ## 6 : Int
-    ## ```
-    let size(str : String) -> Int =
-        todo("not implemented")
+## Calculate the number of characters in a string.
+##
+## @since 0.1.0
+##
+## ```
+## ➢ String.size("foobar")
+## 6 : Int
+## ```
+let size(str : String) -> Int =
+    todo("not implemented")
 
-    ## Append two strings.
-    ##
-    ## @since 0.1.0
-    ##
-    ## ```
-    ## ➢ String.append("foo", "bar")
-    ## "foobar" : String
-    ## ```
-    let append(str1 : String, str2 : String) -> String =
-        todo("not implemented")
+## Append two strings.
+##
+## @since 0.1.0
+##
+## ```
+## ➢ String.append("foo", "bar")
+## "foobar" : String
+## ```
+let append(str1 : String, str2 : String) -> String =
+    todo("not implemented")
 
-    ## Concatenate many strings into one.
-    ##
-    ## @since 0.1.0
-    ##
-    ## ```
-    ## ➢ String.concat(["foo", "bar"])
-    ## "foobar" : String
-    ## ```
-    let concat(list : List(String)) -> String =
-        todo("not implemented")
+## Concatenate many strings into one.
+##
+## @since 0.1.0
+##
+## ```
+## ➢ String.concat(["foo", "bar"])
+## "foobar" : String
+## ```
+let concat(list : List(String)) -> String =
+    todo("not implemented")
 
-    ## Put many strings together with a given pattern.
-    ##
-    ## @since 0.1.0
-    ##
-    ## ```
-    ## ➢ String.concat(Pattern("/"), (["foo", "bar", "baz"])
-    ## "foo/bar/baz" : String
-    ## ```
-    let join(pattern : Pattern, list : List(String)) -> String =
-        todo("not implemented")
+## Put many strings together with a given pattern.
+##
+## @since 0.1.0
+##
+## ```
+## ➢ String.concat(Pattern("/"), (["foo", "bar", "baz"])
+## "foo/bar/baz" : String
+## ```
+let join(pattern : Pattern, list : List(String)) -> String =
+    todo("not implemented")
 
-    ## Take *n* characters from the left side of a string.
-    ##
-    ## @since 0.1.0
-    ##
-    ## ```
-    ## ➢ String.take_left("foobar", 3)
-    ## "foo" : String
-    ## ```
-    let take_left(str : String, n : Int) -> String =
-        if n < 1 then
-            ""
-        else
-            slice(str, 0, n)
+## Take *n* characters from the left side of a string.
+##
+## @since 0.1.0
+##
+## ```
+## ➢ String.take_left("foobar", 3)
+## "foo" : String
+## ```
+let take_left(str : String, n : Int) -> String =
+    if n < 1 then
+        ""
+    else
+        slice(str, 0, n)
 
-    ## Take *n* characters from the right side of a string.
-    ##
-    ## @since 0.1.0
-    ##
-    ## ```
-    ## ➢ String.take_right("foobar", 3)
-    ## "bar" : String
-    ## ```
-    let take_right(str : String, n : Int) -> String =
-        todo("not implemented")
+## Take *n* characters from the right side of a string.
+##
+## @since 0.1.0
+##
+## ```
+## ➢ String.take_right("foobar", 3)
+## "bar" : String
+## ```
+let take_right(str : String, n : Int) -> String =
+    todo("not implemented")
 
-    ## ???
-    ##
-    ## @since 0.1.0
-    ##
-    ## ```
-    ## ➢ String.take_while("foobar", vowel?)
-    ## : String
-    ## ```
-    let take_while(str : String, predicate : (Char -> Bool)) -> String =
-        todo("not implemented")
+## ???
+##
+## @since 0.1.0
+##
+## ```
+## ➢ String.take_while("foobar", vowel?)
+## : String
+## ```
+let take_while(str : String, predicate : (Char -> Bool)) -> String =
+    todo("not implemented")
 
-    ## Drop *n* characters from the right side of a string.
-    ##
-    ## @since 0.1.0
-    ##
-    ## ```
-    ## ➢ String.drop_left("foobar", 3)
-    ## "bar" : String
-    ## ```
-    let drop_left(str : String, n : Int) -> String =
-        todo("not implemented")
+## Drop *n* characters from the right side of a string.
+##
+## @since 0.1.0
+##
+## ```
+## ➢ String.drop_left("foobar", 3)
+## "bar" : String
+## ```
+let drop_left(str : String, n : Int) -> String =
+    todo("not implemented")
 
-    ## Drop *n* characters from the right side of a string.
-    ##
-    ## @since 0.1.0
-    ##
-    ## ```
-    ## ➢ String.drop_right("foobar", 3)
-    ## "foo" : String
-    ## ```
-    let drop_right(str : String, n : Int) -> String =
-        todo("not implemented")
+## Drop *n* characters from the right side of a string.
+##
+## @since 0.1.0
+##
+## ```
+## ➢ String.drop_right("foobar", 3)
+## "foo" : String
+## ```
+let drop_right(str : String, n : Int) -> String =
+    todo("not implemented")
 
-    ## ???
-    ##
-    ## @since 0.1.0
-    ##
-    ## ```
-    ## ➢
-    ## : String
-    ## ```
-    let drop_while(str : String, predicate : (Char -> Bool)) -> String =
-        todo("not implemented")
+## ???
+##
+## @since 0.1.0
+##
+## ```
+## ➢
+## : String
+## ```
+let drop_while(str : String, predicate : (Char -> Bool)) -> String =
+    todo("not implemented")
 
-    ## Determin if the second string contains the first one.
-    ##
-    ## @since 0.1.0
-    ##
-    ## ```
-    ## ➢
-    ## : String
-    ## ```
-    let contains?(str : String, pattern : Pattern) -> Bool =
-        todo("not implemented")
+## Determin if the second string contains the first one.
+##
+## @since 0.1.0
+##
+## ```
+## ➢
+## : String
+## ```
+let contains?(str : String, pattern : Pattern) -> Bool =
+    todo("not implemented")
 
-    ## Break a string into words, splitting on chunks of whitespace.
-    ##
-    ## @since 0.1.0
-    ##
-    ## ```
-    ## ➢ String.words "..."
-    ## [] : List String
-    ## ```
-    let words(str : String) -> List(String) =
-        todo("not implemented")
+## Break a string into words, splitting on chunks of whitespace.
+##
+## @since 0.1.0
+##
+## ```
+## ➢ String.words "..."
+## [] : List String
+## ```
+let words(str : String) -> List(String) =
+    todo("not implemented")
 
-    ## Break a string into lines, splitting on newlines.
-    ##
-    ## @since 0.1.0
-    ##
-    ## ```
-    ## ➢ String.lines "..."
-    ## [] : List String
-    ## ```
-    let lines(str : String) -> List(String) =
-        todo("not implemented")
+## Break a string into lines, splitting on newlines.
+##
+## @since 0.1.0
+##
+## ```
+## ➢ String.lines "..."
+## [] : List String
+## ```
+let lines(str : String) -> List(String) =
+    todo("not implemented")
 
-    ## ???
-    ##
-    ## @since 0.1.0
-    ##
-    ## ```
-    ## ➢
-    ## : String
-    ## ```
-    let index_of(str : String, pattern : Pattern) -> Maybe(Int) =
-        todo("not implemented")
+## ???
+##
+## @since 0.1.0
+##
+## ```
+## ➢
+## : String
+## ```
+let index_of(str : String, pattern : Pattern) -> Maybe(Int) =
+    todo("not implemented")
 
-    ## ???
-    ##
-    ## @since 0.1.0
-    ##
-    ## ```
-    ## ➢
-    ## : String
-    ## ```
-    let last_index_of(str : String, pattern : Pattern) -> Maybe(Int) =
-        todo("not implemented")
+## ???
+##
+## @since 0.1.0
+##
+## ```
+## ➢
+## : String
+## ```
+let last_index_of(str : String, pattern : Pattern) -> Maybe(Int) =
+    todo("not implemented")
 
-    ## Split a string using a given pattern.
-    ##
-    ## @since 0.1.0
-    ##
-    ## ```
-    ## ➢ String.split_on("foo,bar", Pattern(","))
-    ## ["foo", "bar"] : List(String)
-    ## ```
-    let split_on(str : String, pattern : Pattern) -> List(String) =
-        todo("not implemented")
+## Split a string using a given pattern.
+##
+## @since 0.1.0
+##
+## ```
+## ➢ String.split_on("foo,bar", Pattern(","))
+## ["foo", "bar"] : List(String)
+## ```
+let split_on(str : String, pattern : Pattern) -> List(String) =
+    todo("not implemented")
 
-    ## Split a string using a given pattern.
-    ##
-    ## @since 0.1.0
-    ##
-    ## ```
-    ## ➢ String.split_at("foobar", 3)
-    ## ("foo", "bar") : (String, String)
-    ## ```
-    let split_at(str : String, n : Int) -> (String, String) =
-        todo("not implemented")
+## Split a string using a given pattern.
+##
+## @since 0.1.0
+##
+## ```
+## ➢ String.split_at("foobar", 3)
+## ("foo", "bar") : (String, String)
+## ```
+let split_at(str : String, n : Int) -> (String, String) =
+    todo("not implemented")
 
-    ## Take a substring given a start and end index.
-    ##
-    ## @since 0.1.0
-    ##
-    ## ```
-    ## ➢ String.slice("abcd", 1, 3)
-    ## "bc" : String
-    ## ```
-    let slice(str : String, start : Int, end : Int) -> String =
-        todo("not implemented")
+## Take a substring given a start and end index.
+##
+## @since 0.1.0
+##
+## ```
+## ➢ String.slice("abcd", 1, 3)
+## "bc" : String
+## ```
+let slice(str : String, start : Int, end : Int) -> String =
+    todo("not implemented")
 
-    ## Convert a string to all lower case.
-    ##
-    ## @since 0.1.0
-    ##
-    ## ```
-    ## ➢ String.to_lower("FOOBAR")
-    ## "foobar" : String
-    ## ```
-    let to_lower(str : String) -> String =
-        todo("not implemented")
+## Convert a string to all lower case.
+##
+## @since 0.1.0
+##
+## ```
+## ➢ String.to_lower("FOOBAR")
+## "foobar" : String
+## ```
+let to_lower(str : String) -> String =
+    todo("not implemented")
 
-    ## Convert a string to all upper case.
-    ##
-    ## @since 0.1.0
-    ##
-    ## ```
-    ## ➢ String.to_upper("foobar")
-    ## "FOOBAR" : String
-    ## ```
-    let to_upper(str : String) -> String =
-        todo("not implemented")
+## Convert a string to all upper case.
+##
+## @since 0.1.0
+##
+## ```
+## ➢ String.to_upper("foobar")
+## "FOOBAR" : String
+## ```
+let to_upper(str : String) -> String =
+    todo("not implemented")
 
-    ## Reverse a string.
-    ##
-    ## @since 0.1.0
-    ##
-    ## ```
-    ## ➢ String.reverse("foobar")
-    ## "raboof" : String
-    ## ```
-    let reverse(str : String) -> String =
-        todo("not implemented")
+## Reverse a string.
+##
+## @since 0.1.0
+##
+## ```
+## ➢ String.reverse("foobar")
+## "raboof" : String
+## ```
+let reverse(str : String) -> String =
+    todo("not implemented")
 
-    ## Repeat a string *n* times.
-    ##
-    ## @since 0.1.0
-    ##
-    ## ```
-    ## ➢ String.repeat("ha", 3)
-    ## "hahaha" : String
-    ## ```
-    let repeat(str : String, count : Int) -> String =
-        todo("not implemented")
+## Repeat a string *n* times.
+##
+## @since 0.1.0
+##
+## ```
+## ➢ String.repeat("ha", 3)
+## "hahaha" : String
+## ```
+let repeat(str : String, count : Int) -> String =
+    todo("not implemented")
 
-    ## ???
-    ##
-    ## @since 0.1.0
-    ##
-    ## ```
-    ## ➢
-    ## : string
-    ## ```
-    let empty?(str : String) -> Bool =
-        todo("not implemented")
+## ???
+##
+## @since 0.1.0
+##
+## ```
+## ➢
+## : string
+## ```
+let empty?(str : String) -> Bool =
+    todo("not implemented")
 
-    ## Returns `True` if string ends with the given pattern.
-    ##
-    ## @since 0.1.0
-    ##
-    ## ```
-    ## ➢ String.ends_with?("abc", "c")
-    ## True : Bool
-    ## ```
-    let ends_with?(str : String, pattern : Pattern) =
-        todo("not implemented")
+## Returns `True` if string ends with the given pattern.
+##
+## @since 0.1.0
+##
+## ```
+## ➢ String.ends_with?("abc", "c")
+## True : Bool
+## ```
+let ends_with?(str : String, pattern : Pattern) =
+    todo("not implemented")
 
-    ## Returns `True` if string starts with the given pattern.
-    ##
-    ## @since 0.1.0
-    ##
-    ## ```
-    ## ➢ String.starts_with?("abc", "a")
-    ## True : Bool
-    ## ```
-    let starts_with?(str : String, pattern : Pattern) -> Bool
-        todo("not implemented")
+## Returns `True` if string starts with the given pattern.
+##
+## @since 0.1.0
+##
+## ```
+## ➢ String.starts_with?("abc", "a")
+## True : Bool
+## ```
+let starts_with?(str : String, pattern : Pattern) -> Bool
+    todo("not implemented")
 
-    ## Replace all occurrences of some pattern.
-    ##
-    ## @since 0.1.0
-    ##
-    ## ```
-    ## ➢ String.replace "foo-bar-baz" (Pattern "-") (Pattern "_")
-    ## "foo_bar_baz" : String
-    ## ```
-    let replace(str: String, pattern1 : String, pattern2 : String) -> String =
-        todo("not implemented")
+## Replace all occurrences of some pattern.
+##
+## @since 0.1.0
+##
+## ```
+## ➢ String.replace "foo-bar-baz" (Pattern "-") (Pattern "_")
+## "foo_bar_baz" : String
+## ```
+let replace(str: String, pattern1 : String, pattern2 : String) -> String =
+    todo("not implemented")
 
-    ## Remove whitespace from both sides of a string.
-    ##
-    ## @since 0.1.0
-    ##
-    ## ```
-    ## ➢ String.trim("  foo  ")
-    ## "foo" : String
-    ## ```
-    let trim(str : String) -> String =
-        todo("not implemented")
+## Remove whitespace from both sides of a string.
+##
+## @since 0.1.0
+##
+## ```
+## ➢ String.trim("  foo  ")
+## "foo" : String
+## ```
+let trim(str : String) -> String =
+    todo("not implemented")
 
-    ## Remove whitespace from the left of a string.
-    ##
-    ## @since 0.1.0
-    ##
-    ## ```
-    ## ➢ String.trim_left("  foo")
-    ## "foo" : String
-    ## ```
-    let trim_left(str : String) -> String =
-        todo("not implemented")
+## Remove whitespace from the left of a string.
+##
+## @since 0.1.0
+##
+## ```
+## ➢ String.trim_left("  foo")
+## "foo" : String
+## ```
+let trim_left(str : String) -> String =
+    todo("not implemented")
 
-    ## Remove whitespace from the right of a string.
-    ##
-    ## @since 0.1.0
-    ##
-    ## ```
-    ## ➢ String.trim_right("foo  ")
-    ## "foo" : String
-    ## ```
-    let trim_right(str : String) -> String =
-        todo("not implemented")
+## Remove whitespace from the right of a string.
+##
+## @since 0.1.0
+##
+## ```
+## ➢ String.trim_right("foo  ")
+## "foo" : String
+## ```
+let trim_right(str : String) -> String =
+    todo("not implemented")
 
-    ## Pad a string on both sides until it has a given length.
-    ##
-    ## @since 0.1.0
-    ##
-    ## ```
-    ## ➢ String.pad("foobar", 10, '_')
-    ## "__foobar__" : String
-    ## ```
-    let pad : Int -> Char -> String -> String =
-    let pad(str : String, n : Int, char : Char) -> String =
-        todo("not implemented")
+## Pad a string on both sides until it has a given length.
+##
+## @since 0.1.0
+##
+## ```
+## ➢ String.pad("foobar", 10, '_')
+## "__foobar__" : String
+## ```
+let pad : Int -> Char -> String -> String =
+let pad(str : String, n : Int, char : Char) -> String =
+    todo("not implemented")
 
-    ## Pad a string from the left until it has a given length.
-    ##
-    ## @since 0.1.0
-    ##
-    ## ```
-    ## ➢ String.pad_left("foo", 6, Pattern(" "))
-    ## "   foo" : String
-    ## ```
-    let pad_left(str : String, count : Int, pattern : Pattern) -> String =
-        todo("not implemented")
+## Pad a string from the left until it has a given length.
+##
+## @since 0.1.0
+##
+## ```
+## ➢ String.pad_left("foo", 6, Pattern(" "))
+## "   foo" : String
+## ```
+let pad_left(str : String, count : Int, pattern : Pattern) -> String =
+    todo("not implemented")
 
-    ## Pad a string from the right until it has a given length.
-    ##
-    ## @since 0.1.0
-    ##
-    ## ```
-    ## ➢ String.pad_right("foo", 6, Pattern(" "))
-    ## "foo   " : String
-    ## ```
-    let pad_right(str : String, count : Int, pattern : Pattern) -> String =
-        todo("not implemented")
+## Pad a string from the right until it has a given length.
+##
+## @since 0.1.0
+##
+## ```
+## ➢ String.pad_right("foo", 6, Pattern(" "))
+## "foo   " : String
+## ```
+let pad_right(str : String, count : Int, pattern : Pattern) -> String =
+    todo("not implemented")
 
-    ## Returns `True` if string starts with the given pattern.
-    ##
-    ## @since 0.1.0
-    ##
-    ## ```
-    ## ➢ String.indexes_of("Mississippi", "i")
-    ## [1, 4, 7, 10] : List(Int)
-    ## ```
-    let indexes_of(str: String, substr : String) -> List(Int) =
-        todo("not implemented")
+## Returns `True` if string starts with the given pattern.
+##
+## @since 0.1.0
+##
+## ```
+## ➢ String.indexes_of("Mississippi", "i")
+## [1, 4, 7, 10] : List(Int)
+## ```
+let indexes_of(str: String, substr : String) -> List(Int) =
+    todo("not implemented")
 
-    let to_int(str : String) -> Maybe(Int) =
-        todo("not implemented")
+let to_int(str : String) -> Maybe(Int) =
+    todo("not implemented")
 
-    let to_float(str : String) -> Maybe(Float) =
-        todo("not implemented")
+let to_float(str : String) -> Maybe(Float) =
+    todo("not implemented")
 
-    let from_char(char : Char) -> String =
-        todo("not implemented")
+let from_char(char : Char) -> String =
+    todo("not implemented")
 
-    ## Transform every character in a string
-    let map(str : String, f : (Char -> Char)) -> String =
-        todo("not implemented")
+## Transform every character in a string
+let map(str : String, f : (Char -> Char)) -> String =
+    todo("not implemented")
 
-    ## Keep only the characters that pass the test.
-    let keep(str : String, predicate : (Char -> Bool)) -> String =
-        todo("not implemented")
+## Keep only the characters that pass the test.
+let keep(str : String, predicate : (Char -> Bool)) -> String =
+    todo("not implemented")
 
-    let reject(str : String, predicate : (Char -> Bool)) -> String =
-        todo("not implemented")
+let reject(str : String, predicate : (Char -> Bool)) -> String =
+    todo("not implemented")
 
-    ## Reduce a string from the left.
-    let fold_left(str : String, f : (Char, b -> b), init : b) -> b =
-        todo("not implemented")
+## Reduce a string from the left.
+let fold_left(str : String, f : (Char, b -> b), init : b) -> b =
+    todo("not implemented")
 
-    ## Reduce a string from the right.
-    let fold_right(str : String, f : (Char, b -> b), init : b) -> b =
-        todo("not implemented")
+## Reduce a string from the right.
+let fold_right(str : String, f : (Char, b -> b), init : b) -> b =
+    todo("not implemented")
 
-    ## Determine whether *any* characters pass the test.
-    let any?(str : String, pred : (Char -> Bool)) -> Bool =
-        todo("not implemented")
+## Determine whether *any* characters pass the test.
+let any?(str : String, pred : (Char -> Bool)) -> Bool =
+    todo("not implemented")
 
-    ## Determine whether *all* characters pass the test.
-    let all?(str : String, pred : (Char -> Bool)) -> Bool =
-        todo("not implemented")
+## Determine whether *all* characters pass the test.
+let all?(str : String, pred : (Char -> Bool)) -> Bool =
+    todo("not implemented")
 
-    ## Get character at the given position.
-    let at(str : String, position : Int) -> Maybe(Char) =
-        todo("not implemented")
+## Get character at the given position.
+let at(str : String, position : Int) -> Maybe(Char) =
+    todo("not implemented")
 
-    ## Determines if a string matches the given pattern.
-    let match?(str : String, pattern : Pattern) -> Bool =
-        todo("not implemented")
-end
+## Determines if a string matches the given pattern.
+let match?(str : String, pattern : Pattern) -> Bool =
+    todo("not implemented")

--- a/stdlib/tuple.mn
+++ b/stdlib/tuple.mn
@@ -8,30 +8,29 @@ module Tuple exposing
     , snd
     )
 
-    # CREATE
+# CREATE
 
-    let pair(x : a, y : b) -> (a, b) =
-        (x, y)
+let pair(x : a, y : b) -> (a, b) =
+    (x, y)
 
-    # ACCESS
+# ACCESS
 
-    let fst(x : a, _ : b) -> a =
-        x
+let fst(x : a, _ : b) -> a =
+    x
 
-    let snd(_ : a, y: b) -> a =
-        y
+let snd(_ : a, y: b) -> a =
+    y
 
-    # TRANSFORM
+# TRANSFORM
 
-    let map_both(pair : (a, b), f : (a -> x), g : (b -> y)) -> (x, y) =
-        match pair on
-        | (x, y) => (f(x), g(y))
+let map_both(pair : (a, b), f : (a -> x), g : (b -> y)) -> (x, y) =
+    match pair on
+    | (x, y) => (f(x), g(y))
 
-    let map_first(pair : (a, b), f : (a -> x)) -> (x, b) =
-        match pair on
-        | (x, y) => (f(x), y)
+let map_first(pair : (a, b), f : (a -> x)) -> (x, b) =
+    match pair on
+    | (x, y) => (f(x), y)
 
-    let map_second(pair : (a, b), f : (b -> y)) -> (a, y) =
-        match pair on
-        | (x, y) => (x, f(y))
-end
+let map_second(pair : (a, b), f : (b -> y)) -> (a, y) =
+    match pair on
+    | (x, y) => (x, f(y))

--- a/stdlib/unit.mn
+++ b/stdlib/unit.mn
@@ -1,15 +1,15 @@
 module Unit exposing (Unit(..), ignore)
-    type Unit =
-        Unit
 
-    ## Discard the value of its argument and return `Unit`.
-    ##
-    ## @since 0.1.0
-    ##
-    ## ```
-    ## ➢ ignore(42)
-    ## Unit : Unit
-    ## ```
-    let ignore(_ : a) -> Unit =
-        Unit
-end
+type Unit =
+    Unit
+
+## Discard the value of its argument and return `Unit`.
+##
+## @since 0.1.0
+##
+## ```
+## ➢ ignore(42)
+## Unit : Unit
+## ```
+let ignore(_ : a) -> Unit =
+    Unit

--- a/stdlib/validation.mn
+++ b/stdlib/validation.mn
@@ -1,5 +1,5 @@
 module Validation exposing (Validation(..))
-    ## Result type that accumulates errors
-    type Validation(e, a) =
-        Validation(e, a)
-end
+
+## Result type that accumulates errors
+type Validation(e, a) =
+    Validation(e, a)


### PR DESCRIPTION
# Evaluating the `end` keyword

Pros and cons of keeping `end` versus relying on `EOF`:

### Pros of keeping `end`:
- **Explicitness**: It makes the module’s boundary crystal clear, which could help humans (and parsers) quickly identify where the module ends, especially in long files. This aligns with the principle of making intent obvious, a strength in languages like OCaml.
- **Future Flexibility**: Provides a foundation to build on without breaking existing code should I ever reconsider nested modules or want to allow multiple modules in a single file (e.g., for testing or small utilities).

### Cons of keeping `end`:
- **Redundancy**: If every file is a single module and you’re not nesting, `end` becomes ceremonial—it doesn’t add semantic value beyond what `EOF` already provides. In Elm, for example, modules don’t need an end because the file itself is the scope.

### Pros of using `EOF`:
- **Simplicity**: It’s one less token for the parser and programmer to worry about. The file’s end naturally closes the module, which is intuitive and elegant.
- **Alignment with File-as-Module**: `EOF` reinforces the one-module-per-file rule design choice organically.

### Cons of using `EOF`:
- **Less Explicit**: Some programmers might prefer the visual cue of end, especially in a teaching context or when skimming code.


