### PR TITLE
refactor to use new func decl syntax

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -16,6 +16,9 @@ jobs:
   preflight:
     runs-on: ubuntu-latest
 
+    # Skip the entire job for draft PRs
+    if: github.event.pull_request.draft == false
+
     steps:
       - uses: actions/checkout@v4
       - uses: cachix/install-nix-action@v27

--- a/compiler/frontend/lexer.zig
+++ b/compiler/frontend/lexer.zig
@@ -29,7 +29,7 @@ pub const KeywordKind = enum {
 
 pub const OperatorKind = enum {
     // Arithmetic
-    Exp,
+    Exponent,
     FloatAdd,
     FloatDiv,
     FloatMul,
@@ -51,13 +51,27 @@ pub const OperatorKind = enum {
     LogicalAnd,
     LogicalOr,
 
-    // Other
-    Cons,
-    Equal,
-    Expand,
-    ListConcat,
+    // Functions
+    ThinArrow,
+    FatArrow,
+    ComposeLeft,
+    ComposeRight,
+    PipeLeft,
     PipeRight,
-    StrConcat,
+
+    // Lists
+    ListCons,
+    ListConcat,
+
+    // Strings
+    StringConcat,
+
+    // Assignment
+    Equal,
+
+    // Miscellaneous
+    Expand,
+    Pipe,
 };
 
 pub const DelimiterKind = enum {
@@ -86,9 +100,7 @@ pub const IdentifierKind = enum {
 };
 
 pub const SymbolKind = enum {
-    ArrowRight,
-    DoubleArrowRight,
-    Pipe,
+    TypeHole,
     Underscore,
 };
 
@@ -99,7 +111,6 @@ pub const CommentKind = enum {
 
 pub const SpecialKind = enum {
     Eof,
-    Hole,
     Unrecognized,
 };
 
@@ -298,7 +309,7 @@ pub const Lexer = struct {
                 self.advance();
 
                 if (self.peek() == null) {
-                    return Token.init(.{ .special = .Hole }, "?", .{
+                    return Token.init(.{ .symbol = .TypeHole }, "?", .{
                         .filename = self.loc.filename,
                         .src = .{
                             .line = start_line,
@@ -653,7 +664,7 @@ pub const Lexer = struct {
                     if (next == '>') {
                         self.advance();
 
-                        return Token.init(.{ .symbol = .ArrowRight }, "->", .{
+                        return Token.init(.{ .operator = .ThinArrow }, "->", .{
                             .filename = self.loc.filename,
                             .src = .{
                                 .line = start_line,
@@ -702,7 +713,7 @@ pub const Lexer = struct {
                     if (next == '*') {
                         self.advance();
 
-                        return Token.init(.{ .operator = .Exp }, "**", .{
+                        return Token.init(.{ .operator = .Exponent }, "**", .{
                             .filename = self.loc.filename,
                             .src = .{
                                 .line = start_line,
@@ -816,7 +827,39 @@ pub const Lexer = struct {
                     if (next == '>') {
                         self.advance();
 
-                        return Token.init(.{ .operator = .StrConcat }, "<>", .{
+                        return Token.init(.{ .operator = .StringConcat }, "<>", .{
+                            .filename = self.loc.filename,
+                            .src = .{
+                                .line = start_line,
+                                .col = start_col,
+                            },
+                            .span = .{
+                                .start = span_start,
+                                .end = self.loc.span.end,
+                            },
+                        });
+                    }
+
+                    if (next == '|') {
+                        self.advance();
+
+                        return Token.init(.{ .operator = .PipeLeft }, "<|", TokenLoc{
+                            .filename = self.loc.filename,
+                            .src = .{
+                                .line = start_line,
+                                .col = start_col,
+                            },
+                            .span = .{
+                                .start = span_start,
+                                .end = self.loc.span.end,
+                            },
+                        });
+                    }
+
+                    if (next == '<') {
+                        self.advance();
+
+                        return Token.init(.{ .operator = .ComposeLeft }, "<<", TokenLoc{
                             .filename = self.loc.filename,
                             .src = .{
                                 .line = start_line,
@@ -850,6 +893,22 @@ pub const Lexer = struct {
                         self.advance();
 
                         return Token.init(.{ .operator = .GreaterThanEqual }, ">=", .{
+                            .filename = self.loc.filename,
+                            .src = .{
+                                .line = start_line,
+                                .col = start_col,
+                            },
+                            .span = .{
+                                .start = span_start,
+                                .end = self.loc.span.end,
+                            },
+                        });
+                    }
+
+                    if (next == '>') {
+                        self.advance();
+
+                        return Token.init(.{ .operator = .ComposeRight }, ">>", TokenLoc{
                             .filename = self.loc.filename,
                             .src = .{
                                 .line = start_line,
@@ -945,7 +1004,7 @@ pub const Lexer = struct {
                     }
                 }
 
-                return Token.init(.{ .symbol = .Pipe }, "|", .{
+                return Token.init(.{ .operator = .Pipe }, "|", .{
                     .filename = self.loc.filename,
                     .src = .{
                         .line = start_line,
@@ -964,7 +1023,7 @@ pub const Lexer = struct {
                     if (next == ':') {
                         self.advance();
 
-                        return Token.init(.{ .operator = .Cons }, "::", .{
+                        return Token.init(.{ .operator = .ListCons }, "::", .{
                             .filename = self.loc.filename,
                             .src = .{
                                 .line = start_line,
@@ -1079,7 +1138,7 @@ pub const Lexer = struct {
                     if (next == '>') {
                         self.advance();
 
-                        return Token.init(.{ .symbol = .DoubleArrowRight }, "=>", .{
+                        return Token.init(.{ .operator = .FatArrow }, "=>", .{
                             .filename = self.loc.filename,
                             .src = .{
                                 .line = start_line,
@@ -2067,24 +2126,8 @@ test "[symbol]" {
     // Setup
     const cases = [_]TestCase{
         .{
-            .source = "->",
-            .token = Token.init(.{ .symbol = .ArrowRight }, "->", .{
-                .filename = TEST_FILE,
-                .src = .{ .line = 1, .col = 1 },
-                .span = .{ .start = 0, .end = 2 },
-            }),
-        },
-        .{
-            .source = "=>",
-            .token = Token.init(.{ .symbol = .DoubleArrowRight }, "=>", .{
-                .filename = TEST_FILE,
-                .src = .{ .line = 1, .col = 1 },
-                .span = .{ .start = 0, .end = 2 },
-            }),
-        },
-        .{
-            .source = "|",
-            .token = Token.init(.{ .symbol = .Pipe }, "|", .{
+            .source = "?",
+            .token = Token.init(.{ .symbol = .TypeHole }, "?", .{
                 .filename = TEST_FILE,
                 .src = .{ .line = 1, .col = 1 },
                 .span = .{ .start = 0, .end = 1 },
@@ -2131,7 +2174,7 @@ test "[operator]" {
         // Arithmetic
         .{
             .source = "**",
-            .token = Token.init(.{ .operator = .Exp }, "**", .{
+            .token = Token.init(.{ .operator = .Exponent }, "**", .{
                 .filename = TEST_FILE,
                 .src = .{ .line = 1, .col = 1 },
                 .span = .{ .start = 0, .end = 2 },
@@ -2267,7 +2310,64 @@ test "[operator]" {
                 .span = .{ .start = 0, .end = 2 },
             }),
         },
-        // Other
+        // Functions
+        .{
+            .source = "->",
+            .token = Token.init(.{ .operator = .ThinArrow }, "->", .{
+                .filename = TEST_FILE,
+                .src = .{ .line = 1, .col = 1 },
+                .span = .{ .start = 0, .end = 2 },
+            }),
+        },
+        .{
+            .source = "=>",
+            .token = Token.init(.{ .operator = .FatArrow }, "=>", .{
+                .filename = TEST_FILE,
+                .src = .{ .line = 1, .col = 1 },
+                .span = .{ .start = 0, .end = 2 },
+            }),
+        },
+        .{
+            .source = "<<",
+            .token = Token.init(.{ .operator = .ComposeLeft }, "<<", .{
+                .filename = TEST_FILE,
+                .src = .{ .line = 1, .col = 1 },
+                .span = .{ .start = 0, .end = 2 },
+            }),
+        },
+        .{
+            .source = ">>",
+            .token = Token.init(.{ .operator = .ComposeRight }, ">>", .{
+                .filename = TEST_FILE,
+                .src = .{ .line = 1, .col = 1 },
+                .span = .{ .start = 0, .end = 2 },
+            }),
+        },
+        .{
+            .source = "<|",
+            .token = Token.init(.{ .operator = .PipeLeft }, "<|", .{
+                .filename = TEST_FILE,
+                .src = .{ .line = 1, .col = 1 },
+                .span = .{ .start = 0, .end = 2 },
+            }),
+        },
+        .{
+            .source = "|>",
+            .token = Token.init(.{ .operator = .PipeRight }, "|>", .{
+                .filename = TEST_FILE,
+                .src = .{ .line = 1, .col = 1 },
+                .span = .{ .start = 0, .end = 2 },
+            }),
+        },
+        // Lists
+        .{
+            .source = "::",
+            .token = Token.init(.{ .operator = .ListCons }, "::", .{
+                .filename = TEST_FILE,
+                .src = .{ .line = 1, .col = 1 },
+                .span = .{ .start = 0, .end = 2 },
+            }),
+        },
         .{
             .source = "++",
             .token = Token.init(.{ .operator = .ListConcat }, "++", .{
@@ -2276,6 +2376,26 @@ test "[operator]" {
                 .span = .{ .start = 0, .end = 2 },
             }),
         },
+        // Strings
+        .{
+            .source = "<>",
+            .token = Token.init(.{ .operator = .StringConcat }, "<>", .{
+                .filename = TEST_FILE,
+                .src = .{ .line = 1, .col = 1 },
+                .span = .{ .start = 0, .end = 2 },
+            }),
+        },
+        // Assignment
+        .{
+            .source = "=",
+            .token = Token.init(.{ .operator = .Equal }, "=", .{
+                .filename = TEST_FILE,
+                .src = .{ .line = 1, .col = 1 },
+                .span = .{ .start = 0, .end = 1 },
+            }),
+        },
+
+        // Other
         .{
             .source = "..",
             .token = Token.init(.{ .operator = .Expand }, "..", .{
@@ -2285,35 +2405,11 @@ test "[operator]" {
             }),
         },
         .{
-            .source = "::",
-            .token = Token.init(.{ .operator = .Cons }, "::", .{
-                .filename = TEST_FILE,
-                .src = .{ .line = 1, .col = 1 },
-                .span = .{ .start = 0, .end = 2 },
-            }),
-        },
-        .{
-            .source = "<>",
-            .token = Token.init(.{ .operator = .StrConcat }, "<>", .{
-                .filename = TEST_FILE,
-                .src = .{ .line = 1, .col = 1 },
-                .span = .{ .start = 0, .end = 2 },
-            }),
-        },
-        .{
-            .source = "=",
-            .token = Token.init(.{ .operator = .Equal }, "=", .{
+            .source = "|",
+            .token = Token.init(.{ .operator = .Pipe }, "|", .{
                 .filename = TEST_FILE,
                 .src = .{ .line = 1, .col = 1 },
                 .span = .{ .start = 0, .end = 1 },
-            }),
-        },
-        .{
-            .source = "|>",
-            .token = Token.init(.{ .operator = .PipeRight }, "|>", .{
-                .filename = TEST_FILE,
-                .src = .{ .line = 1, .col = 1 },
-                .span = .{ .start = 0, .end = 2 },
             }),
         },
     };
@@ -2347,8 +2443,8 @@ test "[special]" {
     // Setup
     const cases = [_]TestCase{
         .{
-            .source = "?",
-            .token = Token.init(.{ .special = .Hole }, "?", .{
+            .source = "%",
+            .token = Token.init(.{ .special = .Unrecognized }, "%", .{
                 .filename = TEST_FILE,
                 .src = .{ .line = 1, .col = 1 },
                 .span = .{ .start = 0, .end = 1 },
@@ -3527,7 +3623,7 @@ test "[type variant]" {
             .src = .{ .line = 1, .col = 13 },
             .span = .{ .start = 12, .end = 13 },
         }),
-        Token.init(.{ .symbol = .Pipe }, "|", .{
+        Token.init(.{ .operator = .Pipe }, "|", .{
             .filename = TEST_FILE,
             .src = .{ .line = 1, .col = 15 },
             .span = .{ .start = 14, .end = 15 },
@@ -3537,7 +3633,7 @@ test "[type variant]" {
             .src = .{ .line = 1, .col = 17 },
             .span = .{ .start = 16, .end = 19 },
         }),
-        Token.init(.{ .symbol = .Pipe }, "|", .{
+        Token.init(.{ .operator = .Pipe }, "|", .{
             .filename = TEST_FILE,
             .src = .{ .line = 1, .col = 21 },
             .span = .{ .start = 20, .end = 21 },
@@ -3814,9 +3910,9 @@ test "[module declaration]" {
     }
 }
 
-test "[top level function definition]" {
+test "[top level function declaration]" {
     // Setup
-    const source = "let add(x : Int, y : Int) -> Int = x + y";
+    const source = "let add (x : Int) (y : Int) : Int = x + y";
 
     const expected_tokens = [_]Token{
         Token.init(.{ .keyword = .Let }, "let", .{
@@ -3831,83 +3927,88 @@ test "[top level function definition]" {
         }),
         Token.init(.{ .delimiter = .LeftParen }, "(", .{
             .filename = TEST_FILE,
-            .src = .{ .line = 1, .col = 8 },
-            .span = .{ .start = 7, .end = 8 },
-        }),
-        Token.init(.{ .identifier = .Lower }, "x", .{
-            .filename = TEST_FILE,
             .src = .{ .line = 1, .col = 9 },
             .span = .{ .start = 8, .end = 9 },
         }),
+        Token.init(.{ .identifier = .Lower }, "x", .{
+            .filename = TEST_FILE,
+            .src = .{ .line = 1, .col = 10 },
+            .span = .{ .start = 9, .end = 10 },
+        }),
         Token.init(.{ .delimiter = .Colon }, ":", .{
             .filename = TEST_FILE,
-            .src = .{ .line = 1, .col = 11 },
-            .span = .{ .start = 10, .end = 11 },
+            .src = .{ .line = 1, .col = 12 },
+            .span = .{ .start = 11, .end = 12 },
         }),
         Token.init(.{ .identifier = .Upper }, "Int", .{
             .filename = TEST_FILE,
-            .src = .{ .line = 1, .col = 13 },
-            .span = .{ .start = 12, .end = 15 },
+            .src = .{ .line = 1, .col = 14 },
+            .span = .{ .start = 13, .end = 16 },
         }),
-        Token.init(.{ .delimiter = .Comma }, ",", .{
+        Token.init(.{ .delimiter = .RightParen }, ")", .{
             .filename = TEST_FILE,
-            .src = .{ .line = 1, .col = 16 },
-            .span = .{ .start = 15, .end = 16 },
+            .src = .{ .line = 1, .col = 17 },
+            .span = .{ .start = 16, .end = 17 },
+        }),
+        Token.init(.{ .delimiter = .LeftParen }, "(", .{
+            .filename = TEST_FILE,
+            .src = .{ .line = 1, .col = 19 },
+            .span = .{ .start = 18, .end = 19 },
         }),
         Token.init(.{ .identifier = .Lower }, "y", .{
-            .filename = TEST_FILE,
-            .src = .{ .line = 1, .col = 18 },
-            .span = .{ .start = 17, .end = 18 },
-        }),
-        Token.init(.{ .delimiter = .Colon }, ":", .{
             .filename = TEST_FILE,
             .src = .{ .line = 1, .col = 20 },
             .span = .{ .start = 19, .end = 20 },
         }),
-        Token.init(.{ .identifier = .Upper }, "Int", .{
+        Token.init(.{ .delimiter = .Colon }, ":", .{
             .filename = TEST_FILE,
             .src = .{ .line = 1, .col = 22 },
-            .span = .{ .start = 21, .end = 24 },
+            .span = .{ .start = 21, .end = 22 },
+        }),
+        Token.init(.{ .identifier = .Upper }, "Int", .{
+            .filename = TEST_FILE,
+            .src = .{ .line = 1, .col = 24 },
+            .span = .{ .start = 23, .end = 26 },
         }),
         Token.init(.{ .delimiter = .RightParen }, ")", .{
             .filename = TEST_FILE,
-            .src = .{ .line = 1, .col = 25 },
-            .span = .{ .start = 24, .end = 25 },
-        }),
-        Token.init(.{ .symbol = .ArrowRight }, "->", .{
-            .filename = TEST_FILE,
             .src = .{ .line = 1, .col = 27 },
-            .span = .{ .start = 26, .end = 28 },
+            .span = .{ .start = 26, .end = 27 },
+        }),
+        Token.init(.{ .delimiter = .Colon }, ":", .{
+            .filename = TEST_FILE,
+            .src = .{ .line = 1, .col = 29 },
+            .span = .{ .start = 28, .end = 29 },
         }),
         Token.init(.{ .identifier = .Upper }, "Int", .{
             .filename = TEST_FILE,
-            .src = .{ .line = 1, .col = 30 },
-            .span = .{ .start = 29, .end = 32 },
+            .src = .{ .line = 1, .col = 31 },
+            .span = .{ .start = 30, .end = 33 },
         }),
         Token.init(.{ .operator = .Equal }, "=", .{
             .filename = TEST_FILE,
-            .src = .{ .line = 1, .col = 34 },
-            .span = .{ .start = 33, .end = 34 },
+            .src = .{ .line = 1, .col = 35 },
+            .span = .{ .start = 34, .end = 35 },
         }),
         Token.init(.{ .identifier = .Lower }, "x", .{
             .filename = TEST_FILE,
-            .src = .{ .line = 1, .col = 36 },
-            .span = .{ .start = 35, .end = 36 },
+            .src = .{ .line = 1, .col = 37 },
+            .span = .{ .start = 36, .end = 37 },
         }),
         Token.init(.{ .operator = .IntAdd }, "+", .{
             .filename = TEST_FILE,
-            .src = .{ .line = 1, .col = 38 },
-            .span = .{ .start = 37, .end = 38 },
+            .src = .{ .line = 1, .col = 39 },
+            .span = .{ .start = 38, .end = 39 },
         }),
         Token.init(.{ .identifier = .Lower }, "y", .{
             .filename = TEST_FILE,
-            .src = .{ .line = 1, .col = 40 },
-            .span = .{ .start = 39, .end = 40 },
+            .src = .{ .line = 1, .col = 41 },
+            .span = .{ .start = 40, .end = 41 },
         }),
         Token.init(.{ .special = .Eof }, "", .{
             .filename = TEST_FILE,
-            .src = .{ .line = 1, .col = 41 },
-            .span = .{ .start = 40, .end = 40 },
+            .src = .{ .line = 1, .col = 42 },
+            .span = .{ .start = 41, .end = 41 },
         }),
     };
 
@@ -3952,7 +4053,7 @@ test "[pattern matching]" {
             .src = .{ .line = 1, .col = 9 },
             .span = .{ .start = 8, .end = 10 },
         }),
-        Token.init(.{ .symbol = .Pipe }, "|", .{
+        Token.init(.{ .operator = .Pipe }, "|", .{
             .filename = TEST_FILE,
             .src = .{ .line = 1, .col = 12 },
             .span = .{ .start = 11, .end = 12 },
@@ -3962,7 +4063,7 @@ test "[pattern matching]" {
             .src = .{ .line = 1, .col = 14 },
             .span = .{ .start = 13, .end = 16 },
         }),
-        Token.init(.{ .symbol = .DoubleArrowRight }, "=>", .{
+        Token.init(.{ .operator = .FatArrow }, "=>", .{
             .filename = TEST_FILE,
             .src = .{ .line = 1, .col = 18 },
             .span = .{ .start = 17, .end = 19 },
@@ -3972,7 +4073,7 @@ test "[pattern matching]" {
             .src = .{ .line = 1, .col = 21 },
             .span = .{ .start = 20, .end = 21 },
         }),
-        Token.init(.{ .symbol = .Pipe }, "|", .{
+        Token.init(.{ .operator = .Pipe }, "|", .{
             .filename = TEST_FILE,
             .src = .{ .line = 1, .col = 23 },
             .span = .{ .start = 22, .end = 23 },
@@ -3982,7 +4083,7 @@ test "[pattern matching]" {
             .src = .{ .line = 1, .col = 25 },
             .span = .{ .start = 24, .end = 27 },
         }),
-        Token.init(.{ .symbol = .DoubleArrowRight }, "=>", .{
+        Token.init(.{ .operator = .FatArrow }, "=>", .{
             .filename = TEST_FILE,
             .src = .{ .line = 1, .col = 29 },
             .span = .{ .start = 28, .end = 30 },
@@ -3997,7 +4098,7 @@ test "[pattern matching]" {
             .src = .{ .line = 1, .col = 34 },
             .span = .{ .start = 33, .end = 34 },
         }),
-        Token.init(.{ .symbol = .DoubleArrowRight }, "=>", .{
+        Token.init(.{ .operator = .FatArrow }, "=>", .{
             .filename = TEST_FILE,
             .src = .{ .line = 1, .col = 36 },
             .span = .{ .start = 35, .end = 37 },

--- a/stdlib/aff.mn
+++ b/stdlib/aff.mn
@@ -19,83 +19,83 @@ module Aff exposing
 ## ➢
 ## :
 ## ```
-type alias Aff(e, a) =
-    AsyncEffect(e, a)
+type alias Aff e a =
+    AsyncEffect e a
 
 ## Lifts an error into a failed `Aff`.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ Aff.fail("foobar!") : Aff(String, String)
-## : Aff(String, String)
+## ➢ Aff.fail "foobar!" : Aff String String
+## : Aff String String
 ## ```
-let fail(err : e) -> Aff(e, Unit) =
-    Scheduler.Async.fail(err)
+let fail (err : e) : Aff e Unit =
+    Scheduler.Async.fail err
 
 ## Lifts a value into a successful `Aff`.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ Aff.success("foobar") : Aff(String, String)
-## : Aff(String, String)
+## ➢ Aff.success "foobar" : Aff String String
+## : Aff String String
 ## ```
-let succeed(value : a) -> Aff(Unit, a) =
-    Scheduler.Async.succeed(value)
+let succeed (value : a) : Aff Unit a =
+    Scheduler.Async.succeed value
 
-let map(aff_a : Aff(e, a), f : (a -> b)) =
-    match run(aff_a) on
-    | Err(ea) => fail(ea)
-    | Ok(a) => succeed(f(a))
+let map (aff_a : Aff e a) (f : a -> b) : Aff e b =
+    match run aff_a on
+    | Err ea => fail ea
+    | Ok a => succeed (f a)
 
-let map2(
-    aff_a: Aff(e, a),
-    aff_b: Aff(e, b),
-    f: ((a, b) -> c)
-) -> Aff(e, c) =
-    match run(aff_a) on
-    | Err(ea) => fail(ea)
-    | Ok(a) =>
-        match run(aff_b) on
-        | Err(eb) => fail(eb)
-        | Ok(b) => succeed(f(a, b))
+let map2
+    (aff_a : Aff e a)
+    (aff_b : Aff e b)
+    (f : a -> b -> c)
+    : Aff e c =
+    match run aff_a on
+    | Err ea => fail ea
+    | Ok a =>
+        match run aff_b on
+        | Err eb => fail eb
+        | Ok b => succeed (f a b)
 
-let map3(
-    aff_a: Aff(e, a),
-    aff_b: Aff(e, b),
-    aff_c: Aff(e, c),
-    f: ((a, b, c) -> d)
-) -> Aff(e, d) =
-    match run(aff_a) on
-    | Err(ea) => fail(ea)
-    | Ok(a) =>
-        match run(aff_b) on
-        | Err(eb) => fail(eb)
-        | Ok(b) =>
-            match run(aff_c) on
-            | Err(ec) => fail(ec)
-            | Ok(c) => succeed(f(a, b, c))
+let map3
+    (aff_a : Aff e a)
+    (aff_b : Aff e b)
+    (aff_c : Aff e c)
+    (f : a -> b -> c -> d)
+    : Aff e d =
+    match run aff_a on
+    | Err ea => fail ea
+    | Ok a =>
+        match run aff_b on
+        | Err eb => fail eb
+        | Ok b =>
+            match run aff_c on
+            | Err ec => fail ec
+            | Ok c => succeed (f a b c)
 
-let map4(
-    aff_a: Aff(e, a),
-    aff_b: Aff(e, b),
-    aff_c: Aff(e, c),
-    aff_d: Aff(e, d),
-    f: ((a, b, c, d) -> e)
-) -> Aff(e, e) =
-    match run(aff_a) on
-    | Err(ea) => fail(ea)
-    | Ok(a) =>
-        match run(aff_b) on
-        | Err(eb) => fail(eb)
-        | Ok(b) =>
-            match run(aff_c) on
-            | Err(ec) => fail(ec)
-            | Ok(c) =>
-                match run(aff_d) on
-                | Err(ed) => fail(ed)
-                | Ok(d) => succeed(f(a, b, c, d))
+let map4
+    (aff_a : Aff e a)
+    (aff_b : Aff e b)
+    (aff_c : Aff e c)
+    (aff_d : Aff e d)
+    (f : a -> b -> c -> d -> value)
+    : Aff e value =
+    match run aff_a on
+    | Err ea => fail ea
+    | Ok a =>
+        match run aff_b on
+        | Err eb => fail eb
+        | Ok b =>
+            match run aff_c on
+            | Err ec => fail ec
+            | Ok c =>
+                match run aff_d on
+                | Err ed => fail ed
+                | Ok d => succeed (f a b c d)
 
 ## Equivalent of `>>=` from the `Monad` typeclass.
 ##
@@ -105,13 +105,13 @@ let map4(
 ## ➢ Aff.and_then ...
 ## ...
 ## ```
-let and_then(aff: Aff(e, a), f: (a) -> Aff(e, b)) -> Aff(e, b) =
-    todo("not implemented")
+let and_then (aff : Aff e a) (f : a -> Aff e b) : Aff e b =
+    todo "not implemented"
 
-let run(aff: Aff(e, a)) -> Result(e, a) =
-    todo("not implemented")
+let run (aff : Aff e a) : Result e a =
+    todo "not implemented"
 
-let from_result(result: Result(e, a)) -> Aff(e, a) =
+let from_result (result : Result e a) : Aff e a =
     match result on
-    | Err(e) => fail(e)
-    | Ok(a) => succeed(a)
+    | Err e => fail e
+    | Ok a => succeed a

--- a/stdlib/bitwise.mn
+++ b/stdlib/bitwise.mn
@@ -19,11 +19,11 @@ module Bitwise exposing
 ## @since 0.1.0
 ##
 ## ```
-## ➢ Bitwise.and(9, 3)
+## ➢ Bitwise.and 9 3
 ## 1 : Int
 ## ```
-let and(x : Int, y : Int) -> Int =
-    bitwise_and(x, y)
+let and (x : Int) (y : Int) : Int =
+    bitwise_and x y
 
 ## Performs a bitwise OR operation between two integers.
 ## Each bit in the result is 1 if at least one of the corresponding
@@ -32,11 +32,11 @@ let and(x : Int, y : Int) -> Int =
 ## @since 0.1.0
 ##
 ## ```
-## ➢ Bitwise.or(9, 3)
+## ➢ Bitwise.or 9 3
 ## 11 : Int
 ## ```
-let or(x : Int, y : Int) -> Int =
-    bitwise_or(x, y)
+let or (x : Int) (y : Int) : Int =
+    bitwise_or x y
 
 ## Performs a bitwise NOT operation on an integer, inverting all bits.
 ## Each 0 becomes 1 and each 1 becomes 0 in the binary representation.
@@ -44,11 +44,11 @@ let or(x : Int, y : Int) -> Int =
 ## @since 0.1.0
 ##
 ## ```
-## ➢ Bitwise.not(2)
+## ➢ Bitwise.not 2
 ## -3 : Int
 ## ```
-let not(x : Int) -> Int =
-    bitwise_not(x)
+let not (x : Int) : Int =
+    bitwise_not x
 
 ## Performs a bitwise XOR (exclusive OR) operation between two integers.
 ## Each bit in the result is 1 only if the corresponding bits in the
@@ -57,11 +57,11 @@ let not(x : Int) -> Int =
 ## @since 0.1.0
 ##
 ## ```
-## ➢ Bitwise.xor(9, 3)
+## ➢ Bitwise.xor 9 3
 ## 10 : Int
 ## ```
-let xor(x : Int, y : Int) -> Int =
-    bitwise_xor(x, y)
+let xor (x : Int) (y : Int) : Int =
+    bitwise_xor x y
 
 ## Shifts all bits in the first integer to the left by the number of
 ## positions specified by the second integer. New bits are filled with zeros.
@@ -69,11 +69,11 @@ let xor(x : Int, y : Int) -> Int =
 ## @since 0.1.0
 ##
 ## ```
-## ➢ Bitwise.shift_left(1, 2)
+## ➢ Bitwise.shift_left 1 2
 ## 4 : Int
 ## ```
-let shift_left(x : Int, y : Int) -> Int =
-    bitwise_shl(x, y)
+let shift_left (x : Int) (y : Int) : Int =
+    bitwise_shl x y
 
 ## Performs an arithmetic right shift, preserving the sign bit. All
 ## bits are shifted right by the specified number of positions, with
@@ -82,11 +82,11 @@ let shift_left(x : Int, y : Int) -> Int =
 ## @since 0.1.0
 ##
 ## ```
-## ➢ Bitwise.shift_right(1, 2)
+## ➢ Bitwise.shift_right 1 2
 ## 0 : Int
 ## ```
-let shift_right(x : Int, y : Int) -> Int =
-    bitwise_shr(x, y)
+let shift_right (x : Int) (y : Int) : Int =
+    bitwise_shr x y
 
 ## Performs a logical right shift, filling new bits with zeros
 ## regardless of the sign bit. This differs from `shift_right` in how
@@ -95,11 +95,11 @@ let shift_right(x : Int, y : Int) -> Int =
 ## @since 0.1.0
 ##
 ## ```
-## ➢ Bitwise.logical_shift_right(1, 32)
+## ➢ Bitwise.logical_shift_right 1 32
 ## 16 : Int
 ## ```
-let logical_shift_right(x : Int, y : Int) -> Int =
-    bitwise_lshr(x, y)
+let logical_shift_right (x : Int) (y : Int) : Int =
+    bitwise_lshr x y
 
 ## Rotates all bits to the left by the specified number of positions.
 ## Unlike shifting, bits that would be shifted out are wrapped around
@@ -108,11 +108,11 @@ let logical_shift_right(x : Int, y : Int) -> Int =
 ## @since 0.1.0
 ##
 ## ```
-## ➢ Bitwise.rotate_left(11, 2)
+## ➢ Bitwise.rotate_left 11 2
 ## 14 : Int
 ## ```
-let rotate_left(x : Int, y : Int) -> Int =
-    bitwise_rotl(x, y)
+let rotate_left (x : Int) (y : Int) : Int =
+    bitwise_rotl x y
 
 ## Rotates all bits to the right by the specified number of positions.
 ## Unlike shifting, bits that would be shifted out are wrapped around
@@ -121,11 +121,11 @@ let rotate_left(x : Int, y : Int) -> Int =
 ## @since 0.1.0
 ##
 ## ```
-## ➢ Bitwise.rotate_right(11, 2)
+## ➢ Bitwise.rotate_right 11 2
 ## 14 : Int
 ## ```
-let rotate_right(x : Int, y : Int) -> Int =
-    bitwise_rotr(x, y)
+let rotate_right (x : Int) (y : Int) : Int =
+    bitwise_rotr x y
 
 ## Returns the Hamming weight (population count) of an integer - the
 ## number of 1s in its binary representation.
@@ -133,11 +133,11 @@ let rotate_right(x : Int, y : Int) -> Int =
 ## @since 0.1.0
 ##
 ## ```
-## ➢ Bitwise.hamming_weight(29)
+## ➢ Bitwise.hamming_weight 29
 ## 4 : Int
 ## ```
-let hamming_weight(x : Int) -> Int =
-    bitwise_hw(x)
+let hamming_weight (x : Int) : Int =
+    bitwise_hw x
 
 ## Calculates the Hamming distance between two integers - the number of
 ## positions at which their binary representations differ.
@@ -145,41 +145,41 @@ let hamming_weight(x : Int) -> Int =
 ## @since 0.1.0
 ##
 ## ```
-## ➢ Bitwise.distance(29, 21)
+## ➢ Bitwise.distance 29 21
 ## 1 : Int
 ## ```
-let distance(x : Int, y : Int) -> Int =
-    bitwise_dist(x, y)
+let distance (x : Int) (y : Int) : Int =
+    bitwise_dist x y
 
-foreign bitwise_and(_ : Int, _ : Int) -> Int =
+foreign bitwise_and : Int -> Int -> Int =
     "zig_bitwise_and"
 
-foreign bitwise_or(_ : Int, _ : Int) -> Int =
+foreign bitwise_or : Int -> Int -> Int =
     "zig_bitwise_or"
 
-foreign bitwise_not(_ : Int) -> Int =
+foreign bitwise_not : Int -> Int =
     "zig_bitwise_not"
 
-foreign bitwise_xor(_ : Int, _ : Int) -> Int =
+foreign bitwise_xor : Int -> Int -> Int =
     "zig_bitwise_xor"
 
-foreign bitwise_shl(_ : Int, _ : Int) -> Int =
+foreign bitwise_shl : Int -> Int -> Int =
     "zig_bitwise_shl"
 
-foreign bitwise_shr(_ : Int, _ : Int) -> Int =
+foreign bitwise_shr : Int -> Int -> Int =
     "zig_bitwise_shr"
 
-foreign bitwise_lshr(_ : Int, _ : Int) -> Int =
+foreign bitwise_lshr : Int -> Int -> Int =
     "zig_bitwise_lshr"
 
-foreign bitwise_rotl(_ : Int, _ : Int) -> Int =
+foreign bitwise_rotl : Int -> Int -> Int =
     "zig_bitwise_rotl"
 
-foreign bitwise_rotr(_ : Int, _ : Int) -> Int =
+foreign bitwise_rotr : Int -> Int -> Int =
     "zig_bitwise_rotr"
 
-foreign bitwise_hw(_ : Int) -> Int =
+foreign bitwise_hw : Int -> Int =
     "zig_bitwise_hamming_weight"
 
-foreign bitwise_dist(_ : Int, _ : Int) -> Int =
+foreign bitwise_dist : Int -> Int -> Int =
     "zig_bitwise_distance"

--- a/stdlib/boolean.mn
+++ b/stdlib/boolean.mn
@@ -5,10 +5,10 @@ module Boolean exposing
     , nor
     , not
     , or
+    , xnor
     , xor
     )
 
-## The `Bool` type represents binary true/false values used for logical operations.
 type Bool =
     | False
     | True
@@ -19,10 +19,10 @@ type Bool =
 ## @since 0.1.0
 ##
 ## ```
-## ➢ Boolean.not(True)
+## ➢ Boolean.not True
 ## False : Bool
 ## ```
-let not(x : Bool) -> Bool =
+let not (x : Bool) : Bool =
     match x on
     | False => True
     | True => False
@@ -33,13 +33,13 @@ let not(x : Bool) -> Bool =
 ## @since 0.1.0
 ##
 ## ```
-## ➢ Boolean.and(True, False)
+## ➢ Boolean.and True False
 ## False : Bool
 ##
-## ➢ Boolean.and(True, True)
+## ➢ Boolean.and True True
 ## True : Bool
 ## ```
-let and(x : Bool, y : Bool) -> Bool =
+let and (x : Bool) (y : Bool) : Bool =
     match (x, y) on
     | (True, True) => True
     | _ => False
@@ -50,13 +50,13 @@ let and(x : Bool, y : Bool) -> Bool =
 ## @since 0.1.0
 ##
 ## ```
-## ➢ Boolean.nand(True, False)
+## ➢ Boolean.nand True False
 ## True : Bool
 ##
-## ➢ Boolean.nand(True, True)
+## ➢ Boolean.nand True True
 ## False : Bool
 ## ```
-let nand(x : Bool, y : Bool) -> Bool =
+let nand (x : Bool) (y : Bool) : Bool =
     match (x, y) on
     | (True, True) => False
     | _ => True
@@ -67,13 +67,13 @@ let nand(x : Bool, y : Bool) -> Bool =
 ## @since 0.1.0
 ##
 ## ```
-## ➢ Boolean.or(True, False)
+## ➢ Boolean.or True False
 ## True : Bool
 ##
-## ➢ Boolean.or(False, False)
+## ➢ Boolean.or False False
 ## False : Bool
 ## ```
-let or(x : Bool, y : Bool) -> Bool =
+let or (x : Bool) (y : Bool) : Bool =
     match (x, y) on
     | (False, False) => False
     | _ => True
@@ -84,13 +84,13 @@ let or(x : Bool, y : Bool) -> Bool =
 ## @since 0.1.0
 ##
 ## ```
-## ➢ Boolean.nor(False, False)
+## ➢ Boolean.nor False False
 ## True : Bool
 ##
-## ➢ Boolean.nor(True, False)
+## ➢ Boolean.nor True False
 ## False : Bool
 ## ```
-let nor(x : Bool, y : Bool) -> Bool =
+let nor (x : Bool) (y : Bool) : Bool =
     match (x, y) on
     | (False, False) => True
     | _ => False
@@ -101,13 +101,13 @@ let nor(x : Bool, y : Bool) -> Bool =
 ## @since 0.1.0
 ##
 ## ```
-## ➢ Boolean.xor(True, False)
+## ➢ Boolean.xor True False
 ## True : Bool
 ##
-## ➢ Boolean.xor(True, True)
+## ➢ Boolean.xor True True
 ## False : Bool
 ## ```
-let xor(x : Bool, y : Bool) -> Bool =
+let xor (x : Bool) (y : Bool) : Bool =
     match (x, y) on
     | (False, False) => False
     | (True, True) => False
@@ -119,13 +119,13 @@ let xor(x : Bool, y : Bool) -> Bool =
 ## @since 0.1.0
 ##
 ## ```
-## ➢ Boolean.xnor(True, True)
+## ➢ Boolean.xnor True True
 ## True : Bool
 ##
-## ➢ Boolean.xnor(False, True)
+## ➢ Boolean.xnor False True
 ## False : Bool
 ## ```
-let xnor(x : Bool, y : Bool) -> Bool =
+let xnor (x : Bool) (y : Bool) : Bool =
     match (x, y) on
     | (True, True) => True
     | (False, False) => True

--- a/stdlib/comparable.mn
+++ b/stdlib/comparable.mn
@@ -21,14 +21,14 @@ type Ordering =
 ## @since 0.1.0
 ##
 ## ```
-## ➢ Comparable.eq(42, 42)
+## ➢ Comparable.eq 42 42
 ## True : Bool
 ##
-## ➢ Comparable.eq(42, 41)
+## ➢ Comparable.eq 42 41
 ## False : Bool
 ## ```
-let eq(x : comparable, y : comparable) -> Bool =
-    match compare(x, y) on
+let eq (x : comparable) (y : comparable) : Bool =
+    match compare x y on
     | EQ => True
     | _ => False
 
@@ -37,14 +37,14 @@ let eq(x : comparable, y : comparable) -> Bool =
 ## @since 0.1.0
 ##
 ## ```
-## ➢ Comparable.neq(42, 41)
+## ➢ Comparable.neq 42 41
 ## True : Bool
 ##
-## ➢ Comparable.neq(42, 42)
+## ➢ Comparable.neq 42 42
 ## False : Bool
 ## ```
-let neq(x : comparable, y : comparable) -> Bool =
-    match compare(x, y) on
+let neq (x : comparable) (y : comparable) : Bool =
+    match compare x y on
     | EQ => False
     | _ => True
 
@@ -53,14 +53,14 @@ let neq(x : comparable, y : comparable) -> Bool =
 ## @since 0.1.0
 ##
 ## ```
-## ➢ Comparable.lt(41, 42)
+## ➢ Comparable.lt 41 42
 ## True : Bool
 ##
-## ➢ Comparable.lt(42, 42)
+## ➢ Comparable.lt 42 42
 ## False : Bool
 ## ```
-let lt(x : comparable, y : comparable) -> Bool =
-    match compare(x, y) on
+let lt (x : comparable) (y : comparable) : Bool =
+    match compare x y on
     | LT => True
     | _ => False
 
@@ -69,14 +69,14 @@ let lt(x : comparable, y : comparable) -> Bool =
 ## @since 0.1.0
 ##
 ## ```
-## ➢ Comparable.gt(43, 42)
+## ➢ Comparable.gt 43 42
 ## True : Bool
 ##
-## ➢ Comparable.gt(42, 42)
+## ➢ Comparable.gt 42 42
 ## False : Bool
 ## ```
-let gt(x : comparable, y : comparable) -> Bool =
-    match compare(x, y) on
+let gt (x : comparable) (y : comparable) : Bool =
+    match compare x y on
     | GT => True
     | _ => False
 
@@ -85,14 +85,14 @@ let gt(x : comparable, y : comparable) -> Bool =
 ## @since 0.1.0
 ##
 ## ```
-## ➢ Comparable.lte(42, 42)
+## ➢ Comparable.lte 42 42
 ## True : Bool
 ##
-## ➢ Comparable.lte(43, 42)
+## ➢ Comparable.lte 43 42
 ## False : Bool
 ## ```
-let lte(x : comparable, y : comparable) -> Bool =
-    match compare(x, y) on
+let lte (x : comparable) (y : comparable) : Bool =
+    match compare x y on
     | LT => True
     | EQ => True
     | _ => False
@@ -102,14 +102,14 @@ let lte(x : comparable, y : comparable) -> Bool =
 ## @since 0.1.0
 ##
 ## ```
-## ➢ Comparable.gte(42, 42)
+## ➢ Comparable.gte 42 42
 ## True : Bool
 ##
-## ➢ Comparable.gte(41, 42)
+## ➢ Comparable.gte 41 42
 ## False : Bool
 ## ```
-let gte(x : comparable, y : comparable) -> Bool =
-    match compare(x, y) on
+let gte (x : comparable) (y : comparable) : Bool =
+    match compare x y on
     | GT => True
     | EQ => True
     | _ => False
@@ -119,34 +119,33 @@ let gte(x : comparable, y : comparable) -> Bool =
 ## @since 0.1.0
 ##
 ## ```
-## ➢ Comparable.compare(42, 42)
+## ➢ Comparable.compare 42 42
 ## EQ : Ordering
 ##
-## ➢ Comparable.compare(41, 42)
+## ➢ Comparable.compare 41 42
 ## LT : Ordering
 ##
-## ➢ Comparable.compare(43, 42)
+## ➢ Comparable.compare 43 42
 ## GT : Ordering
 ## ```
-let compare(x : comparable, y : comparable) -> Ordering =
+let compare (x : comparable) (y : comparable) : Ordering =
     if x == y then
         EQ
+    else if x < y then
+        LT
     else
-        if x < y then
-            LT
-        else
-            GT
+        GT
 
 ## Returns the minimum of two comparable values.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ Comparable.min(42, 41)
+## ➢ Comparable.min 42 41
 ## 41 : Int
 ## ```
-let min(x : comparable, y : comparable) -> comparable =
-    match compare(x, y) on
+let min (x : comparable) (y : comparable) : comparable =
+    match compare x y on
     | LT => x
     | _ => y
 
@@ -155,10 +154,10 @@ let min(x : comparable, y : comparable) -> comparable =
 ## @since 0.1.0
 ##
 ## ```
-## ➢ Comparable.max(42, 41)
+## ➢ Comparable.max 42 41
 ## 42 : Int
 ## ```
-let max(x : comparable, y : comparable) -> comparable =
-    match compare(x, y) on
+let max (x : comparable) (y : comparable) : comparable =
+    match compare x y on
     | GT => x
     | _ => y

--- a/stdlib/date.mn
+++ b/stdlib/date.mn
@@ -27,20 +27,17 @@ type Month =
     | November
     | December
 
-let mk_date(month : Month, day : Int, year : Int) -> Date =
-    Date({ month, day, year })
+let mk_date (month : Month) (day : Int) (year : Int) : Date =
+    Date { month, day, year }
 
-let today() -> Eff(Unit, Date) =
-    date_today()
+let today : Eff Unit Date =
+    date_today
 
-let map(f : ((Date) -> Date)), date : Date) -> Date =
-    f(date)
+let map (f : Date -> Date) (date : Date) : Date =
+    f date
 
-let and_then(mdate : Maybe(Date), f : ((Date) -> Maybe(Date))) -> Maybe(Date) =
-    Maybe.map(mdate, f)
+let and_then (f : Date -> Maybe Date) (mdate : Maybe Date) : Maybe Date =
+    Maybe.map f mdate
 
-foreign date_make(_ : Month, _ : Int, _ : Int) -> Date =
-    "zig_date_make"
-
-foreign date_today() -> Eff(Unit, Date) =
+foreign date_today : Eff Unit Date =
     "zig_date_today"

--- a/stdlib/eff.mn
+++ b/stdlib/eff.mn
@@ -19,83 +19,83 @@ module Eff exposing
 ## ➢
 ## :
 ## ```
-type alias Eff(e, a) =
-    SyncEffect(e, a)
+type alias Eff e a =
+    SyncEffect e a
 
 ## Lifts an error into a failed `Eff`.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ Eff.fail("foobar!") : Eff(String, String)
+## ➢ Eff.fail "foobar!" : Eff String String
 ## :
 ## ```
-let fail(err : e) -> Eff(e, Unit) =
-    Scheduler.Sync.fail(err)
+let fail (err : e) : Eff e Unit =
+    Scheduler.Sync.fail err
 
 ## Lifts a value into a successful `#ff`.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ Eff.success("foobar") : Eff(String, String)
+## ➢ Eff.success "foobar" : Eff String String
 ## :
 ## ```
-let succeed(value : a) -> Eff(Unit, a) =
-    Scheduler.Sync.succeed(value)
+let succeed (value : a) : Eff Unit a =
+    Scheduler.Sync.succeed value
 
-let map(eff_a : Eff(e, a), f : (a -> value)) -> Eff(e, value) =
-    match run(eff_a) on
-    | Err ea => fail(ea)
-    | Ok a => succeed(f(a))
+let map (eff_a : Eff e a) (f : a -> b) : Eff e b =
+    match run eff_a on
+    | Err ea => fail ea
+    | Ok a => succeed (f a)
 
-let map2(
-    eff_a : Eff(e, a),
-    eff_b : Eff(e, b),
-    f : ((a, b) -> value)
-) -> Eff(e, value) =
-    match run(eff_a) on
-    | Err(ea) => fail(ea)
-    | Ok(a) =>
-        match run(eff_b) on
-        | Err(eb) => fail(eb)
-        | Ok(b) => succeed(f(a, b))
+let map2
+    (eff_a : Eff e a)
+    (eff_b : Eff e b)
+    (f : a -> b -> c)
+    : Eff e c =
+    match run eff_a on
+    | Err ea => fail ea
+    | Ok a =>
+        match run eff_b on
+        | Err eb => fail eb
+        | Ok b => succeed (f a b)
 
-let map3(
-    eff_a : Eff(e, a),
-    eff_b : Eff(e, b),
-    eff_c : Eff(e, c),
-    f : ((a, b, c) -> value)
-) -> Eff(e, value) =
-    match run(eff_a) on
-    | Err(ea) => fail(ea)
-    | Ok(a) =>
-        match run(eff_b) on
-        | Err(eb) => fail(eb)
-        | Ok(b) =>
-            match run(eff_c) on
-            | Err(ec) => fail(ec)
-            | Ok(c) => succeed(f(a, b, c))
+let map3
+    (eff_a : Eff e a)
+    (eff_b : Eff e b)
+    (eff_c : Eff e c)
+    (f : a -> b -> c -> d)
+    : Eff e d =
+    match run eff_a on
+    | Err ea => fail ea
+    | Ok a =>
+        match run eff_b on
+        | Err eb => fail eb
+        | Ok b =>
+            match run eff_c on
+            | Err ec => fail ec
+            | Ok c => succeed (f a b c)
 
-let map4(
-    eff_a : Eff(e, a),
-    eff_b : Eff(e, b),
-    eff_c : Eff(e, c),
-    eff_d : Eff(e, d),
-    f : ((a, b, c, d) -> value)
-) -> Eff(e, value) =
-    match run(eff_a) on
-    | Err(ea) => fail(ea)
-    | Ok(a) =>
-        match run(eff_b) on
-        | Err(eb) => fail(eb)
-        | Ok(b) =>
-            match run(eff_c) on
-            | Err(ec) => fail(ec)
-            | Ok(c) =>
-                match run(eff_d) on
-                | Err(ed) => fail(ed)
-                | Ok(d) => succeed(f(a, b, c, d))
+let map4
+    (eff_a : Eff e a)
+    (eff_b : Eff e b)
+    (eff_c : Eff e c)
+    (eff_d : Eff e d)
+    (f : a -> b -> c -> d -> value)
+    : Eff e value =
+    match run eff_a on
+    | Err ea => fail ea
+    | Ok a =>
+        match run eff_b on
+        | Err eb => fail eb
+        | Ok b =>
+            match run eff_c on
+            | Err ec => fail ec
+            | Ok c =>
+                match run eff_d on
+                | Err ed => fail ed
+                | Ok d => succeed (f a b c d)
 
 ## Equivalent of `>>=` from the `Monad` typeclass.
 ##
@@ -105,13 +105,13 @@ let map4(
 ## ➢ Eff.and_then ...
 ## ...
 ## ```
-let and_then(eff : Eff(e, a), f : (a -> Eff(e, value))) -> Eff(e, value) =
-    todo("not implemented")
+let and_then (eff : Eff e a) (f : a -> Eff e b) : Eff e b =
+    todo "not implemented"
 
-let run(eff : Eff(e, a)) -> Result(e, a) =
-    todo("not implemented")
+let run (eff : Eff e a) : Result e a =
+    todo "not implemented"
 
-let from_result(result : Result(e, a)) -> Eff(e, a) =
+let from_result (result : Result e a) : Eff e a =
     match result on
-    | Err(e) => fail(e)
-    | Ok(a) => succeed(a)
+    | Err e => fail e
+    | Ok a => succeed a

--- a/stdlib/float.mn
+++ b/stdlib/float.mn
@@ -52,10 +52,10 @@ type alias Degrees =
 ## @since 0.1.0
 ##
 ## ```
-## ➢ Float.abs(-42.0)
+## ➢ Float.abs -42.0
 ## 42.0 : Float
 ## ```
-let abs(x : Float) -> Float =
+let abs (x : Float) : Float =
     if x < 0 then
         -x
     else
@@ -66,49 +66,48 @@ let abs(x : Float) -> Float =
 ## @since 0.1.0
 ##
 ## ```
-## ➢ Float.pow(9.0, 3.0)
+## ➢ Float.pow 9.0 3.0
 ## 729.0 : Float
 ## ```
-let pow(x : Float, y : Float) -> Float =
-    float_pow(x, y)
+let pow (x : Float) (y : Float) : Float =
+    float_pow x y
 
 ## Integer remainder.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ Float.mod(42, 8)
+## ➢ Float.mod 42 8
 ## 2 : Int
 ## ```
-let mod(x : Float, y : Float) -> Float =
-    float_mod(x, y)
+let mod (x : Float) (y : Float) : Float =
+    float_mod x y
 
 ## Clamps a number within a given range.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ Float.clamp(100.0, 200.0, 99.0)
+## ➢ Float.clamp 100.0 200.0 99.0
 ## 100.0 : Float
 ## ```
-let clamp(low : Float, high : Float, n : Float) -> Float =
+let clamp (low : Float) (high : Float) (n : Float) : Float =
     if n < low then
         low
+    else if n > high then
+        high
     else
-        if n > high then
-            high
-        else
-            n
+        n
 
 ## Negate a number.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ Float.negate(42.0)
+## ➢ Float.negate 42.0
 ## -42.0 : Float
 ## ```
-let negate(x : Float) -> Float =
+let negate (x : Float) : Float =
     -x
 
 ## Calculate the square root of a number.
@@ -116,22 +115,22 @@ let negate(x : Float) -> Float =
 ## @since 0.1.0
 ##
 ## ```
-## ➢ Float.sqrt(16.0)
+## ➢ Float.sqrt 16.0
 ## 4.0 : Float
 ## ```
-let sqrt(x : Float) -> Float =
-    float_sqrt(x)
+let sqrt (x : Float) : Float =
+    float_sqrt x
 
 ## Calculate the logarithm of a number with a given base.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ Float.log(2.0, 256.0)
+## ➢ Float.log 2.0 256.0
 ## 8.0 : Float
 ## ```
-let log(x : Float, y : Float) -> Float =
-    float_log(x, y)
+let log (x : Float) (y : Float) : Float =
+    float_log x y
 
 ## Calculate the base-2 logarithm of a number.
 ## Undefined for inputs <= 0.
@@ -139,11 +138,11 @@ let log(x : Float, y : Float) -> Float =
 ## @since 0.1.0
 ##
 ## ```
-## ➢ Float.log2(8.0)
+## ➢ Float.log2 8.0
 ## 3.0 : Float
 ## ```
-let log2(x : Float) -> Float =
-    float_log(2, x)
+let log2 (x : Float) : Float =
+    float_log 2 x
 
 ## Calculate the base-10 logarithm of a number.
 ## Undefined for inputs <= 0.
@@ -151,33 +150,33 @@ let log2(x : Float) -> Float =
 ## @since 0.1.0
 ##
 ## ```
-## ➢ Float.log10(1000.0)
+## ➢ Float.log10 1000.0
 ## 3.0 : Float
 ## ```
-let log10(x : Float) -> Float =
-    float_log(10, x)
+let log10 (x : Float) : Float =
+    float_log 10 x
 
 ## An approximation of *e*.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ Float.e()
+## ➢ Float.e
 ## 3.141592653589793 : Float
 ## ```
-let e() -> Float =
-    float_e()
+let e : Float =
+    float_e
 
 ## An approximation of pie.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ Float.pi()
+## ➢ Float.pi
 ## 3.141592653589793 : Float
 ## ```
-let pi() -> Float =
-    float_pi()
+let pi : Float =
+    float_pi
 
 ## ```
 ## Calculate the cosine of an angle in radians.
@@ -185,22 +184,22 @@ let pi() -> Float =
 ## @since 0.1.0
 ##
 ## ```
-## ➢ Float.cos(Float.pi)
+## ➢ Float.cos Float.pi
 ## -1.0 : Float
 ## ```
-let cos(x : Radians) -> Float =
-    float_cos(x)
+let cos (x : Radians) : Float =
+    float_cos x
 
 ## Calculate the sine of an angle in radians.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ Float.sin(Float.pi / 2)
+## ➢ Float.sin (Float.pi / 2)
 ## 1.0 : Float
 ## ```
-let sin(x : Radians) -> Float =
-    float_sin(x)
+let sin (x : Radians) : Float =
+    float_sin x
 
 ## Calculate the tangent of an angle in radians.
 ## Note: Undefined at odd multiples of π/2.
@@ -208,11 +207,11 @@ let sin(x : Radians) -> Float =
 ## @since 0.1.0
 ##
 ## ```
-## ➢ Float.tan(Float.pi / 4)
+## ➢ Float.tan (Float.pi / 4)
 ## 1.0 : Float
 ## ```
-let tan(x : Radians) -> Float =
-    float_tan(x)
+let tan (x : Radians) : Float =
+    float_tan x
 
 ## Calculate the arc cosine (inverse cosine) of a value.
 ## Returns an angle in radians in the range [0, π].
@@ -221,11 +220,11 @@ let tan(x : Radians) -> Float =
 ## @since 0.1.0
 ##
 ## ```
-## ➢ Float.acos(0.0)
+## ➢ Float.acos 0.0
 ## 1.5707963267948966 : Radians  # π/2
 ## ```
-let acos(x : Float) -> Radians =
-    float_acos(x)
+let acos (x : Float) : Radians =
+    float_acos x
 
 ## Calculate the arc sine (inverse sine) of a value.
 ## Returns an angle in radians in the range [-π/2, π/2].
@@ -234,11 +233,11 @@ let acos(x : Float) -> Radians =
 ## @since 0.1.0
 ##
 ## ```
-## ➢ Float.asin(1.0)
+## ➢ Float.asin 1.0
 ## 1.5707963267948966 : Radians  # π/2
 ## ```
-let asin(x : Float) -> Radians =
-    float_asin(x)
+let asin (x : Float) : Radians =
+    float_asin x
 
 ## Calculate the arc tangent (inverse tangent) of a value.
 ## Returns an angle in radians in the range [-π/2, π/2].
@@ -246,11 +245,11 @@ let asin(x : Float) -> Radians =
 ## @since 0.1.0
 ##
 ## ```
-## ➢ Float.atan(1.0)
+## ➢ Float.atan 1.0
 ## 0.7853981633974483 : Radians  # π/4
 ## ```
-let atan(x : Float) -> Radians =
-    float_atan(x)
+let atan (x : Float) : Radians =
+    float_atan x
 
 ## Calculate the angle (in radians) from the positive x-axis to the
 ## point (x, y), handling all quadrants correctly.
@@ -259,21 +258,21 @@ let atan(x : Float) -> Radians =
 ## @since 0.1.0
 ##
 ## ```
-## ➢ Float.atan2(1.0, 1.0)
+## ➢ Float.atan2 1.0 1.0
 ## 0.7853981633974483 : Radians  # π/4
 ## ```
-let atan2(x : Float, y : Float) -> Radians =
-    float_atan2(x, y)
+let atan2 (x : Float) (y : Float) : Radians =
+    float_atan2 x y
 
 ## Converts a degree value into radians.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ Float.radians(Float.pi)
+## ➢ Float.to_radians Float.pi
 ## 3.141592653589793 : Float
 ## ```
-let to_radians(deg : Degrees) -> Radians =
+let to_radians (deg : Degrees) : Radians =
     (deg *. pi) /. 180.0
 
 ## Converts an angle from radians to degrees.
@@ -281,10 +280,10 @@ let to_radians(deg : Degrees) -> Radians =
 ## @since 0.1.0
 ##
 ## ```
-## ➢ Float.degrees(180.0)
+## ➢ Float.to_degrees 180.0
 ## 3.141592653589793 : Float
 ## ```
-let to_degrees(rad : Radians) -> Degrees =
+let to_degrees (rad : Radians) : Degrees =
     (rad *. 180.0) /. pi
 
 ## Truncate a number, rounding towards zero.
@@ -292,69 +291,69 @@ let to_degrees(rad : Radians) -> Degrees =
 ## @since 0.1.0
 ##
 ## ```
-## ➢ Float.trunc(-99.29)
+## ➢ Float.trunc -99.29
 ## -99 : Int
 ## ```
-let trunc(x : Float) -> Int =
-    float_trunc(x)
+let trunc (x : Float) : Int =
+    float_trunc x
 
 ## Rounds a number up to the nearest integer.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ Float.ceil(1.4)
+## ➢ Float.ceil 1.4
 ## 2 : Int
 ## ```
-let ceil(x : Float) -> Int =
-    float_ceil(x)
+let ceil (x : Float) : Int =
+    float_ceil x
 
 ## Rounds a number down to the nearest integer.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ Float.floor(1.2)
+## ➢ Float.floor 1.2
 ## 1 : Int
 ## ```
-let floor(x : Float) -> Int =
-    float_floor(x)
+let floor (x : Float) : Int =
+    float_floor x
 
 ## Round a number to the nearest integer.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ Float.round(1.2)
+## ➢ Float.round 1.2
 ## 1 : Int
 ##
-## ➢ Float.round(1.5)
+## ➢ Float.round 1.5
 ## 2 : Int
 ## ```
-let round(x : Float) -> Int =
-    float_round(x)
+let round (x : Float) : Int =
+    float_round x
 
 ## Calculate the hyperbolic cosine of an angle in radians.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ Float.cosh(1.0)
+## ➢ Float.cosh 1.0
 ## 1.5430806348152437 : Float
 ## ```
-let cosh(x : Radians) -> Float =
-    float_cosh(x)
+let cosh (x : Radians) : Float =
+    float_cosh x
 
 ## Calculate the hyperbolic sine of an angle in radians.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ Float.sinh(1.0)
+## ➢ Float.sinh 1.0
 ## 1.1752011936438014 : Float
 ## ```
-let sinh(x : Radians) -> Float =
-    float_sinh(x)
+let sinh (x : Radians) : Float =
+    float_sinh x
 
 ## Calculate the hyperbolic tangent of an angle in radians.
 ## Returns values in the range [-1, 1].
@@ -362,11 +361,11 @@ let sinh(x : Radians) -> Float =
 ## @since 0.1.0
 ##
 ## ```
-## ➢ Float.tanh(1.0)
+## ➢ Float.tanh 1.0
 ## 0.7615941559557649 : Float
 ## ```
-let tanh(x : Radians) -> Float =
-    float_tanh(x)
+let tanh (x : Radians) : Float =
+    float_tanh x
 
 ## Calculate the hyperbolic cotangent of an angle in radians.
 ## Undefined at x = 0.
@@ -374,22 +373,22 @@ let tanh(x : Radians) -> Float =
 ## @since 0.1.0
 ##
 ## ```
-## ➢ Float.coth(1.0)
+## ➢ Float.coth 1.0
 ## 1.3130352854993315 : Float
 ## ```
-let coth(x : Radians) -> Float =
-    float_coth(x)
+let coth (x : Radians) : Float =
+    float_coth x
 
 ## Calculate the hyperbolic secant of an angle in radians.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ Float.sech(1.0)
+## ➢ Float.sech 1.0
 ## 0.6480542736638854 : Float
 ## ```
-let sech(x : Radians) -> Float =
-    float_sech(x)
+let sech (x : Radians) : Float =
+    float_sech x
 
 ## Calculate the hyperbolic cosecant of an angle in radians.
 ## Undefined at x = 0.
@@ -397,11 +396,11 @@ let sech(x : Radians) -> Float =
 ## @since 0.1.0
 ##
 ## ```
-## ➢ Float.cosech(1.0)
+## ➢ Float.cosech 1.0
 ## 0.8509181282393216 : Float
 ## ```
-let cosech(x : Radians) -> Float =
-    float_cosech(x)
+let cosech (x : Radians) : Float =
+    float_cosech x
 
 ## Calculate the inverse hyperbolic cosine.
 ## Only defined for inputs >= 1.
@@ -409,22 +408,22 @@ let cosech(x : Radians) -> Float =
 ## @since 0.1.0
 ##
 ## ```
-## ➢ Float.acosh(1.0)
+## ➢ Float.acosh 1.0
 ## 0.0 : Float
 ## ```
-let acosh(x : Float) -> Float =
-    float_acosh(x)
+let acosh (x : Float) : Float =
+    float_acosh x
 
 ## Calculate the inverse hyperbolic sine.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ Float.asinh(1.0)
+## ➢ Float.asinh 1.0
 ## 0.8813735870195429 : Float
 ## ```
-let asinh(x : Float) -> Float =
-    float_asinh(x)
+let asinh (x : Float) : Float =
+    float_asinh x
 
 ## Calculate the inverse hyperbolic tangent.
 ## Only defined for inputs in range (-1, 1).
@@ -432,11 +431,11 @@ let asinh(x : Float) -> Float =
 ## @since 0.1.0
 ##
 ## ```
-## ➢ Float.atanh(0.5)
+## ➢ Float.atanh 0.5
 ## 0.5493061443340549 : Float
 ## ```
-let atanh(x : Float) -> Float =
-    float_atanh(x)
+let atanh (x : Float) : Float =
+    float_atanh x
 
 ## Calculate the inverse hyperbolic cotangent.
 ## Undefined for inputs in range [-1, 1].
@@ -444,11 +443,11 @@ let atanh(x : Float) -> Float =
 ## @since 0.1.0
 ##
 ## ```
-## ➢ Float.acoth(2.0)
+## ➢ Float.acoth 2.0
 ## 0.5493061443340549 : Float
 ## ```
-let acoth(x : Float) -> Float =
-    float_acoth(x)
+let acoth (x : Float) : Float =
+    float_acoth x
 
 ## Calculate the inverse hyperbolic secant.
 ## Only defined for inputs in range (0, 1].
@@ -456,11 +455,11 @@ let acoth(x : Float) -> Float =
 ## @since 0.1.0
 ##
 ## ```
-## ➢ Float.asech(0.5)
+## ➢ Float.asech 0.5
 ## 1.3169578969248166 : Float
 ## ```
-let asech(x : Float) -> Float =
-    float_asech(x)
+let asech (x : Float) : Float =
+    float_asech x
 
 ## Calculate the inverse hyperbolic cosecant.
 ## Undefined at x = 0.
@@ -468,137 +467,137 @@ let asech(x : Float) -> Float =
 ## @since 0.1.0
 ##
 ## ```
-## ➢ Float.acosech(1.0)
+## ➢ Float.acosech 1.0
 ## 0.8813735870195429 : Float
 ## ```
-let acosech(x : Float) -> Float =
-    float_acosech(x)
+let acosech (x : Float) : Float =
+    float_acosech x
 
 ## Return the minimum positive, non-zero representable floating-point value.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ Float.min()
+## ➢ Float.min
 ## 5e-324 : Float
 ## ```
-let min() -> Float =
-    float_min()
+let min : Float =
+    float_min
 
 ## Return the maximum representable finite floating-point value.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ Float.max()
+## ➢ Float.max
 ## 1.7976931348623157e+308 : Float
 ## ```
-let max() -> Float =
-    float_max()
+let max : Float =
+    float_max
 
 ## Convert an integer to a floating-point number.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ Float.from_int(42)
+## ➢ Float.from_int 42
 ## 42.0 : Float
 ## ```
-let from_int(x : Int) -> Float =
-    float_from_int(x)
+let from_int (x : Int) : Float =
+    float_from_int x
 
-foreign float_pow(_ : Float, _ : Float) -> Float =
+foreign float_pow : Float -> Float -> Float =
     "zig_float_pow"
 
-foreign float_mod(_ : Float, _ : Float) -> Float =
+foreign float_mod : Float -> Float -> Float =
     "zig_float_mod"
 
-foreign float_sqrt(_ : Float) -> Float =
+foreign float_sqrt : Float -> Float =
     "zig_float_sqrt"
 
-foreign float_log(_ : Float, _ : Float) -> Float =
+foreign float_log : Float -> Float -> Float =
     "zig_float_log"
 
-foreign float_e() -> Float =
+foreign float_e : Float =
     "zig_float_e"
 
-foreign float_pi() -> Float =
+foreign float_pi : Float =
     "zig_float_pi"
 
-foreign float_cos(_ : Float) -> Float =
+foreign float_cos : Float -> Float =
     "zig_float_cos"
 
-foreign float_sin(_ : Float) -> Float =
+foreign float_sin : Float -> Float =
     "zig_float_sin"
 
-foreign float_tan(_ : Float) -> Float =
+foreign float_tan : Float -> Float =
     "zig_float_tan"
 
-foreign float_acos(_ : Float) -> Float =
+foreign float_acos : Float -> Float =
     "zig_float_acos"
 
-foreign float_asin(_ : Float) -> Float =
+foreign float_asin : Float -> Float =
     "zig_float_asin"
 
-foreign float_atan(_ : Float) -> Float =
+foreign float_atan : Float -> Float =
     "zig_float_atan"
 
-foreign float_atan2(_ : Float, _ : Float) -> Float =
+foreign float_atan2 : Float -> Float -> Float =
     "zig_float_atan2"
 
-foreign float_trunc(_ : Float) -> Int =
+foreign float_trunc : Float -> Int =
     "zig_float_trunc"
 
-foreign float_ceil(_ : Float) -> Int =
+foreign float_ceil : Float -> Int =
     "zig_float_ceil"
 
-foreign float_floor(_ : Float) -> Int =
+foreign float_floor : Float -> Int =
     "zig_float_floor"
 
-foreign float_round(_ : Float) -> Int =
+foreign float_round : Float -> Int =
     "zig_float_round"
 
-foreign float_cosh(_ : Float) -> Float =
+foreign float_cosh : Float -> Float =
     "zig_float_cosh"
 
-foreign float_sinh(_ : Float) -> Float =
+foreign float_sinh : Float -> Float =
     "zig_float_sinh"
 
-foreign float_tanh(_ : Float) -> Float =
+foreign float_tanh : Float -> Float =
     "zig_float_tanh"
 
-foreign float_coth(_ : Float) -> Float =
+foreign float_coth : Float -> Float =
     "zig_float_coth"
 
-foreign float_sech(_ : Float) -> Float =
+foreign float_sech : Float -> Float =
     "zig_float_sech"
 
-foreign float_cosech(_ : Float) -> Float =
+foreign float_cosech : Float -> Float =
     "zig_float_cosech"
 
-foreign float_acosh(_ : Float) -> Float =
+foreign float_acosh : Float -> Float =
     "zig_float_acosh"
 
-foreign float_asinh(_ : Float) -> Float =
+foreign float_asinh : Float -> Float =
     "zig_float_asinh"
 
-foreign float_atanh(_ : Float) -> Float =
+foreign float_atanh : Float -> Float =
     "zig_float_atanh"
 
-foreign float_acoth(_ : Float) -> Float =
+foreign float_acoth : Float -> Float =
     "zig_float_acoth"
 
-foreign float_asech(_ : Float) -> Float =
+foreign float_asech : Float -> Float =
     "zig_float_asech"
 
-foreign float_acosech(_ : Float) -> Float =
+foreign float_acosech : Float -> Float =
     "zig_float_acosech"
 
-foreign float_min() -> Float =
+foreign float_min -> Float =
     "zig_float_min"
 
-foreign float_max() -> Float =
+foreign float_max -> Float =
     "zig_float_max"
 
-foreign float_from_int(_ : Int) -> Float =
+foreign float_from_int : Int -> Float =
     "zig_float_from_int"

--- a/stdlib/list.mn
+++ b/stdlib/list.mn
@@ -29,33 +29,33 @@ module List exposing
     , tail
     )
 
-type List(a) =
+type List a =
     | Nil
-    | a :: List(a)
+    | a :: List a
 
 ## Add an element to the beginning of a list.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ List.cons([2, 3], 1)
-## [1, 2, 3] : List(Int)
+## ➢ List.cons 1 [2, 3]
+## [1, 2, 3] : List Int
 ##
-## ➢ List.cons(Nil, 42)
-## [42] : List(Int)
+## ➢ List.cons 42 Nil
+## [42] : List Int
 ## ```
-let cons(xs : List(a), x : a) -> List(a) =
-    list_cons(xs, x)
+let cons (x : a) (xs : List a) : List a =
+    list_cons x xs
 
 ## Create a list with only one element.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ List.singleton(42)
-## [42] : List(Int)
+## ➢ List.singleton 42
+## [42] : List Int
 ## ```
-let singleton(x : a) -> List(a) =
+let singleton (x : a) : List a =
     x :: Nil
 
 ## Test whether a list is empty.
@@ -63,13 +63,13 @@ let singleton(x : a) -> List(a) =
 ## @since 0.1.0
 ##
 ## ```
-## ➢ List.empty?([42])
+## ➢ List.empty? [42]
 ## False : Bool
 ##
-## ➢ List.empty?(Nil)
+## ➢ List.empty? Nil
 ## True : Bool
 ## ```
-let empty?(list : List(a)) -> Bool =
+let empty? (list : List a) : Bool =
     match list on
     | Nil => True
     | _ => False
@@ -79,233 +79,235 @@ let empty?(list : List(a)) -> Bool =
 ## @since 0.1.0
 ##
 ## ```
-## ➢ List.size([42])
+## ➢ List.size [42]
 ## 1 : Int
 ##
-## ➢ List.size(Nil)
+## ➢ List.size Nil
 ## 0 : Int
 ## ```
-let size(list : List(a)) -> Int =
-    list_size(list)
+let size (list : List a) : Int =
+    list_size list
 
 ## Determine if a list contains a value.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ List.member?([42], 42)
+## ➢ List.member? 42 [42]
 ## True : Bool
 ##
-## ➢ List.member?(Nil, 0)
+## ➢ List.member? 0 Nil
 ## False : Bool
 ## ```
-let member?(list : List(a), elem : a) -> Bool =
-    any?(list, fn(x) => x == elem)
+let member? (elem : a) (list : List a) : Bool =
+    any? (fn x => x == elem) list
 
 ## Determine if all elements satisfy some test.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ List.all?([2, 4, 6], fn(x) => Math.even?(x))
+## ➢ List.all? Math.even? [2, 4, 6]
 ## True : Bool
 ## ```
-let all?(list : List(a), predicate : (a -> Bool)) -> Bool =
-    not(any?(list, fn(x) => not(predicate(x))))
+let all? (predicate : a -> Bool) (list : List a) : Bool =
+    not (any? (not << predicate) list)
 
 ## Determine if any elements satisfy some test.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ List.any?([2, 4, 6] fn(x) => x == 4)
+## ➢ List.any? (fn x => x == 4) [2, 4, 6]
 ## True : Bool
 ## ```
-let any?(list : List(a), predicate : (a -> Bool)) -> Bool =
+let any? (predicate : a -> Bool) (list : List a) : Bool =
     match list on
-    | Nil => False
-    | x :: xs =>
-        if predicate(x) then
-            True
-        else
-            any?(xs, predicate)
+        | Nil => False
+        | x :: xs =>
+            if predicate x then
+                True
+            else
+                any? predicate xs
 
 ## Reduce a list from the left.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ List.fold_left([1, 2, 3], 0, fn(acc, x) => acc + x)
+## ➢ List.fold_left (fn acc x => acc + x) 0 [1, 2, 3]
 ## 6 : Int
 ##
-## ➢ List.fold_left([1, 2, 3], "", fn(acc, x) => acc ++ Int.to_string(x))
+## ➢ List.fold_left (fn acc x => acc ++ Int.to_string x) "" [1, 2, 3]
 ## "123" : String
 ## ```
-let fold_left(list : List(a), acc : b, f : (b, a) -> b) -> b =
+let fold_left (f : b -> a -> b) (acc : b) (list : List a) : b =
     match list on
     | Nil => acc
-    | x :: xs => fold_left(xs, f(acc, x), f)
+    | x :: xs => fold_left f (f acc x) xs
 
 ## Reduce a list from the right.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ List.fold_right([1, 2, 3], 0, fn(x, acc) => x + acc)
+## ➢ List.fold_right (fn x acc => x + acc) 0 [1, 2, 3]
 ## 6 : Int
 ##
-## ➢ List.fold_right([1, 2, 3], "", fn(x, acc) => Int.to_string(x) ++ acc)
+## ➢ List.fold_right (fn x acc => Int.to_string x ++ acc) "" [1, 2, 3]
 ## "123" : String
 ## ```
-let fold_right(list : List(a), acc : b, f : (a, b) -> b) -> b =
+let fold_right (f : a -> b -> b) (acc : b) (list : List a) : b =
     match list on
     | Nil => acc
-    | x :: xs => f(x, fold_right(xs, acc, f))
+    | x :: xs => f x (fold_right f acc xs)
 
 ## Get the first element in a list, or `None` if the list is empty.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ List.head([1, 2, 3])
-## Some(1) : Maybe(Int)
+## ➢ List.head [1, 2, 3]
+## Some 1 : Maybe Int
 ##
-## ➢ List.head(Nil : List(Int))
-## None : Maybe(Int)
+## ➢ List.head (Nil : List Int)
+## None : Maybe Int
 ## ```
-let head(list : List(a)) -> Maybe(a) =
+let head (list : List a) : Maybe a =
     match list on
     | Nil => None
-    | x :: _ => Some(x)
+    | x :: _ => Some x
 
 ## Get all but the first element of a list, or `None` if the list is empty.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ List.tail([1, 2, 3])
-## Some([2, 3]) : Maybe(List(Int))
+## ➢ List.tail [1, 2, 3]
+## Some [2, 3] : Maybe (List Int)
 ##
-## ➢ List.tail(Nil : List(Int))
-## None : Maybe(List(Int))
+## ➢ List.tail (Nil : List Int)
+## None : Maybe (List Int)
 ## ```
-let tail(list : List(a)) -> Maybe(List(a)) =
+let tail (list : List a) : Maybe (List a) =
     match list on
     | Nil => None
-    | _ :: xs => Some(xs)
+    | _ :: xs => Some xs
 
 ## Get the last element in a list, or `None` if the list is empty.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ List.last([1, 2, 3])
-## Some(3) : Maybe(Int)
+## ➢ List.last [1, 2, 3]
+## Some 3 : Maybe Int
 ##
-## ➢ List.last(Nil : List(Int))
-## None : Maybe(Int)
+## ➢ List.last (Nil : List Int)
+## None : Maybe Int
 ## ```
-let last(list : List(a)) -> Maybe(a) =
+let last (list : List a) : Maybe a =
     match list on
-    | x :: Nil => Some(x)
-    | _ :: xs => last(xs)
-    | _ => None
+    | Nil => None
+    | x :: Nil => Some x
+    | _ :: xs => last xs
 
 ## Reverse a list.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ List.reverse([1, 2, 3])
-## [3, 2, 1] : List(Int)
+## ➢ reverse [1, 2, 3]
+## [3, 2, 1] : List Int
+##
+## ➢ reverse (Nil : List Int)
+## Nil : List Int
 ## ```
-let reverse(list : List(a)) -> List(a) =
-    fold_left(list, Nil, fn(xs, x) => cons(xs, x))
+let reverse (list : List a) : List a =
+    fold_left (fn acc x => x :: acc) Nil list
 
 ## Apply a function to every element in a list.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ List.map([1, 2, 3], fn(x) => x * 2)
-## [2, 4, 6] : List(Int)
+## ➢ List.map (fn x => x * 2) [1, 2, 3]
+## [2, 4, 6] : List Int
 ## ```
-let map(list : List(a), f : (a -> b)) -> List(b) =
-    fold_right(list, Nil, fn(x, acc) => cons(acc, f(x)))
+let map (f : a -> b) (list : List a) : List b =
+    fold_right (fn x acc => f x :: acc) Nil list
 
 ## Keep elements that satisfy the given predicate.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ List.keep([1, 2, 3, 4, 5], fn(x) => Math.even?(x))
-## [2, 4] : List(Int)
+## ➢ List.keep (fn x => x > 1) [1, 2, 3]
+## [2, 3] : List Int
 ##
-## ➢ List.keep(["apple", "banana", "cherry"], fn(s) => String.size(s) > 5)
-## ["banana", "cherry"] : List(String)
+## ➢ List.keep Math.even? [1, 2, 3, 4]
+## [2, 4] : List Int
 ## ```
-let keep(list : List(a), predicate : (a -> Bool)) -> List(a) =
-    list
-    |> fold_right(
-        Nil,
-        fn(x, xs) =>
-            if predicate(x) then
-                cons(xs, x)
-            else
-                xs
-    )
+let keep (predicate : a -> Bool) (list : List a) : List a =
+    match list on
+    | Nil => Nil
+    | x :: xs =>
+        if predicate x then
+            x :: keep predicate xs
+        else
+            keep predicate xs
 
 ## Exclude elements that satisfy the given predicate.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ List.reject([1, 2, 3, 4, 5], fn(x) => Math.even?(x))
-## [1, 3, 5] : List(Int)
+## ➢ List.reject (fn x => x > 1) [1, 2, 3]
+## [1] : List Int
 ##
-## ➢ List.reject(["apple", "banana", "cherry"], fn(s) => String.size(s) > 5)
-## ["apple"] : List(String)
+## ➢ List.reject Math.even? [1, 2, 3, 4]
+## [1, 3] : List Int
 ## ```
-let reject(list : List(a), predicate : (a -> Bool)) -> List(a) =
-    keep(list, fn(x) => not(predicate(x)))
+let reject (predicate : a -> Bool) (list : List a) : List a =
+    match list on
+    | Nil => Nil
+    | x :: xs =>
+        if predicate x then
+            reject predicate xs
+        else
+            x :: reject predicate xs
 
 ## Applies filter and map simultaneously.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ List.collect_map([1, 2, 3, 4], fn(x) => if Math.even?(x) then Some(x * 2) else None)
-## [4, 8] : List(Int)
-##
-## ➢ List.collect_map(["apple", "", "banana", ""], fn(s) => if String.empty?(s) then None else Some(String.to_upper(s)))
-## ["APPLE", "BANANA"] : List(String)
+## ➢ List.collect_map (fn x => if Math.even? x then Some (x * 2) else None) [1, 2, 3, 4]
+## [4, 8] : List Int
 ## ```
-let collect_map(list : List(a), f : (a -> Maybe(b))) -> List(b) =
-    list
-    |> fold_right(
-        Nil,
-        fn(x, xs) =>
-            match f(x) on
-            | None => xs
-            | Some(y) => cons(xs, y)
-    )
+let collect_map (f : a -> Maybe b) (list : List a) : List b =
+    match list on
+    | Nil => Nil
+    | x :: xs =>
+        match f x on
+        | Some y => y :: collect_map f xs
+        | None => collect_map f xs
 
 ## Create a list of numbers, every element increasing by one.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ List.range(1, 5)
-## [1, 2, 3, 4, 5] : List(Int)
+## ➢ List.range 1 5
+## [1, 2, 3, 4, 5] : List Int
 ##
-## ➢ List.range(10, 12)
-## [10, 11, 12] : List(Int)
+## ➢ List.range 10 12
+## [10, 11, 12] : List Int
 ##
-## ➢ List.range(5, 1)
-## [] : List(Int)
+## ➢ List.range 5 1
+## Nil : List Int
 ## ```
-let range(start : Int, end : Int) -> List(Int) =
-    list_range(start, end)
+let range (start : Int) (end : Int) : List a =
+    list_range start end
 
 ## Insert an element at the specified index in a list.
 ## Returns `None` if the index is out of bounds.
@@ -313,21 +315,21 @@ let range(start : Int, end : Int) -> List(Int) =
 ## @since 0.1.0
 ##
 ## ```
-## ➢ List.insert_at([1, 2, 4], 2, 3)
-## Some([1, 2, 3, 4]) : Maybe(List(Int))
+## ➢ List.insert_at 2 3 [1, 2, 4]
+## Some [1, 2, 3, 4] : Maybe (List Int)
 ##
-## ➢ List.insert_at([1, 2, 3], 0, 0)
-## Some([0, 1, 2, 3]) : Maybe(List(Int))
+## ➢ List.insert_at 0 0 [1, 2, 3]
+## Some [0, 1, 2, 3] : Maybe (List Int)
 ##
-## ➢ List.insert_at([1, 2, 3], 10, 4)
-## None : Maybe(List(Int))
+## ➢ List.insert_at 10 4 [1, 2, 3]
+## None : Maybe (List Int)
 ## ```
-let insert_at(list : List(a), index : Int, elem : a) -> Maybe(List(a)) =
+let insert_at (index : Int) (elem : a) (list : List a) : Maybe (List a) =
     match list on
-    | _ when index == 0 => Some(cons(list, elem))
+    | _ when index == 0 => Some (elem :: list)
     | x :: xs =>
-        insert_at(xs, index - 1, elem)
-        |> Maybe.map(fn(rest) => cons(rest, x))
+        insert_at (index - 1) elem xs
+        |> Maybe.map (fn rest => x :: rest)
     | _ => None
 
 ## Delete an element at the specified index in a list.
@@ -336,24 +338,24 @@ let insert_at(list : List(a), index : Int, elem : a) -> Maybe(List(a)) =
 ## @since 0.1.0
 ##
 ## ```
-## ➢ List.delete_at([1, 2, 3, 4], 2)
-## Some([1, 2, 4]) : Maybe(List(Int))
+## ➢ List.delete_at 2  [1, 2, 3, 4]
+## Some [1, 2, 4] : Maybe (List Int)
 ##
-## ➢ List.delete_at([1, 2, 3], 0)
-## Some([2, 3]) : Maybe(List(Int))
+## ➢ List.delete_at 0 [1, 2, 3]
+## Some [2, 3] : Maybe (List Int)
 ##
-## ➢ List.delete_at([1, 2, 3], 10)
-## None : Maybe(List(Int))
+## ➢ List.delete_at 10 [1, 2, 3]
+## None : Maybe (List Int)
 ## ```
-let delete_at(list : List(a), index : Int) -> Maybe(List(a)) =
+let delete_at (index : Int) (list : List a) : Maybe (List a) =
     match list on
     | _ when index == 0 =>
         match list on
-        | _ :: xs => Some(xs)
+        | _ :: xs => Some xs
         | _ => None
     | x :: xs =>
-        delete_at(xs, index - 1)
-        |> Maybe.map(fn(rest) => cons(rest, x))
+        delete_at (index - 1) xs
+        |> Maybe.map (fn rest => x :: rest)
     | _ => None
 
 ## Apply a function to the element at the specified index.
@@ -362,17 +364,17 @@ let delete_at(list : List(a), index : Int) -> Maybe(List(a)) =
 ## @since 0.1.0
 ##
 ## ```
-## ➢ List.modify_at([1, 2, 3, 4], 2, fn(x) => x * 10)
-## Some([1, 2, 30, 4]) : Maybe(List(Int))
+## ➢ List.modify_at 2 (fn x => x * 10) [1, 2, 3, 4]
+## Some [1, 2, 30, 4] : Maybe (List Int)
 ##
-## ➢ List.modify_at(["a", "b", "c"], 1, String.to_upper)
-## Some(["a", "B", "c"]) : Maybe(List(String))
+## ➢ List.modify_at 1 String.to_upper ["a", "b", "c"]
+## Some ["a", "B", "c"] : Maybe (List String)
 ##
-## ➢ List.modify_at([1, 2, 3], 10, fn(x) => x + 1)
-## None : Maybe(List(Int))
+## ➢ List.modify_at 10 (fn x => x + 1) [1, 2, 3]
+## None : Maybe (List Int)
 ## ```
-let modify_at(list : List(a), index : Int, f : (a -> a)) -> Maybe(List(a)) =
-    alter_at(list, index, fn(x) => Some(f(x)))
+let modify_at (index : Int) (f : a -> a) (list : List a) : Maybe (List a) =
+    alter_at index (fn x => Some (f x)) list
 
 ## Apply a function that returns `Maybe` to the element at the specified index.
 ## The function can transform or remove the element.
@@ -381,25 +383,24 @@ let modify_at(list : List(a), index : Int, f : (a -> a)) -> Maybe(List(a)) =
 ## @since 0.1.0
 ##
 ## ```
-## ➢ List.alter_at([1, 2, 3, 4], 2, fn(x) => Some(x * 10))
-## Some([1, 2, 30, 4]) : Maybe(List(Int))
+## ➢ List.alter_at 2 (fn x => Some (x * 10)) [1, 2, 3, 4]
+## Some [1, 2, 30, 4] : Maybe (List Int)
 ##
-## ➢ List.alter_at([1, 2, 3, 4], 2, fn(x) => if x > 2 then Some(x * 10) else None)
-## Some([1, 2, 30, 4]) : Maybe(List(Int))
+## ➢ List.alter_at 2 (fn x => if x > 2 then Some (x * 10) else None) [1, 2, 3, 4]
+## Some [1, 2, 30, 4] : Maybe (List Int)
 ##
-## ➢ List.alter_at([1, 2, 3], 10, fn(x) => Some(x + 1))
-## None : Maybe(List(Int))
+## ➢ List.alter_at 10 (fn x => Some (x + 1)) [1, 2, 3]
+## None : Maybe (List Int)
 ## ```
-let alter_at(list : List(a), index : Int, f : (a -> Maybe(a))) -> Maybe(List(a)) =
+let alter_at (index : Int) (f : a -> Maybe a) (list : List a) : Maybe (List a) =
     match list on
     | _ when index == 0 =>
         match list on
-        | x :: xs =>
-            Maybe.map(f(x), fn(y) => cons(xs, y))
+        | x :: xs => Maybe.map (fn y => y :: xs) (f x)
         | _ => None
     | x :: xs =>
-        alter_at(xs, index - 1, f)
-        |> Maybe.map(fn(rest) => cons(rest, x))
+        alter_at (index - 1) f xs
+        |> Maybe.map (fn rest => x :: rest)
     | _ => None
 
 ## Flatten a list of lists into a single list.
@@ -407,32 +408,32 @@ let alter_at(list : List(a), index : Int, f : (a -> Maybe(a))) -> Maybe(List(a))
 ## @since 0.1.0
 ##
 ## ```
-## ➢ List.flatten([[1, 2], [3, 4], [5]])
-## [1, 2, 3, 4, 5] : List(Int)
+## ➢ List.flatten [[1, 2], [3, 4], [5]]
+## [1, 2, 3, 4, 5] : List Int
 ##
-## ➢ List.flatten([[1, 2], [], [3, 4]])
-## [1, 2, 3, 4] : List(Int)
+## ➢ List.flatten [[1, 2], Nil, [3, 4]]
+## [1, 2, 3, 4] : List Int
 ##
-## ➢ List.flatten([] : List(List(Int)))
-## [] : List(Int)
+## ➢ List.flatten (Nil : List (List Int))
+## Nil : List Int
 ## ```
-let flatten(list : List(List(a))) -> List(a) =
-    list_flatten(list)
+let flatten (list : List (List a)) : List a =
+    list_flatten list
 
 ## Find the maximum element in a list.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ List.maximum([1, 4, 2])
-## Some(4) : Maybe(Int)
+## ➢ List.maximum [1, 4, 2]
+## Some 4 : Maybe Int
 ##
-## ➢ List.maximum(Nil : Maybe(Int))
-## None : Maybe(Int)
+## ➢ List.maximum (Nil : Maybe Int)
+## None : Maybe Int
 ## ```
-let maximum(list : List(Comparable)) -> Maybe(Comparable) =
+let maximum (list : List comparable) : Maybe comparable =
     match list on
-    | x :: xs => Some(fold_left(xs, x, max))
+    | x :: xs => Some (fold_left x max xs)
     | _ => None
 
 ## Find the minimum element in a non-empty list.
@@ -440,15 +441,15 @@ let maximum(list : List(Comparable)) -> Maybe(Comparable) =
 ## @since 0.1.0
 ##
 ## ```
-## ➢ List.minimum([3, 2, 1])
-## Some(1) : Maybe(Int)
+## ➢ List.minimum [3, 2, 1]
+## Some 1 : Maybe Int
 ##
-## ➢ List.minimum(Nil : Maybe(Int))
-## None : Maybe(Int)
+## ➢ List.minimum (Nil : Maybe Int)
+## None : Maybe Int
 ## ```
-let minimum(list : List(Comparable)) -> Maybe(Comparable) =
+let minimum (list : List comparable) : Maybe comparable =
     match list on
-    | x :: xs => Some(fold_left(xs, x, min))
+    | x :: xs => Some (fold_left x min xs)
     | _ => None
 
 ## Get the sum of the list elements.
@@ -456,14 +457,14 @@ let minimum(list : List(Comparable)) -> Maybe(Comparable) =
 ## @since 0.1.0
 ##
 ## ```
-## ➢ List.sum([3, 2, 1])
-## 6.0 : Double
+## ➢ List.sum [3, 2, 1]
+## 6.0 : Float
 ##
-## ➢ List.sum Nil
-## 0.0 : Double
+## ➢ List.sum (Nil : List Float)
+## 0.0 : Float
 ## ```
-let sum(list : List(Number)) -> Number =
-    list_sum(list)
+let sum (list : List Number) : Number =
+    list_sum list
 
 ## Get the product of the list elements.
 ##
@@ -473,23 +474,23 @@ let sum(list : List(Number)) -> Number =
 ## ➢ List.product [2, 4, 6]
 ## 48 : Int
 ##
-## ➢ List.product Nil : Int
+## ➢ List.product (Nil : Int)
 ## 1 : Int
 ## ```
-let product(list : List(Number)) -> Number =
-    fold_left(list, 1, fn(acc, x) => acc * x)
+let product (list : List Number) : Number =
+    fold_left 1 (fn acc x => acc * x) list
 
-foreign list_cons(_ : List(a), _ : a) -> List(a) =
+foreign list_cons : a -> List a -> List a =
     "zig_list_cons"
 
-foreign list_size(_ : List(a)) -> Int =
+foreign list_size : List a -> Int =
     "zig_list_size"
 
-foreign list_range(_ : Int, _ : Int) -> List(Int) =
+foreign list_range : Int -> Int -> List a =
     "zig_list_range"
 
-foreign list_flatten(_ : List(List(a))) -> List(a) =
+foreign list_flatten : List (List a) -> List a =
     "zig_list_flatten"
 
-foreign list_sum(_ : List(Number)) -> Number =
+foreign list_sum : List Number -> Number =
     "zig_list_sum"

--- a/stdlib/map.mn
+++ b/stdlib/map.mn
@@ -30,77 +30,72 @@ open TreeMap as TM
 ## Keys must be comparable.
 ##
 ## @since 0.1.0
-type Map(k, v) =
-    Map(TM.TreeMap(k, v))
+type Map k v =
+    Map (TM.TreeMap k v)
 
 ## Create an empty map.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ Map.empty()
-## {} : Map(k, v)
+## ➢ Map.empty
+## {} : Map k v
 ## ```
-let empty() -> Map(k, v) =
-    Map(TM.empty())
+let empty : Map k v =
+    Map TM.empty
 
 ## Determine if a map is empty.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ Map.empty?(Map.empty())
+## ➢ Map.empty? (Map.empty())
 ## True : Bool
 ##
-## ➢ Map.empty?(Map.singleton(1, "one"))
+## ➢ Map.empty? (Map.singleton 1 "one")
 ## False : Bool
 ## ```
-let empty?(map : Map(k, v)) -> Bool =
-    match map on
-    | Map(tree) => TM.empty?(tree)
+let empty? (map : Map k v) : Bool =
+    todo "not implemented"
 
 ## Create a map with a single key-value pair.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ Map.singleton(1, "one")
-## {1: "one"} : Map(Int, String)
+## ➢ Map.singleton 1 "one"
+## {1: "one"} : Map Int String
 ## ```
-let singleton(key : comparable, value : v) -> Map(comparable, v) =
-    Map(TM.singleton(key, value))
+let singleton (key : comparable) (value : v) : Map comparable v =
+    todo "not implemented"
 
 ## Get the value associated with a key.
-## Returns `None` if the key is not found.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ Map.get(Map.singleton(1, "one"), 1)
-## Some("one") : Maybe(String)
+## ➢ Map.get 1 (Map.singleton 1 "one")
+## Some "one" : Maybe String
 ##
-## ➢ Map.get(Map.singleton(1, "one"), 2)
-## None : Maybe(String)
+## ➢ Map.get 2 (Map.singleton 1 "one")
+## None : Maybe String
 ## ```
-let get(map : Map(comparable, v), key : comparable) -> Maybe(v) =
-    match map on
-    | Map(tree) => TM.get(tree, key)
+let get (key : comparable) (map : Map comparable v) : Maybe v =
+    todo "not implemented"
 
 ## Determine if a map contains a key.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ Map.member?(Map.singleton(1, "one"), 1)
+## ➢ Map.member? 1 (Map.singleton 1 "one")
 ## True : Bool
 ##
-## ➢ Map.member?(Map.singleton(1, "one"), 2)
+## ➢ Map.member? 2 (Map.singleton 1 "one")
 ## False : Bool
 ## ```
-let member?(map : Map(comparable, v), key : comparable) -> Bool =
-    match get(map, key) on
-    | None => False
-    | Some(_) => True
+let member? (key : comparable) (map : Map comparable v) : Bool =
+    todo "not implemented"
 
 ## Insert a key-value pair into a map.
 ## If the key already exists, the value is updated.
@@ -108,15 +103,14 @@ let member?(map : Map(comparable, v), key : comparable) -> Bool =
 ## @since 0.1.0
 ##
 ## ```
-## ➢ Map.insert(Map.singleton(1, "one"), 2, "two")
-## {1: "one", 2: "two"} : Map(Int, String)
+## ➢ Map.insert 2 "two" (Map.singleton 1 "one")
+## {1: "one", 2: "two"} : Map Int String
 ##
-## ➢ Map.insert(Map.singleton(1, "one"), 1, "ONE")
-## {1: "ONE"} : Map(Int, String)
+## ➢ Map.insert 1 "ONE" (Map.singleton 1 "one")
+## {1: "ONE"} : Map Int String
 ## ```
-let insert(map : Map(comparable, v), key : comparable, value : v) -> Map(comparable, v) =
-    match map on
-    | Map(tree) => Map(TM.insert(tree, key, value))
+let insert (key : comparable) (value : v) (map : Map comparable v) : Map comparable v =
+    todo "not implemented"
 
 ## Update the value at a specific key using the given function.
 ## If the key does not exist, the map is not modified.
@@ -124,18 +118,14 @@ let insert(map : Map(comparable, v), key : comparable, value : v) -> Map(compara
 ## @since 0.1.0
 ##
 ## ```
-## ➢ Map.update(Map.singleton(1, "one"), 1, String.to_upper)
-## {1: "ONE"} : Map(Int, String)
+## ➢ Map.update 1 String.to_upper (Map.singleton 1 "one")
+## {1: "ONE"} : Map Int String
 ##
-## ➢ Map.update(Map.singleton(1, "one"), 2, String.to_upper)
-## {1: "one"} : Map(Int, String)
+## ➢ Map.update 2 String.to_upper (Map.singleton 1 "one")
+## {1: "one"} : Map Int String
 ## ```
-let update(map : Map(comparable, v), key : comparable, f : (v -> v)) -> Map(comparable, v) =
-    match map on
-    | Map(tree) =>
-        match get(map, key) on
-        | None => map
-        | Some(value) => Map(TM.insert(tree, key, f(value)))
+let update (key : comparable) (f : v -> v) (map : Map comparable v) : Map comparable v =
+    todo "not implemented"
 
 ## Remove a key-value pair from a map.
 ## If the key is not found, no changes are made.
@@ -143,36 +133,33 @@ let update(map : Map(comparable, v), key : comparable, f : (v -> v)) -> Map(comp
 ## @since 0.1.0
 ##
 ## ```
-## ➢ Map.remove(Map.from_list([(1, "one"), (2, "two")]), 1)
-## {2: "two"} : Map(Int, String)
+## ➢ Map.remove 1 (Map.from_list [(1, "one"), (2, "two")])
+## {2: "two"} : Map Int String
 ## ```
-let remove(map : Map(comparable, v), key : comparable) -> Map(comparable, v) =
-    match map on
-    | Map(tree) => Map(TM.remove(tree, key))
+let remove (key : comparable) (map : Map comparable v) : Map comparable v =
+    todo "not implemented"
 
 ## Determine the number of key-value pairs in a map.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ Map.size(Map.from_list([(1, "one"), (2, "two")]))
+## ➢ Map.size (Map.from_list [(1, "one"), (2, "two")])
 ## 2 : Int
 ## ```
-let size(map : Map(k, v)) -> Int =
-    match map on
-    | Map(tree) => TM.size(tree)
+let size (map : Map k v) : Int =
+    todo "not implemented"
 
 ## Convert a map into a list of key-value pairs, sorted by key.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ Map.to_list(Map.from_list([(2, "two"), (1, "one")]))
-## [(1, "one"), (2, "two")] : List((Int, String))
+## ➢ Map.to_list (Map.from_list [(2, "two"), (1, "one")])
+## [(1, "one"), (2, "two")] : List (Int, String)
 ## ```
-let to_list(map : Map(k, v)) -> List((k, v)) =
-    match map on
-    | Map(tree) => TM.to_list(tree)
+let to_list (map : Map k v) : List (k, v) =
+    todo "not implemented"
 
 ## Convert a list of key-value pairs into a map.
 ## If there are duplicate keys, later values overwrite earlier ones.
@@ -180,47 +167,44 @@ let to_list(map : Map(k, v)) -> List((k, v)) =
 ## @since 0.1.0
 ##
 ## ```
-## ➢ Map.from_list([(1, "one"), (2, "two"), (1, "ONE")])
-## {1: "ONE", 2: "two"} : Map(Int, String)
+## ➢ Map.from_list [(1, "one"), (2, "two"), (1, "ONE")]
+## {1: "ONE", 2: "two"} : Map Int String
 ## ```
-let from_list(list : List((comparable, v))) -> Map(comparable, v) =
-    Map(TM.from_list(list))
+let from_list (list : List (comparable, v)) : Map comparable v =
+    todo "not implemented"
 
 ## Get a list of all keys in a map, sorted.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ Map.keys(Map.from_list([(1, "one"), (2, "two")]))
-## [1, 2] : List(Int)
+## ➢ Map.keys (Map.from_list [(1, "one"), (2, "two")])
+## [1, 2] : List Int
 ## ```
-let keys(map : Map(k, v)) -> List(k) =
-    match map on
-    | Map(tree) => TM.keys(tree)
+let keys (map : Map k v) : List k =
+    todo "not implemented"
 
 ## Get a list of all values in a map, in key order.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ Map.values(Map.from_list([(1, "one"), (2, "two")]))
-## ["one", "two"] : List(String)
+## ➢ Map.values (Map.from_list [(1, "one"), (2, "two")])
+## ["one", "two"] : List String
 ## ```
-let values(map : Map(k, v)) -> List(v) =
-    match map on
-    | Map(tree) => TM.values(tree)
+let values (map : Map k v) : List v =
+    todo "not implemented"
 
 ## Combine two maps, favoring values from the second map when keys overlap.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ Map.union(Map.from_list([(1, "one"), (2, "two")]), Map.from_list([(2, "TWO"), (3, "three")]))
-## {1: "one", 2: "TWO", 3: "three"} : Map(Int, String)
+## ➢ Map.union (Map.from_list [(2, "TWO"), (3, "three")]) (Map.from_list [(1, "one"), (2, "two")])
+## {1: "one", 2: "two", 3: "three"} : Map Int String
 ## ```
-let union(map1 : Map(comparable, v), map2 : Map(comparable, v)) -> Map(comparable, v) =
-    match (map1, map2) on
-    | (Map(tree1), Map(tree2)) => Map(TM.union(tree1, tree2))
+let union (map2 : Map comparable v) (map1 : Map comparable v) : Map comparable v =
+    todo "not implemented"
 
 ## Keep only key-value pairs where the key exists in both maps.
 ## Values are taken from the first map.
@@ -228,84 +212,77 @@ let union(map1 : Map(comparable, v), map2 : Map(comparable, v)) -> Map(comparabl
 ## @since 0.1.0
 ##
 ## ```
-## ➢ Map.intersect(Map.from_list([(1, "one"), (2, "two")]), Map.from_list([(2, "TWO"), (3, "three")]))
-## {2: "two"} : Map(Int, String)
+## ➢ Map.intersect (Map.from_list [(2, "TWO"), (3, "three")]) (Map.from_list [(1, "one"), (2, "two")])
+## {2: "two"} : Map Int String
 ## ```
-let intersect(map1 : Map(comparable, v), map2 : Map(comparable, v)) -> Map(comparable, v) =
-    match (map1, map2) on
-    | (Map(tree1), Map(tree2)) => Map(TM.intersect(tree1, tree2))
+let intersect (map2 : Map comparable v) (map1 : Map comparable v) : Map comparable v =
+    todo "not implemented"
 
 ## Keep only key-value pairs where the key exists in the first map but not the second.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ Map.diff(Map.from_list([(1, "one"), (2, "two")]), Map.from_list([(2, "TWO"), (3, "three")]))
-## {1: "one"} : Map(Int, String)
+## ➢ Map.diff (Map.from_list [(2, "TWO"), (3, "three")]) (Map.from_list [(1, "one"), (2, "two")])
+## {3: "three"} : Map Int String
 ## ```
-let diff(map1 : Map(comparable, v), map2 : Map(comparable, v)) -> Map(comparable, v) =
-    match (map1, map2) on
-    | (Map(tree1), Map(tree2)) => Map(TM.diff(tree1, tree2))
+let diff (map2 : Map comparable v) (map1 : Map comparable v) : Map comparable v =
+    todo "not implemented"
 
 ## Fold over the key-value pairs in a map, in key order from lowest to highest.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ Map.fold_left(Map.from_list([(1, "one"), (2, "two")]), fn(k, v, acc) => acc ++ v, "")
+## ➢ Map.fold_left (fn k v acc => acc ++ v) "" (Map.from_list [(1, "one"), (2, "two")])
 ## "onetwo" : String
 ## ```
-let fold_left(map : Map(k, v), f : (k, v, acc -> acc), init : acc) -> acc =
-    match map on
-    | Map(tree) => TM.fold_left(tree, f, init)
+let fold_left (f : k -> v -> acc -> acc) (init : acc) (map : Map k v) : acc =
+    todo "not implemented"
 
 ## Fold over the key-value pairs in a map, in key order from highest to lowest.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ Map.fold_right(Map.from_list([(1, "one"), (2, "two")]), fn(k, v, acc) => acc ++ v, "")
+## ➢ Map.fold_right (fn k v acc => acc ++ v) "" (Map.from_list [(1, "one"), (2, "two")])
 ## "twoone" : String
 ## ```
-let fold_right(map : Map(k, v), f : (k, v, acc -> acc), init : acc) -> acc =
-    match map on
-    | Map(tree) => TM.fold_right(tree, f, init)
+let fold_right (f : k -> v -> acc -> acc) (init : acc) (map : Map k v) : acc =
+    todo "not implemented"
 
 ## Transform values in a map.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ Map.map(Map.from_list([(1, "one"), (2, "two")]), fn(k, v) => String.to_upper(v))
-## {1: "ONE", 2: "TWO"} : Map(Int, String)
+## ➢ Map.map (fn k v => String.to_upper v) (Map.from_list [(1, "one"), (2, "two")])
+## {1: "ONE", 2: "TWO"} : Map Int String
 ## ```
-let map(map : Map(k, v), f : (k, v -> v2)) -> Map(k, v2) =
-    match map on
-    | Map(tree) => Map(TM.map(tree, f))
+let map (f : k -> v -> v2) (map : Map k v) : Map k v2 =
+    todo "not implemented"
 
 ## Keep only key-value pairs that satisfy the given predicate.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ Map.keep(Map.from_list([(1, "one"), (2, "two")]), fn(k, v) => mod(k, 2) == 0)
-## {2: "two"} : Map(Int, String)
+## ➢ Map.keep (fn k v => mod k 2 == 0) (Map.from_list [(1, "one"), (2, "two")])
+## {2: "two"} : Map Int String
 ## ```
-let keep(map : Map(comparable, v), pred : (comparable, v -> Bool)) -> Map(comparable, v) =
-    match map on
-    | Map(tree) => Map(TM.keep(tree, pred))
+let keep (pred : comparable -> v -> Bool) (map : Map comparable v) : Map comparable v =
+    todo "not implemented"
 
 ## Remove key-value pairs that satisfy the given predicate.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ Map.reject(Map.from_list([(1, "one"), (2, "two")]), fn(k, v) => mod(k, 2) == 0)
-## {1: "one"} : Map(Int, String)
+## ➢ Map.reject (fn k v => mod k 2 == 0) (Map.from_list [(1, "one"), (2, "two")])
+## {1: "one"} : Map Int String
 ## ```
-let reject(map : Map(comparable, v), pred : (comparable, v -> Bool)) -> Map(comparable, v) =
-    match map on
-    | Map(tree) => Map(TM.reject(tree, pred))
+let reject (pred : comparable -> v -> Bool) (map : Map comparable v) : Map comparable v =
+    todo "not implemented"
 
 ## Create two new maps. The first contains all key-value pairs that passed the
 ## given test, and the second contains all key-value pairs that did not.
@@ -313,11 +290,8 @@ let reject(map : Map(comparable, v), pred : (comparable, v -> Bool)) -> Map(comp
 ## @since 0.1.0
 ##
 ## ```
-## ➢ Map.partition(Map.from_list([(1, "one"), (2, "two")]), fn(k, v) => mod(k, 2) == 0)
-## ({2: "two"}, {1: "one"}) : (Map(Int, String), Map(Int, String))
+## ➢ Map.partition (fn k v => mod k 2 == 0) (Map.from_list [(1, "one"), (2, "two")])
+## ({2: "two"}, {1: "one"}) : (Map Int String, Map Int String)
 ## ```
-let partition(map : Map(comparable, v), pred : (comparable, v -> Bool)) -> (Map(comparable, v), Map(comparable, v)) =
-    match map on
-    | Map(tree) =>
-        let (passed, failed) = TM.partition(tree, pred)
-        (Map(passed), Map(failed))
+let partition (pred : comparable -> v -> Bool) (map : Map comparable v) : (Map comparable v, Map comparable v) =
+    todo "not implemented"

--- a/stdlib/maybe.mn
+++ b/stdlib/maybe.mn
@@ -28,38 +28,38 @@ module Maybe exposing
 ## @since 0.1.0
 ##
 ## ```
-## ➢ Some(42)
-## Some(42) : Maybe(Int)
+## ➢ Some 42
+## Some 42 : Maybe Int
 ## ```
-type Maybe(a) =
+type Maybe a =
     | None
-    | Some(a)
+    | Some a
 
 ## Returns `True` when the `Maybe` value was constructed with `Some`.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ Maybe.some?(Some(42))
+## ➢ Maybe.some? (Some 42)
 ## True : Bool
 ## ```
-let some?(ma : Maybe(a)) -> Bool =
+let some? (ma : Maybe a) : Bool =
     match ma on
     | None => False
-    | Some(_) => True
+    | Some _ => True
 
 ## Returns `True` when the `Maybe` value is `None`.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ Maybe.none?(Some(42))
+## ➢ Maybe.none? (Some 42)
 ## False : Bool
 ## ```
-let none?(ma : Maybe(a)) -> Bool =
+let none? (ma : Maybe a) : Bool =
     match ma on
     | None => True
-    | Some(_) => False
+    | Some _ => False
 
 ## Unwrap a value while providing a default value.
 ## Useful for pipelines, otherwise use a `match` expr instead.
@@ -68,28 +68,28 @@ let none?(ma : Maybe(a)) -> Bool =
 ## @since 0.1.0
 ##
 ## ```
-## ➢ Maybe.with_default(Some(42), 100)
+## ➢ Maybe.with_default 100 (Some 42)
 ## 42 : Int
 ##
-## ➢ Maybe.with_default(None, 100)
+## ➢ Maybe.with_default 100 None
 ## 100 : Int
 ## ```
-let with_default(ma : Maybe(a), default : a) -> a =
+let with_default (default : a) (ma : Maybe a) : a =
     match ma on
     | None => default
-    | Some(a) => a
+    | Some a => a
 
 ## Applies the predicate to a value and lifts the result into a `Maybe`.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ Maybe.from_predicate(42, fn(x) => x == 42)
-## Some(42) : Maybe(Int)
+## ➢ Maybe.from_predicate 42 (fn x => x == 42)
+## Some 42 : Maybe Int
 ## ```
-let from_predicate(x : a, predicate : (a -> Bool)) -> Maybe(a) =
-    if predicate(x) then
-        Some(x)
+let from_predicate (x : a) (predicate : a -> Bool) : Maybe a =
+    if predicate x then
+        Some x
     else
         None
 
@@ -98,13 +98,13 @@ let from_predicate(x : a, predicate : (a -> Bool)) -> Maybe(a) =
 ## @since 0.1.0
 ##
 ## ```
-## ➢ Maybe.satisfy?(Some(15), fn(x) => x > 10)
+## ➢ Maybe.satisfy? (fn x => x > 10) (Some 15)
 ## True : Bool
 ## ```
-let satisfy?(ma : Maybe(a), predicate : (a -> Bool)) -> Bool =
+let satisfy? (predicate : a -> Bool) (ma : Maybe a) : Bool =
     match ma on
     | None => False
-    | Some(a) => predicate(a)
+    | Some a => predicate a
 
 ## Apply a function to value wrapped by a `Maybe`.
 ## Equivalent of `<$>` from the `Functor` typeclass.
@@ -112,110 +112,106 @@ let satisfy?(ma : Maybe(a), predicate : (a -> Bool)) -> Bool =
 ## @since 0.1.0
 ##
 ## ```
-## ➢ Maybe.map(Some(21), fn(x) => x * 2)
-## Some(42) : Maybe(Int)
+## ➢ Maybe.map (fn x => x * 2) (Some 21)
+## Some 42 : Maybe Int
 ## ```
-let map(ma : Maybe(a), f : (a -> value)) -> Maybe(value) =
+let map (f : a -> value) (ma : Maybe a) : Maybe value =
     match ma on
     | None => None
-    | Some(a) => Some(f(a))
+    | Some a => Some (f a)
 
 ## Apply a function if all the arguments are `Some`'s.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ Maybe.map2(Some(21), Some(21), fn(x, y) => x + y)
-## Some(42) : Maybe(Int)
+## ➢ Maybe.map2 (fn x y => x + y) (Some 21) (Some 21)
+## Some 42 : Maybe Int
 ## ```
-let map2(
-    ma : Maybe(a),
-    mb : Maybe(b)
-    f : ((a, b) -> value),
-) -> Maybe(value) =
+let map2 (f : a -> b -> value) (ma : Maybe a) (mb : Maybe b) : Maybe value =
     match ma on
     | None => None
-    | Some(a) =>
+    | Some a =>
         match mb on
         | None => None
-        | Some(b) => Some(f(a, b))
+        | Some b => Some (f a b)
 
 ## Apply a function if all the arguments are `Some`'s.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ Some(14) |> Maybe.map3(Some(14), Some(14), fn(x, y, z) => x + y + z)
-## Some(42) : Maybe(Int)
+## ➢ Maybe.map3 (fn x y z => x + y + z) (Some 14) (Some 14) (Some 14)
+## Some 42 : Maybe Int
 ## ```
-let map3(
-    ma : Maybe(a),
-    mb : Maybe(b),
-    mc : Maybe(c),
-    f : ((a, b, c) -> value)
-) -> Maybe(value) =
+let map3
+    (f : a -> b -> c -> value)
+    (ma : Maybe a)
+    (mb : Maybe b)
+    (mc : Maybe c)
+    : Maybe value =
     match ma on
     | None => None
-    | Some(a) =>
+    | Some a =>
         match mb on
         | None => None
-        | Some(b) =>
+        | Some b =>
             match mc on
             | None => None
-            | Some(c) => Some(f(a, b, c))
+            | Some c => Some (f a b c)
 
 ## Apply a function if all the arguments are `Some`s.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ Some(10) |> Maybe.map4(Some(11), Some(12), Some(13), fn(w, x, y, z) => w + x + y + z)
-## Some(46) : Maybe(Int)
+## ➢ Maybe.map4 (fn w x y z => w + x + y + z) (Some 10) (Some 11) (Some 12) (Some 13)
+## Some 46 : Maybe Int
 ## ```
-let map4(
-    ma : Maybe(a),
-    mb : Maybe(b),
-    mc : Maybe(c),
-    md : Maybe(d),
-    f : ((a, b, c, d) -> value)
-) -> Maybe(value) =
+let map4
+    (f : a -> b -> c -> d -> value)
+    (ma : Maybe a)
+    (mb : Maybe b)
+    (mc : Maybe c)
+    (md : Maybe d)
+    : Maybe value =
     match ma on
     | None => None
-    | Some(a) =>
+    | Some a =>
         match mb on
         | None => None
-        | Some(b) =>
+        | Some b =>
             match mc on
             | None => None
-            | Some(c) =>
+            | Some c =>
                 match md on
                 | None => None
-                | Some(d) => Some(f(a, b, c, d))
+                | Some d => Some (f a b c d)
 
 ## Removes one level of nesting.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ Maybe.flatten(Some(Some(42)))
-## Some(42) : Maybe(Int)
+## ➢ Maybe.flatten (Some (Some 42))
+## Some 42 : Maybe Int
 ## ```
-let flatten(mma : Maybe(Maybe(a))) -> Maybe(a) =
+let flatten (mma : Maybe (Maybe a)) : Maybe a =
     match mma on
     | None => None
-    | Some(ma) => ma
+    | Some ma => ma
 
 ## Combines two `Maybe` values into a tuple, if both are `Some`.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ Maybe.zip(Some("hello world"), Some(42))
-## Some("hello world", 42) : Maybe(String, Int)
+## ➢ Maybe.zip (Some "hello world") (Some 42)
+## Some ("hello world", 42) : Maybe (String, Int)
 ## ```
-let zip(ma : Maybe(a), mb : Maybe(b)) -> Maybe((a, b)) =
+let zip (ma : Maybe a) (mb : Maybe b) : Maybe (a, b) =
     match (ma, mb) on
-    | (Some(a), Some(b)) => Some((a, b))
+    | (Some a, Some b) => Some (a, b)
     | _ => None
 
 ## Equivalent of `<|>` from the `Alternative` typeclass.
@@ -223,110 +219,110 @@ let zip(ma : Maybe(a), mb : Maybe(b)) -> Maybe((a, b)) =
 ## @since 0.1.0
 ##
 ## ```
-## ➢ Maybe.or(None, Some(42))
-## Some(42) : Maybe(Int)
+## ➢ Maybe.or None (Some 42)
+## Some 42 : Maybe Int
 ## ```
-let or(ma : Maybe(a), mb : Maybe(a)) -> Maybe(a) =
+let or (ma : Maybe a) (mb : Maybe a) : Maybe a =
     match ma on
     | None => mb
-    | Some(_) => ma
+    | Some _ => ma
 
 ## Equivalent of `>>=` from the `Monad` typeclass.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ Maybe.and_then(Some(21), fn(x) => Some(x * 2))
-## Some(42) : Maybe(Int)
+## ➢ Maybe.and_then (fn x => Some (x * 2)) (Some 21)
+## Some 42 : Maybe Int
 ## ```
-let and_then(ma : Maybe(a), f : (a -> Maybe(value))) -> Maybe(value) =
+let and_then (f : a -> Maybe value) (ma : Maybe a) : Maybe value =
     match ma on
     | None => None
-    | Some(a) => f(a)
+    | Some a => f a
 
 ## Equivalent of `>>=` from the `Monad` typeclass.
 ##
 ## @since 0.1.0
-let and_then2(
-    ma : Maybe(a),
-    mb : Maybe(b),
-    f : ((a, b) -> Maybe(value))
-) -> Maybe(value) =
+let and_then2
+    (f : a -> b -> Maybe value)
+    (ma : Maybe a)
+    (mb : Maybe b)
+    : Maybe value =
     match ma on
     | None => None
-    | Some(a) =>
+    | Some a =>
         match mb on
         | None => None
-        | Some(b) => f(a, b)
+        | Some b => f a b
 
 ## Equivalent of `>>=` from the `Monad` typeclass.
 ##
 ## @since 0.1.0
-let and_then3(
-    ma : Maybe(a),
-    mb : Maybe(b),
-    mc : Maybe(c),
-    f : ((a, b, c) -> Maybe(value))
-) -> Maybe(value) =
+let and_then3
+    (ma : Maybe a)
+    (mb : Maybe b)
+    (mc : Maybe c)
+    (f : a -> b -> c -> Maybe value)
+    : Maybe value =
     match ma on
     | None => None
-    | Some(a) =>
+    | Some a =>
         match mb on
         | None => None
-        | Some(b) =>
+        | Some b =>
             match mc on
             | None => None
-            | Some(c) => f(a, b, c)
+            | Some c => f a b c
 
 ## Equivalent of `>>=` from the `Monad` typeclass.
 ##
 ## @since 0.1.0
-let and_then4(
-    ma : Maybe(a),
-    mb : Maybe(b),
-    mc : Maybe(c),
-    md : Maybe(d),
-    f : ((a, b, c, d) -> Maybe(value))
-) -> Maybe(value) =
+let and_then4
+    (f : a -> b -> c -> d -> Maybe value)
+    (ma : Maybe a)
+    (mb : Maybe b)
+    (mc : Maybe c)
+    (md : Maybe d)
+    : Maybe value =
     match ma on
     | None => None
-    | Some(a) =>
+    | Some a =>
         match mb on
         | None => None
-        | Some(b) =>
+        | Some b =>
             match mc on
             | None => None
-            | Some(c) =>
+            | Some c =>
                 match md on
                 | None => None
-                | Some(d) => f(a, b, c, d)
+                | Some d => f a b c d
 
 ## Try a list of functions against a value. Return the value of the first call that succeeds (returns `Some`).
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ Maybe.one_of("42.0", [String.to_int, String.to_float])
-## Some(42.0) : Maybe(Float)
+## ➢ Maybe.one_of "42.0" [String.to_int, String.to_float]
+## Some 42.0 : Maybe Float
 ## ```
-let one_of(default : a, fmbs : List((a -> Maybe(b)))) -> Maybe(b) =
+let one_of (default : a) (fmbs : List (a -> Maybe b)) : Maybe b =
     match fmbs on
     | Nil => None
     | fmb :: rest =>
-        match fmb(default) on
-        | None => one_of(default, rest)
-        | Some(b) => Some(b)
+        match fmb default on
+        | None => one_of default rest
+        | Some b => Some b
 
 ## Removes `None` values from a collection while unwrapping all present values.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ Maybe.compact([Some(1), None, Some(2)])
-## [1, 2] : List(Int)
+## ➢ Maybe.compact [Some 1, None, Some 2]
+## [1, 2] : List Int
 ## ```
-let compact(maybes : List(Maybe(a))) -> List(a) =
-    List.collect_map(maybes, identity)
+let compact (maybes : List (Maybe a)) : List a =
+    List.collect_map maybes identity
 
 ## Take two `Maybe` values. If the first one equals `None`, return `None`. Otherwise return the second value.
 ## Allows for chaining `Maybe` computations, with a possible "early return" in case of `None`.
@@ -335,19 +331,19 @@ let compact(maybes : List(Maybe(a))) -> List(a) =
 ## @since 0.1.0
 ##
 ## ```
-## ➢ Maybe.next(Some(1), Some(2))
-## Some(2) : Maybe(Int)
+## ➢ Maybe.next (Some 1) (Some 2)
+## Some 2 : Maybe Int
 ##
-## ➢ Maybe.next(None, Some(2))
-## None : Maybe(Int)
+## ➢ Maybe.next None (Some 2)
+## None : Maybe Int
 ##
-## ➢ Maybe.next(Some(1), None)
-## None : Maybe(Int)
+## ➢ Maybe.next (Some 1) None
+## None : Maybe Int
 ## ```
-let next(ma : Maybe(a), mb : Maybe(b)) -> Maybe(b) =
+let next (ma : Maybe a) (mb : Maybe b) : Maybe b =
     match ma on
     | None => None
-    | Some(_) => mb
+    | Some _ => mb
 
 ## Take two `Maybe` values. If the second one equals `None`, return `None`. Otherwise return the first value.
 ## Equivalent of `<*` from the `Applicative` typeclass.
@@ -355,32 +351,32 @@ let next(ma : Maybe(a), mb : Maybe(b)) -> Maybe(b) =
 ## @since 0.1.0
 ##
 ## ```
-## ➢ Maybe.prev(Some(1), Some(2))
-## Some(1) : Maybe(Int)
+## ➢ Maybe.prev (Some 1) (Some 2)
+## Some 1 : Maybe Int
 ##
-## ➢ Maybe.prev(None, Some(2))
-## None : Maybe(Int)
+## ➢ Maybe.prev None (Some 2)
+## None : Maybe Int
 ##
-## ➢ Maybe.prev(Some(1), None)
-## None : Maybe(Int)
+## ➢ Maybe.prev (Some 1) None
+## None : Maybe Int
 ## ```
-let prev(ma : Maybe(a), mb : Maybe(b)) -> Maybe(a) =
+let prev (ma : Maybe a) (mb : Maybe b) : Maybe a =
     match mb on
     | None => None
-    | Some(_) => ma
+    | Some _ => ma
 
 ## Converts a `Result` to `Maybe`, dropping the error.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ Maybe.from_result(Ok(42))
-## Some(42) : Maybe(Int)
+## ➢ Maybe.from_result (Ok 42)
+## Some 42 : Maybe Int
 ##
-## ➢ Maybe.from_result(Err("uh oh!"))
-## None : Maybe(Int)
+## ➢ Maybe.from_result (Err "uh oh!")
+## None : Maybe Int
 ## ```
-let from_result(result : Result(e, a)) -> Maybe(a) =
+let from_result (result : Result e a) : Maybe a =
     match result on
-    | Err(_) => None
-    | Ok(a) => Some(a)
+    | Err _ => None
+    | Ok a => Some a

--- a/stdlib/non_empty.mn
+++ b/stdlib/non_empty.mn
@@ -17,20 +17,20 @@ module NonEmpty exposing
     , to_list
     )
 
-type NonEmpty(a) =
+type NonEmpty a =
     | [a]
-    | a :: List(a)
+    | a :: List a
 
 ## Create a non-empty list containing a single element.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ NonEmpty.singleton(42)
-## [42] : NonEmpty(Int)
+## ➢ NonEmpty.singleton 42
+## [42] : NonEmpty Int
 ## ```
-let singleton(x : a) -> NonEmpty(a) =
-    todo("not implemented")
+let singleton (x : a) : NonEmpty a =
+    todo "not implemented"
 
 ## Get the first element of a non-empty list.
 ## Unlike `List.head`, this always succeeds since the list cannot be empty.
@@ -38,11 +38,11 @@ let singleton(x : a) -> NonEmpty(a) =
 ## @since 0.1.0
 ##
 ## ```
-## ➢ NonEmpty.head([1, 2, 3])
+## ➢ NonEmpty.head [1, 2, 3]
 ## 1 : Int
 ## ```
-let head(list : NonEmpty(a)) -> a =
-    todo("not implemented")
+let head (list : NonEmpty a) : a =
+    todo "not implemented"
 
 ## Get all elements except the first one.
 ## Unlike `List.tail`, this always succeeds since the list cannot be empty.
@@ -50,33 +50,33 @@ let head(list : NonEmpty(a)) -> a =
 ## @since 0.1.0
 ##
 ## ```
-## ➢ NonEmpty.tail([1, 2, 3])
-## [2, 3] : List(Int)
+## ➢ NonEmpty.tail [1, 2, 3]
+## [2, 3] : List Int
 ## ```
-let tail(list : NonEmpty(a)) -> List(a) =
-    todo("not implemented")
+let tail (list : NonEmpty a) : List a =
+    todo "not implemented"
 
 ## Apply a function to each element in a non-empty list.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ NonEmpty.map(fn(x) => x * 2, [1, 2, 3])
-## [2, 4, 6] : NonEmpty(Int)
+## ➢ NonEmpty.map (fn x => x * 2) [1, 2, 3]
+## [2, 4, 6] : NonEmpty Int
 ## ```
-let map(f : ((a) -> b), list : NonEmpty(a)) -> NonEmpty(b) =
-    todo("not implemented")
+let map (f : a -> b) (list : NonEmpty a) : NonEmpty b =
+    todo "not implemented"
 
 ## Place a value between all elements of a non-empty list.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ NonEmpty.intersperse(0, [1, 2, 3])
-## [1, 0, 2, 0, 3] : NonEmpty(Int)
+## ➢ NonEmpty.intersperse 0 [1, 2, 3]
+## [1, 0, 2, 0, 3] : NonEmpty Int
 ## ```
-let intersperse(x : a, list : NonEmpty(a)) -> NonEmpty(a) =
-    todo("not implemented")
+let intersperse (x : a) (list : NonEmpty a) : NonEmpty a =
+    todo "not implemented"
 
 ## Get the number of elements in a non-empty list.
 ## The result is always at least 1.
@@ -84,44 +84,44 @@ let intersperse(x : a, list : NonEmpty(a)) -> NonEmpty(a) =
 ## @since 0.1.0
 ##
 ## ```
-## ➢ NonEmpty.size([1, 2, 3])
+## ➢ NonEmpty.size [1, 2, 3]
 ## 3 : Int
 ## ```
-let size(list : NonEmpty(a)) -> Int =
-    todo("not implemented")
+let size (list : NonEmpty a) : Int =
+    todo "not implemented"
 
 ## Sort a non-empty list in ascending order.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ NonEmpty.sort([3, 1, 2])
-## [1, 2, 3] : NonEmpty(Int)
+## ➢ NonEmpty.sort [3, 1, 2]
+## [1, 2, 3] : NonEmpty Int
 ## ```
-let sort(list : NonEmpty(comparable)) -> NonEmpty(comparable) =
-    todo("not implemented")
+let sort (list : NonEmpty comparable) : NonEmpty comparable =
+    todo "not implemented"
 
 ## Reverse the order of elements in a non-empty list.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ NonEmpty.reverse([1, 2, 3])
-## [3, 2, 1] : NonEmpty(Int)
+## ➢ NonEmpty.reverse [1, 2, 3]
+## [3, 2, 1] : NonEmpty Int
 ## ```
-let reverse(list : NonEmpty(a)) -> NonEmpty(a) =
-    todo("not implemented")
+let reverse (list : NonEmpty a) : NonEmpty a =
+    todo "not implemented"
 
 ## Create a non-empty list with a single value repeated infinitely.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ NonEmpty.repeat(42)
-## [42, 42, 42, ...] : NonEmpty(Int)
+## ➢ NonEmpty.repeat 42
+## [42, 42, 42, ...] : NonEmpty Int
 ## ```
-let repeat(x : a) -> NonEmpty(a) =
-    todo("not implemented")
+let repeat (x : a) : NonEmpty a =
+    todo "not implemented"
 
 ## Take the first n elements from a non-empty list.
 ## If n is 0 or negative, returns an empty list.
@@ -129,11 +129,11 @@ let repeat(x : a) -> NonEmpty(a) =
 ## @since 0.1.0
 ##
 ## ```
-## ➢ NonEmpty.take_left(2, [1, 2, 3, 4])
-## [1, 2] : List(Int)
+## ➢ NonEmpty.take_left 2 [1, 2, 3, 4]
+## [1, 2] : List Int
 ## ```
-let take_left(n : Int, list : NonEmpty(a)) -> List(a) =
-    todo("not implemented")
+let take_left (n : Int) (list : NonEmpty a) : List a =
+    todo "not implemented"
 
 ## Drop the first n elements from a non-empty list.
 ## If n is greater than or equal to the size of the list, returns an empty list.
@@ -141,33 +141,33 @@ let take_left(n : Int, list : NonEmpty(a)) -> List(a) =
 ## @since 0.1.0
 ##
 ## ```
-## ➢ NonEmpty.drop_left(2, [1, 2, 3, 4])
-## [3, 4] : List(Int)
+## ➢ NonEmpty.drop_left 2 [1, 2, 3, 4]
+## [3, 4] : List Int
 ## ```
-let drop_left(n : Int, list : NonEmpty(a)) -> List(a) =
-    todo("not implemented")
+let drop_left (n : Int) (list : NonEmpty a) : List a =
+    todo "not implemented"
 
 ## Keep elements from the start of the list as long as they pass the predicate.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ NonEmpty.take_while(fn(x) => x < 3, [1, 2, 3, 4, 1])
-## [1, 2] : List(Int)
+## ➢ NonEmpty.take_while (fn x => x < 3) [1, 2, 3, 4, 1]
+## [1, 2] : List Int
 ## ```
-let take_while(predicate : ((a) -> Bool), list : NonEmpty(a)) -> List(a) =
-    todo("not implemented")
+let take_while (predicate : a -> Bool) (list : NonEmpty a) : List a =
+    todo "not implemented"
 
 ## Drop elements from the start of the list as long as they pass the predicate.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ NonEmpty.drop_while(fn(x) => x < 3, [1, 2, 3, 4, 1])
-## [3, 4, 1] : List(Int)
+## ➢ NonEmpty.drop_while (fn x => x < 3) [1, 2, 3, 4, 1]
+## [3, 4, 1] : List Int
 ## ```
-let drop_while(predicate : ((a) -> Bool), list : NonEmpty(a)) -> List(a) =
-    todo("not implemented")
+let drop_while (predicate : a -> Bool) (list : NonEmpty a) : List a =
+    todo "not implemented"
 
 ## Convert a regular list to a non-empty list.
 ## Returns None if the input list is empty.
@@ -175,22 +175,22 @@ let drop_while(predicate : ((a) -> Bool), list : NonEmpty(a)) -> List(a) =
 ## @since 0.1.0
 ##
 ## ```
-## ➢ NonEmpty.from_list([1, 2, 3])
-## Some([1, 2, 3]) : Maybe(NonEmpty(Int))
+## ➢ NonEmpty.from_list [1, 2, 3]
+## Some [1, 2, 3] : Maybe (NonEmpty Int)
 ##
-## ➢ NonEmpty.from_list([])
-## None : Maybe(NonEmpty(Int))
+## ➢ NonEmpty.from_list []
+## None : Maybe (NonEmpty Int)
 ## ```
-let from_list(list : List(a)) -> Maybe(NonEmpty(a)) =
-    todo("not implemented")
+let from_list (list : List a) : Maybe (NonEmpty a) =
+    todo "not implemented"
 
 ## Convert a non-empty list to a regular list.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ NonEmpty.to_list([1, 2, 3])
-## [1, 2, 3] : List(Int)
+## ➢ NonEmpty.to_list [1, 2, 3]
+## [1, 2, 3] : List Int
 ## ```
-let to_list(list : NonEmpty(a)) -> List(a) =
-    todo("not implemented")
+let to_list (list : NonEmpty a) : List a =
+    todo "not implemented"

--- a/stdlib/prelude.mn
+++ b/stdlib/prelude.mn
@@ -2,6 +2,7 @@ module Prelude exposing
     ( abs
     , always
     , even?
+    , flip
     , gcd
     , identity
     , lcm
@@ -10,60 +11,20 @@ module Prelude exposing
     , negate
     , odd?
     , pow
-    , (|>)
-    , (||)
-    , (&&)
-    , (^)
-    , (==)
-    , (/=)
-    , (<)
-    , (>)
-    , (<=)
-    , (>=)
-    , (..)
-    , (<>)
-    , (+)
-    , (-)
-    , (+.)
-    , (-.)
-    , (.|.)
-    , (.^.)
-    , (*)
-    , (/)
-    , (*.)
-    , (/.)
-    , (.&.)
-    , (.>>.)
-    , (.<<.)
-    , (^^)
-    , (**)
-    , (.~.)
     )
 
 include Boolean
 include Compareable
-
-foreign int_add(_ : Int, _ : Int) -> Int = "zig_int_add"
-foreign int_sub(_ : Int, _ : Int) -> Int = "zig_int_sub"
-foreign int_mul(_ : Int, _ : Int) -> Int = "zig_int_mul"
-foreign int_div(_ : Int, _ : Int) -> Int = "zig_int_div"
-foreign int_pow(_ : Int, _ : Int) -> Int = "zig_int_pow"
-foreign int_min(_ : Int, _ : Int) -> Int = "zig_int_min"
-foreign int_max(_ : Int, _ : Int) -> Int = "zig_int_max"
-
-# =============================
-#      HELPFUL FUNCTIONS
-# =============================
 
 ## Returns the input value unchanged.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ identity(42)
+## ➢ identity 42
 ## 42 : Int
 ## ```
-let identity(x : a) -> a =
+let identity (x : a) : a =
     x
 
 ## Returns the first parameter and ignores the second. Useful in higher-order
@@ -72,131 +33,137 @@ let identity(x : a) -> a =
 ## @since 0.1.0
 ##
 ## ```
-## ➢ always(42, 0)
+## ➢ always 42 0
 ## 42 : Int
 ## ```
-let always(x : a, _ : b) -> a =
+let always (x : a) (_ : b) : a =
     x
 
-## Reverse-application operator: `x |> f |> g` is exactly equivalent to `g(f(x))`
-let ap_right(x : a, f : (a -> b)) -> b =
-    f(x)
-
-# =============================
-#      INTEGER ARITHMETIC
-# =============================
+## Flips the order of the first two arguments to a function.
+##
+## @since 0.1.0
+##
+## ```
+## ➢ divide 10 5
+## 2 : Float
+##
+## ➢ flip divide 5 10
+## 2 : Float
+## ```
+let flip : (f : a -> b -> c) (x : b) (y : a) : c =
+    f y x
 
 ## Calculates the addition of two integers.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ add(40, 2)
+## ➢ add 40 2
 ## 42 : Int
 ## ```
-let add(x : Int, y : Int) -> Int =
-    int_add(x, y)
+let add (x : Int) (y : Int) : Int =
+    int_add x y
 
 ## Calculates the subtraction of two integers.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ sub(44, 2)
+## ➢ sub 44 2
 ## 42 : Int
 ## ```
-let sub(x : Int, y : Int) -> Int =
-    int_sub(x, y)
+let sub (x : Int) (y : Int) : Int =
+    int_sub x y
 
 ## Calculates the multiplication of two integers.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ mul(2, 21)
+## ➢ mul 2 21
 ## 42 : Int
 ## ```
-let mul(x : Int, y : Int) -> Int =
-    int_mul(x, y)
+let mul (x : Int) (y : Int) : Int =
+    int_mul x y
 
 ## Calculates the division of two integers.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ div(2, 84)
+## ➢ div 2 84
 ## 42 : Int
 ## ```
-let div(x : Int, y : Int) -> Int =
-    int_div(x, y)
+let div (x : Int) (y : Int) : Int =
+    int_div x y
 
 ## Determines if a number is even.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ even?(4)
+## ➢ even? 4
 ## True : Bool
 ## ```
-let even?(n : Int) -> Bool =
-    mod(n, 2) == 0
+let even? (n : Int) : Bool =
+    (mod n 2) == 0
 
 ## Determines if a number is odd.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ odd?(3)
+## ➢ odd? 3
 ## True : Bool
 ## ```
-let odd?(n : Int) -> Bool =
-    mod(n, 2) /= 0
+let odd? (n : Int) : Bool =
+    (mod n 2) /= 0
 
 ## Returns the greatest common divisor of the two integers.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ gcd(8, 12)
+## ➢ gcd 8 12
 ## 4 : Int
 ## ```
-let gcd(a : Int, b : Int) -> Int =
+let gcd (a : Int) (b : Int) : Int =
     if b == 0 then
         a
     else
-        gcd(b, mod(a, b))
+        gcd b (mod a b)
 
 ## Determines the smallest positive integer that is divisible by both *a* and *b*
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ lcm(21, 6)
+## ➢ lcm 21 6
 ## 42 : Int
 ## ```
-let lcm(a : Int, b : Int) -> Int =
-    abs(a * b) / gcd(a, b)
+let lcm (a : Int) (b : Int) : Int =
+    abs (a * b) / (gcd a b)
 
 ## Calculates the value of *a* to the power of *b*.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ pow(9, 3)
+## ➢ pow 9 3
 ## 729 : Int
 ## ```
-let pow(x : Int, y : Int) -> Int =
-    int_pow(x, y)
+let pow (x : Int) (y : Int) : Int =
+    int_pow x y
 
 ## Integer remainder.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ mod(42, 8)
+## ➢ mod 42 8
 ## 2 : Int
 ## ```
-let mod(a : Int, b : Int) -> Int =
+let mod (a : Int) (b : Int) : Int =
     a - b * (a / b)
 
 ## Negate a number.
@@ -204,10 +171,10 @@ let mod(a : Int, b : Int) -> Int =
 ## @since 0.1.0
 ##
 ## ```
-## ➢ negate(42)
+## ➢ negate 42
 ## -42 : Int
 ## ```
-let negate(n : Int) -> Int =
+let negate (n : Int) : Int =
     -n
 
 ## Get the absolute value of a number.
@@ -215,10 +182,10 @@ let negate(n : Int) -> Int =
 ## @since 0.1.0
 ##
 ## ```
-## ➢ abs(-42)
+## ➢ abs -42
 ## 42 : Int
 ## ```
-let abs(n : Int) -> Int =
+let abs (n : Int) : Int =
     if x < 0 then
         -n
     else
@@ -229,10 +196,10 @@ let abs(n : Int) -> Int =
 ## @since 0.1.0
 ##
 ## ```
-## ➢ clamp(100, 200, 99)
+## ➢ clamp 100 200 99
 ## 100 : Int
 ## ```
-let clamp(low : Int, high : Int, n : Int) -> Int =
+let clamp (low : Int) (high : Int) (n : Int) : Int =
     if n < low then
         low
     else if n > high then
@@ -240,34 +207,29 @@ let clamp(low : Int, high : Int, n : Int) -> Int =
     else
         n
 
-let max() -> Int =
-    int_max()
+let max : Int =
+    int_max
 
-let min() -> Int =
-    int_min()
+let min : Int =
+    int_min
 
-# =============================
-#        INFIX OPERATORS
-# =============================
+foreign int_add : Int -> Int -> Int =
+    "zig_int_add"
 
-infixl 2  (|>)  = pipe_right
-infixr 3  (||)  = logical_or
-infixr 4  (&&)  = logical_and
-infixn 5  (==)  = eq
-infixn 5  (/=)  = neq
-infixn 5  (<)   = lt
-infixn 5  (>)   = gt
-infixn 5  (<=)  = lte
-infixn 5  (>=)  = gte
-infixr 6  (++)  = List.concat
-infixr 7  (<>)  = Str.concat
-infixr 8  (..)  = range
-infixl 9  (+)   = add
-infixl 9  (-)   = sub
-infixl 9  (+.)  = Float.add
-infixl 9  (-.)  = Float.sub
-infixl 10 (*)   = mul
-infixl 10 (/)   = div
-infixl 10 (*.)  = Float.mul
-infixl 10 (/.)  = Float.div
-infixl 11 (**)  = Float.pow
+foreign int_sub : Int -> Int -> Int =
+    "zig_int_sub"
+
+foreign int_mul : Int -> Int -> Int =
+    "zig_int_mul"
+
+foreign int_div : Int -> Int -> Int =
+    "zig_int_div"
+
+foreign int_pow : Int -> Int -> Int =
+    "zig_int_pow"
+
+foreign int_min : Int -> Int -> Int =
+    "zig_int_min"
+
+foreign int_max : Int -> Int -> Int =
+    "zig_int_max"

--- a/stdlib/result.mn
+++ b/stdlib/result.mn
@@ -22,233 +22,232 @@ module Result exposing
 ## @since 0.1.0
 ##
 ## ```
-## ➢ Ok(42) : Result(String, Int)
-## Ok(42) : Result(String, Int)
+## ➢ Ok 42 : Result String Int
+## Ok 42 : Result String Int
 ## ```
-type Result(e, a) =
-    | Err(e)
-    | Ok(a)
+type Result e a =
+    | Err e
+    | Ok a
 
 ## Check whether the result is `Ok` without unwrapping it.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ Result.ok?(Ok(42))
+## ➢ Result.ok? (Ok 42)
 ## True : Bool
 ##
-## ➢ Result.ok?(Err("failed"))
+## ➢ Result.ok? (Err "failed")
 ## False : Bool
 ## ```
-let ok?(ra : Result(e, a)) -> Bool =
+let ok? (ra : Result e a) : Bool =
     match ra on
-    | Err(_) => False
-    | Ok(_) => True
+    | Err _ => False
+    | Ok _ => True
 
 ## Check whether the result is `Err` without unwrapping it.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ Result.err?(Err("failed"))
+## ➢ Result.err? (Err "failed")
 ## True : Bool
 ##
-## ➢ Result.err?(Ok(42))
+## ➢ Result.err? (Ok 42)
 ## False : Bool
 ## ```
-let err?(ra : Result(e, a)) -> Bool =
+let err? (ra : Result e a) : Bool =
     match ra on
-    | Err(_)  => True
-    | Ok(_)  => False
+    | Err _  => True
+    | Ok _  => False
 
 ## Extracts the value from an `Ok` result, or returns the provided default value.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ Result.with_default(Ok(42), 0)
+## ➢ Result.with_default 0 (Ok 42)
 ## 42 : Int
 ##
-## ➢ Result.with_default(Err("failed"), 0)
+## ➢ Result.with_default 0 (Err "failed")
 ## 0 : Int
 ## ```
-let with_default(ra : Result(e, a), default : a) -> a =
+let with_default (default : a) (ra : Result e a) : a =
     match ra on
-    | Err(_) => default
-    | Ok(a) => a
+    | Err _ => default
+    | Ok a => a
 
 ## Applies a function to the value inside an `Ok` result.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ Result.map(Ok(1), fn(x) => x + 1)
-## Ok(2) : Result(e, Int)
+## ➢ Result.map (fn x => x + 1) (Ok 1)
+## Ok 2 : Result e Int
 ##
-## ➢ Result.map(Err("failed"), fn(x) => x + 1)
-## Err("failed") : Result(String, Int)
+## ➢ Result.map (fn x => x + 1) (Err "failed")
+## Err "failed" : Result String Int
 ## ```
-let map(ra : Result(e, a), f : (a -> value)) -> Result(e, value) =
+let map (f : a -> value) (ra : Result e a) : Result e value =
     match ra on
-    | Err(e) => Err(e)
-    | Ok(a) => Ok(f(a))
+    | Err e => Err e
+    | Ok a => Ok (f a)
 
 ## Combines two results using a function.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ Result.map2(Ok(1), Ok(2), fn(a, b) => a + b)
-## Ok(3) : Result(e, Int)
+## ➢ Result.map2 (fn a b => a + b) (Ok 1) (Ok 2)
+## Ok 3 : Result e Int
 ##
-## ➢ Result.map2(Err("failed"), Ok(2), fn(a, b) => a + b)
-## Err("failed") : Result(String, Int)
+## ➢ Result.map2 (fn a b => a + b) (Err "failed") (Ok 2)
+## Err "failed" : Result String Int
 ## ```
-let map2(
-    ra : Result(e, a),
-    rb : Result(e, b),
-    f : ((a, b) -> value)
-) -> Result(e, value) =
+let map2
+    (f : a -> b -> value)
+    (ra : Result e a)
+    (rb : Result e b)
+    : Result e value =
     match ra on
-    | Err(e) => Err(e)
-    | Ok(a) =>
+    | Err e => Err e
+    | Ok a =>
         match rb on
-        | Err(e) => Err(e)
-        | Ok(b) => Ok(f(a, b))
+        | Err e => Err e
+        | Ok b => Ok (f a b)
 
 ## Combines three results using a function.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ Result.map3(Ok(1), Ok(2), Ok(3), fn(a, b, c) => a + b + c)
-## Ok(6) : Result(e, Int)
+## ➢ Result.map3 (fn a b c => a + b + c) (Ok 1) (Ok 2) (Ok 3)
+## Ok 6 : Result e Int
 ##
-## ➢ Result.map3(Ok(1), Err("failed"), Ok(3), fn(a, b, c) => a + b + c)
-## Err("failed") : Result(String, Int)
+## ➢ Result.map3 (fn a b c => a + b + c) (Ok 1) (Err "failed") (Ok 3)
+## Err "failed" : Result String Int
 ## ```
-let map3(
-    ra : Result(e, a),
-    rb : Result(e, b),
-    rc : Result(e, c),
-    f : ((a, b, c) -> value)
-) -> Result(e, value) =
+let map3
+    (f : a -> b -> c -> value)
+    (ra : Result e a)
+    (rb : Result e b)
+    (rc : Result e c)
+    : Result e value =
     match ra on
-    | Err(e) => Err(e)
-    | Ok(a) =>
+    | Err e => Err e
+    | Ok a =>
         match rb on
-        | Err(e) => Err(e)
-        | Ok(b) =>
+        | Err e => Err e
+        | Ok b =>
             match rc on
-            | Err(e) => Err(e)
-            | Ok(c) => Ok(f(a, b, c))
+            | Err e => Err e
+            | Ok c => Ok (f a b c)
 
 ## Combines four results using a function.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ Result.map4(Ok(1), Ok(2), Ok(3), Ok(4), fn(a, b, c, d) => a + b + c + d)
-## Ok(10) : Result(e, Int)
+## ➢ Result.map4 (fn a b c d => a + b + c + d) (Ok 1) (Ok 2) (Ok 3) (Ok 4)
+## Ok 10 : Result e Int
 ## ```
-let map4(
-    ra : Result(e, a),
-    rb : Result(e, b),
-    rc : Result(e, c),
-    rd : Result(e, d),
-    f : ((a, b, c, d) -> value)
-) -> Result(e, value) =
+let map4
+    (f : a -> b -> c -> d -> value)
+    (ra : Result e a)
+    (rb : Result e b)
+    (rc : Result e c)
+    (rd : Result e d)
+    : Result e value =
     match ra on
-    | Err(e) => Err(e)
-    | Ok(a) =>
+    | Err e => Err e
+    | Ok a =>
         match rb on
-        | Err(e) => Err(e)
-        | Ok(b) =>
+        | Err e => Err e
+        | Ok b =>
             match rc on
-            | Err(e) => Err(e)
-            | Ok(c) =>
+            | Err e => Err e
+            | Ok c =>
                 match rd on
-                | Err(e) => Err(e)
-                | Ok(d) => Ok(f(a, b, c, d))
+                | Err e => Err e
+                | Ok d => Ok (f a b c d)
 
 ## Chains result-producing operations together.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ Result.and_then(Ok(1), fn(x) => Ok(x + 1))
-## Ok(2) : Result(e, Int)
+## ➢ Result.and_then (fn x => Ok (x + 1)) (Ok 1)
+## Ok 2 : Result e Int
 ##
-## ➢ Result.and_then(Err("failed"), fn(x) => Ok(x + 1))
-## Err("failed") : Result(String, Int)
+## ➢ Result.and_then (fn x => Ok (x + 1)) (Err "failed")
+## Err "failed" : Result String Int
 ## ```
-let and_then(ra : Result(e, a), f : (a -> Result(e, b))) -> Result(e, b) =
+let and_then (f : a -> Result e b) (ra : Result e a) : Result e b =
     match ra on
-    | Err(e) => Err(e)
-    | Ok(a) => f(a)
+    | Err e => Err e
+    | Ok a => f a
 
 ## Returns the first success between two results, or the second error if both fail.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ Result.or(Ok(1), Ok(2))
-## Ok(1) : Result(e, Int)
+## ➢ Result.or (Ok 1) (Ok 2)
+## Ok 1 : Result e Int
 ##
-## ➢ Result.or(Err("first"), Ok(2))
-## Ok(2) : Result(String, Int)
+## ➢ Result.or (Err "first") (Ok 2)
+## Ok 2 : Result String Int
 ##
-## ➢ Result.or(Err("first"), Err("second"))
-## Err("second") : Result(String, a)
+## ➢ Result.or (Err "first") (Err "second")
+## Err "second" : Result String a
 ## ```
-let or(ra : Result(e, a), rb : Result(e, a)) -> Result(e, a) =
+let or (ra : Result e a) (rb : Result e a) : Result e a =
     match ra on
-    | Err(_) => rb
-    | Ok(_) => ra
-
+    | Err _ => rb
+    | Ok _ => ra
 
 ## Transforms the error value of a result.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ Result.map_error(Err("failed"), String.size)
-## Err(6) : Result(Int, a)
+## ➢ Result.map_error String.size (Err "failed")
+## Err 6 : Result Int a
 ##
-## ➢ Result.map_error(Ok(42), String.size)
-## Ok(42) : Result(Int, Int)
+## ➢ Result.map_error String.size (Ok 42)
+## Ok 42 : Result Int Int
 ## ```
-let map_error(ra : Result(x, a), f : (x -> y)) -> Result(y, a) =
+let map_error (f : x -> y) (ra : Result x a) : Result y a =
     match ra on
-    | Err(e) => Err(f(e))
-    | Ok(a) => Ok(a)
+    | Err e => Err (f e)
+    | Ok a => Ok a
 
 ## Converts a Maybe to a Result with a provided error.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ Result.from_maybe(Some(42), "missing value")
-## Ok(42) : Result(String, Int)
+## ➢ Result.from_maybe "missing value" (Some 42)
+## Ok 42 : Result String Int
 ##
-## ➢ Result.from_maybe(None, "missing value")
-## Err("missing value") : Result(String, a)
+## ➢ Result.from_maybe "missing value" None
+## Err "missing value" : Result String a
 ## ```
-let from_maybe(ma : Maybe(a), err : e) -> Result(e, a) =
+let from_maybe (err : e) (ma : Maybe a) : Result e a =
     match ma on
-    | None => Err(err)
-    | Some(a) => Ok(a)
+    | None => Err err
+    | Some a => Ok a
 
 ## Extracts all successful values from a list of results.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ Result.compact([Ok(1), Err("failed"), Ok(2)])
-## [1, 2] : List(Int)
+## ➢ Result.compact [Ok 1, Err "failed", Ok 2]
+## [1, 2] : List Int
 ## ```
-let compact(results : List(Result(e, a))) -> List(a) =
-    List.collect_map(results, identity)
+let compact (results : List (Result e a)) : List a =
+    List.collect_map results identity
 
 ## Combines a list of results into a single result (holding a list).
 ## Also known as `sequence` on lists.
@@ -256,33 +255,31 @@ let compact(results : List(Result(e, a))) -> List(a) =
 ## @since 0.1.0
 ##
 ## ```
-## ➢ Result.combine([Ok(1), Ok(2)])
-## Ok([1, 2]) : Result(e, List(Int))
+## ➢ Result.combine [Ok 1, Ok 2]
+## Ok [1, 2] : Result e (List Int)
 ##
-## ➢ Result.combine([Ok(1), Err("failed"), Ok(2)])
-## Err("failed") : Result(String, List(Int))
+## ➢ Result.combine [Ok 1, Err "failed", Ok 2]
+## Err "failed" : Result String (List Int)
 ## ```
-let combine(results : List(Result(e, a))) -> Result(e, List(a)) =
+let combine (results : List (Result e a)) : Result e (List a) =
     results
-    |> List.fold_right(
-        fn(r, acc) => map2(r, acc, fn(x, xs) => x :: xs),
-        Ok(Nil)
-    )
+    |> List.fold_right
+        (fn r acc => map2 (fn x xs => x :: xs) r acc)
+        (Ok Nil)
 
 ## Partition a list of Results into two lists of values (successes and failures).
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ Result.partition([Ok(1), Err("uh oh!"), Ok(2)])
-## (["uh oh!"], [1, 2]) : (List(String), List(Int))
+## ➢ Result.partition [Ok 1, Err "uh oh!", Ok 2]
+## (["uh oh!"], [1, 2]) : (List String, List Int)
 ## ```
-let partition(results : List(Result(e, a))) -> (List(e), List(a)) =
+let partition (results : List (Result e a)) : (List e, List a) =
     results
-    |> List.fold_right(
-        fn(r, (err, succ)) =>
+    |> List.fold_right
+        (fn r (err, succ) =>
             match r on
-            | Err(v) => (v :: err, succ)
-            | Ok(v) => (err, v :: succ),
+            | Err v => (v :: err, succ)
+            | Ok v => (err, v :: succ))
         (Nil, Nil)
-    )

--- a/stdlib/set.mn
+++ b/stdlib/set.mn
@@ -1,5 +1,5 @@
 module Set exposing
-    ( Set
+    ( Set(..)
     , diff
     , empty
     , empty?
@@ -29,126 +29,116 @@ open Unit using (Unit)
 ## Operations like insert, remove, and lookup have O(log n) complexity.
 ##
 ## @since 0.1.0
-type alias Set(a) =
-    Set(TM.TreeMap(a, Unit)))
+type alias Set a =
+    Set (TM.TreeMap a Unit)
 
 ## Create an empty set.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ Set.empty()
-## {} : Set(a)
+## ➢ Set.empty
+## {} : Set a
 ## ```
-let empty() -> Set(a) =
-    Set(TM.empty())
+let empty : Set a =
+    todo "not implemented"
 
 ## Determine if a set is empty.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ Set.empty?(Set.empty())
+## ➢ Set.empty? Set.empty
 ## True : Bool
 ##
-## ➢ Set.empty?(Set.singleton(1))
+## ➢ Set.empty? (Set.singleton 1)
 ## False : Bool
 ## ```
-let empty?(set : Set(a)) -> Bool =
-    match set on
-    | Set(map) => TM.empty?(map)
+let empty? : Set a -> Bool =
+    todo "not implemented"
 
 ## Create a set with one value.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ Set.singleton(42)
-## {42} : Set(Int)
+## ➢ Set.singleton 42
+## {42} : Set Int
 ## ```
-let singleton(value : comparable) -> Set(comparable) =
-    Set(TM.singleton(value, Unit))
+let singleton : comparable -> Set comparable =
+    todo "not implemented"
 
 ## Insert a value into a set.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ Set.insert(Set.singleton(1), 2)
-## {1, 2} : Set(Int)
+## ➢ Set.insert 2 (Set.singleton 1)
+## {1, 2} : Set Int
 ##
-## ➢ Set.insert(Set.singleton(1), 1)
-## {1} : Set(Int)
+## ➢ Set.insert 1 (Set.singleton 1)
+## {1} : Set Int
 ## ```
-let insert(set : Set(comparable), value : comparable) -> Set(comparable) =
-    match set on
-    | Set(map) => Set(TM.insert(map, value, Unit))
+let insert : comparable -> Set comparable -> Set comparable =
+    todo "not implemented"
 
 ## Remove a value from a set. If the value is not found, no changes are made.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ Set.remove(Set.from_list([1, 2, 3]), 2)
-## {1, 3} : Set(Int)
+## ➢ Set.remove 2 (Set.from_list [1, 2, 3])
+## {1, 3} : Set Int
 ## ```
-let remove(set : Set(comparable), value : comparable) -> Set(comparable) =
-    match set on
-    | Set(map) => Set(TM.remove(map, value))
+let remove : comparable -> Set comparable -> Set comparable =
+    todo "not implemented"
 
 ## Determine if a value is in a set.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ Set.member?(Set.from_list([1, 2, 3]), 2)
+## ➢ Set.member? 2 (Set.from_list [1, 2, 3])
 ## True : Bool
 ##
-## ➢ Set.member?(Set.from_list([1, 2, 3]), 4)
+## ➢ Set.member? 4 (Set.from_list [1, 2, 3])
 ## False : Bool
 ## ```
-let member?(set : Set(comparable), value : comparable) -> Bool =
-    match set on
-    | Set(map) =>
-        match TM.get(map, value) on
-        | None => False
-        | Some(_) => True
+let member? : comparable -> Set comparable -> Bool =
+    todo "not implemented"
 
 ## Determine the number of elements in a set.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ Set.size(Set.from_list([1, 2, 3]))
+## ➢ Set.size (Set.from_list [1, 2, 3])
 ## 3 : Int
 ## ```
-let size(set : Set(a)) -> Int =
-    match set on
-    | Set(map) => TM.size(map)
+let size : Set a -> Int =
+    todo "not implemented"
 
 ## Get the union of two sets. Keep all values.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ Set.union(Set.from_list([1, 2]), Set.from_list([2, 3]))
-## {1, 2, 3} : Set(Int)
+## ➢ Set.union (Set.from_list [2, 3]) (Set.from_list [1, 2])
+## {1, 2, 3} : Set Int
 ## ```
-let union(set1 : Set(comparable), set2 : Set(comparable)) -> Set(comparable) =
-    match (set1, set2) on
-    | (Set(map1), Set(map2)) => Set(TM.union(map1, map2))
+let union : Set comparable -> Set comparable -> Set comparable =
+    todo "not implemented"
 
 ## Get the intersection of two sets. Keeps values that appear in both sets.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ Set.intersect(Set.from_list([1, 2]), Set.from_list([2, 3]))
-## {2} : Set(Int)
+## ➢ Set.intersect (Set.from_list [2, 3]) (Set.from_list [1, 2])
+## {2} : Set Int
 ## ```
-let intersect(set1 : Set(comparable), set2 : Set(comparable)) -> Set(comparable) =
-    match (set1, set2) on
-    | (Set(map1), Set(map2)) => Set(TM.intersect(map1, map2))
+let intersect : Set comparable -> Set comparable -> Set comparable =
+    todo "not implemented"
 
 ## Get the difference between the first set and the second. Keeps values
 ## that do not appear in the second set.
@@ -156,164 +146,119 @@ let intersect(set1 : Set(comparable), set2 : Set(comparable)) -> Set(comparable)
 ## @since 0.1.0
 ##
 ## ```
-## ➢ Set.diff(Set.from_list([1, 2, 3]), Set.from_list([2, 3, 4]))
-## {1} : Set(Int)
+## ➢ Set.diff (Set.from_list [2, 3, 4]) (Set.from_list [1, 2, 3])
+## {4} : Set Int
 ## ```
-let diff(set1 : Set(comparable), set2 : Set(comparable)) -> Set(comparable) =
-    match (set1, set2) on
-    | (Set(map1), Set(map2)) => Set(TM.diff(map1, map2))
+let diff : Set comparable -> Set comparable -> Set comparable =
+    todo "not implemented"
 
 ## Determine if the first set is a subset of the second set.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ Set.subset?(Set.from_list([1, 2]), Set.from_list([1, 2, 3]))
-## True : Bool
+## ➢ Set.subset? (Set.from_list [1, 2, 3]) (Set.from_list [1, 2])
+## False : Bool
 ##
-## ➢ Set.subset?(Set.from_list([1, 4]), Set.from_list([1, 2, 3]))
+## ➢ Set.subset? (Set.from_list [1, 2, 3]) (Set.from_list [1, 4])
 ## False : Bool
 ## ```
-let subset?(set1 : Set(comparable), set2 : Set(comparable)) -> Bool =
-    match (set1, set2) on
-    | (Set(map1), Set(map2)) =>
-        let keys1 = TM.keys(map1)
-        List.all?(keys1, fn(key) =>
-            match TM.get(map2, key) on
-            | None => False
-            | Some(_) => True
-        )
+let subset? : Set comparable -> Set comparable -> Bool =
+    todo "not implemented"
 
 ## Determine if the first set is a superset of the second set.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ Set.superset?(Set.from_list([1, 2, 3]), Set.from_list([1, 2]))
-## True : Bool
+## ➢ Set.superset? (Set.from_list [1, 2]) (Set.from_list [1, 2, 3])
+## False : Bool
 ##
-## ➢ Set.superset?(Set.from_list([1, 2, 3]), Set.from_list([1, 4]))
+## ➢ Set.superset? (Set.from_list [1, 4]) (Set.from_list [1, 2, 3])
 ## False : Bool
 ## ```
-let superset?(set1 : Set(comparable), set2 : Set(comparable)) -> Bool =
-    subset?(set2, set1)
-
-## Determine if two sets have no elements in common.
-##
-## @since 0.1.0
-##
-## ```
-## ➢ Set.disjoint?(Set.from_list([1, 2]), Set.from_list([3, 4]))
-## True : Bool
-##
-## ➢ Set.disjoint?(Set.from_list([1, 2]), Set.from_list([2, 3]))
-## False : Bool
-## ```
-let disjoint?(set1 : Set(comparable), set2 : Set(comparable)) -> Bool =
-    match (set1, set2) on
-    | (Set(map1), Set(map2)) =>
-        let keys1 = TM.keys(map1)
-
-        List.all?(keys1, fn(key) =>
-            match TM.get(map2, key) on
-            | None => True
-            | Some(_) => False
-        )
+let superset? : Set comparable -> Set comparable -> Bool =
+    todo "not implemented"
 
 ## Convert a set into a list, sorted from lowest to highest.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ Set.to_list(Set.from_list([3, 1, 2]))
-## [1, 2, 3] : List(Int)
+## ➢ Set.to_list (Set.from_list [3, 1, 2])
+## [1, 2, 3] : List Int
 ## ```
-let to_list(set : Set(a)) -> List(a) =
-    match set on
-    | Set(map) => TM.keys(map)
+let to_list : Set a -> List a =
+    todo "not implemented"
 
 ## Convert a list into a set, removing any duplicates.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ Set.from_list([1, 2, 1, 3, 2])
-## {1, 2, 3} : Set(Int)
+## ➢ Set.from_list [1, 2, 1, 3, 2]
+## {1, 2, 3} : Set Int
 ## ```
-let from_list(list : List(comparable)) -> Set(comparable) =
-    List.fold_left(
-        list,
-        empty(),
-        fn(acc, value) => insert(acc, value)
-    )
+let from_list : List comparable -> Set comparable =
+    todo "not implemented"
 
 ## Fold over the values in a set, in order from lowest to highest.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ Set.fold_left(Set.from_list([1, 2, 3]), fn(x, acc) => acc + x, 0)
+## ➢ Set.fold_left (fn x acc => acc + x) 0 (Set.from_list [1, 2, 3])
 ## 6 : Int
 ## ```
-let fold_left(set : Set(a), f : (a, b -> b), init : b) -> b =
-    match set on
-    | Set(map) => TM.fold_left(map, fn(k, _, acc) => f(k, acc), init)
+let fold_left : (a -> b -> b) -> b -> Set a -> b =
+    todo "not implemented"
 
 ## Fold over the values in a set, in order from highest to lowest.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ Set.fold_right(Set.from_list([1, 2, 3]), fn(x, acc) => acc + x, 0)
+## ➢ Set.fold_right (fn x acc => acc + x) 0 (Set.from_list [1, 2, 3])
 ## 6 : Int
 ## ```
-let fold_right(set : Set(a), f : (a, b -> b), init : b) -> b =
-    match set on
-    | Set(map) => TM.fold_right(map, fn(k, _, acc) => f(k, acc), init)
+let fold_right : (a -> b -> b) -> b -> Set a -> b =
+    todo "not implemented"
 
 ## Map a function onto a set, creating a new set with no duplicates.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ Set.map(Set.from_list([1, 2, 3]), fn(x) => x * 2)
-## {2, 4, 6} : Set(Int)
+## ➢ Set.map (fn x => x * 2) (Set.from_list [1, 2, 3])
+## {2, 4, 6} : Set Int
 ##
-## ➢ Set.map(Set.from_list([1, 2, 3, 4]), fn(x) => mod(x, 2))
-## {0, 1} : Set(Int)
+## ➢ Set.map (fn x => mod x 2) (Set.from_list [1, 2, 3, 4])
+## {0, 1} : Set Int
 ## ```
-let map(set : Set(comparable), f : (comparable -> comparable2)) -> Set(comparable2) =
-    match set on
-    | Set(map) =>
-        fold_left(
-            set,
-            fn(value, acc) => insert(acc, f(value)),
-            empty()
-        )
+let map : (comparable -> comparable2) -> Set comparable -> Set comparable2 =
+    todo "not implemented"
 
 ## Only keep elements that satisfy the given predicate.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ Set.keep(Set.from_list([1, 2, 3, 4]), fn(x) => mod(x, 2) == 0)
-## {2, 4} : Set(Int)
+## ➢ Set.keep (fn x => mod x 2 == 0) (Set.from_list [1, 2, 3, 4])
+## {2, 4} : Set Int
 ## ```
-let keep(set : Set(comparable), pred : (comparable -> Bool)) -> Set(comparable) =
-    match set on
-    | Set(map) => Set(TM.keep(map, fn(k, _) => pred(k)))
+let keep : (comparable -> Bool) -> Set comparable -> Set comparable =
+    todo "not implemented"
 
 ## Returns a set by excluding the elements which satisfy the given predicate.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ Set.reject(Set.from_list([1, 2, 3, 4]), fn(x) => mod(x, 2) == 0)
-## {1, 3} : Set(Int)
+## ➢ Set.reject (fn x => mod x 2 == 0) (Set.from_list [1, 2, 3, 4])
+## {1, 3} : Set Int
 ## ```
-let reject(set : Set(comparable), pred : (comparable -> Bool)) -> Set(comparable) =
-    match set on
-    | Set(map) => Set(TM.reject(map, fn(k, _) => pred(k)))
+let reject : (comparable -> Bool) -> Set comparable -> Set comparable =
+    todo "not implemented"
 
 ## Create two new sets. The first contains all the elements that passed the
 ## given test, and the second contains all the elements that did not.
@@ -321,11 +266,8 @@ let reject(set : Set(comparable), pred : (comparable -> Bool)) -> Set(comparable
 ## @since 0.1.0
 ##
 ## ```
-## ➢ Set.partition(Set.from_list([1, 2, 3, 4]), fn(x) => mod(x, 2) == 0)
-## ({2, 4}, {1, 3}) : (Set(Int), Set(Int))
+## ➢ Set.partition (fn x => mod x 2 == 0) (Set.from_list [1, 2, 3, 4])
+## ({2, 4}, {1, 3}) : (Set Int, Set Int)
 ## ```
-let partition(set : Set(comparable), pred : (comparable -> Bool)) -> (Set(comparable), Set(comparable)) =
-    match set on
-    | Set(map) =>
-        let (passed, failed) = TM.partition(map, fn(k, _) => pred(k))
-        (Set(passed), Set(failed))
+let partition : (comparable -> Bool) -> Set comparable -> (Set comparable, Set comparable) =
+    todo "not implemented"

--- a/stdlib/string.mn
+++ b/stdlib/string.mn
@@ -54,617 +54,589 @@ type Pattern =
 ## @since 0.1.0
 ##
 ## ```
-## ➢ String.size("foobar")
+## ➢ String.size "foobar"
 ## 6 : Int
 ## ```
-let size(str : String) -> Int =
-    string_size(str)
+let size (str : String) : Int =
+    string_size str
 
-## Append two strings.
+## Append one string to another.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ String.append("foo", "bar")
+## ➢ String.append "foo" "bar"
 ## "foobar" : String
 ## ```
-let append(str1 : String, str2 : String) -> String =
-    string_append(str1, str2)
+let append (str1 : String) (str2 : String) : String =
+    string_append str1 str2
 
-## Concatenate many strings into one.
+## Concatenate a list of strings into a single string.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ String.concat(["foo", "bar"])
-## "foobar" : String
+## ➢ String.concat ["foo", "bar", "baz"]
+## "foobarbaz" : String
 ## ```
-let concat(list : List(String)) -> String =
-    string_concat(list)
+let concat (list : List String) : String =
+    string_concat list
 
-## Put many strings together with a given pattern.
+## Join a list of strings with a given pattern.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ String.join(Pattern("/"), (["foo", "bar", "baz"])
-## "foo/bar/baz" : String
+## ➢ String.join ", " ["apple", "banana", "cherry"]
+## "apple, banana, cherry" : String
 ## ```
-let join(pattern : Pattern, list : List(String)) -> String =
-    todo("not implemented")
+let join (pattern : Pattern) (list : List String) : String =
+    let (Pattern p) = pattern
+    string_join p list
 
-## Take *n* characters from the left side of a string.
+## Take the leftmost `n` characters from a string.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ String.take_left("foobar", 3)
-## "foo" : String
+## ➢ String.take_left 2 "hello"
+## "he" : String
 ## ```
-let take_left(str : String, n : Int) -> String =
+let take_left (n : Int) (str : String) : String =
     if n < 1 then
         ""
     else
-        slice(str, 0, n)
+        slice 0 n str
 
-## Take *n* characters from the right side of a string.
+## Take the rightmost `n` characters from a string.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ String.take_right("foobar", 3)
-## "bar" : String
+## ➢ String.take_right 2 "hello"
+## "lo" : String
 ## ```
-let take_right(str : String, n : Int) -> String =
-    let len = size(str)
+let take_right (n : Int) (str : String) : String =
+    let len = size str
     if n <= 0 then
         ""
     else if n >= len then
         str
     else
-        slice(str, len - n, len)
+        slice (len - n) len str
 
-## Take characters from the start of a string as long as they satisfy the predicate.
-## Returns a new string containing only the matching characters from the beginning.
+## Take characters from a string while a predicate is true.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ String.take_while("foobar", vowel?)
-## : String
+## ➢ String.take_while (fn c => c == 'a') "aaabbc"
+## "aaa" : String
 ## ```
-let take_while(str : String, predicate : (Char -> Bool)) -> String =
-    todo("not implemented")
-let take_while(str : String, predicate : (Char -> Bool)) -> String =
-    let len = size(str)
-    let find_end(i : Int) -> Int =
-        if i >= len then
-            len
-        else
-            match at(str, i) on
+let take_while (predicate : Char -> Bool) (str : String) : String =
+    let len = size str
+    let find_end (i : Int) : Int =
+        match string_at i str on
             | None => i
-            | Some(c) =>
-                if predicate(c) then
-                    find_end(i + 1)
+            | Some c =>
+                if predicate c then
+                    find_end (i + 1)
                 else
                     i
-    slice(str, 0, find_end(0))
+    string_substr 0 (find_end 0) str
 
-## Drop *n* characters from the right side of a string.
+## Drop the leftmost `n` characters from a string.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ String.drop_left("foobar", 3)
-## "bar" : String
+## ➢ String.drop_left 2 "hello"
+## "llo" : String
 ## ```
-let drop_left(str : String, n : Int) -> String =
-    let len = size(str)
+let drop_left (n : Int) (str : String) : String =
+    let len = size str
     if n <= 0 then
         str
     else if n >= len then
         ""
     else
-        slice(str, n, len)
+        slice n len str
 
-## Drop *n* characters from the right side of a string.
+## Drop the rightmost `n` characters from a string.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ String.drop_right("foobar", 3)
-## "foo" : String
+## ➢ String.drop_right 2 "hello"
+## "hel" : String
 ## ```
-let drop_right(str : String, n : Int) -> String =
-    let len = size(str)
+let drop_right (n : Int) (str : String) : String =
+    let len = size str
     if n <= 0 then
         str
     else if n >= len then
         ""
     else
-        slice(str, 0, len - n)
+        slice 0 (len - n) str
 
-## Remove characters from the start of a string as long as they satisfy the predicate.
-## Returns a new string excluding all matching characters from the beginning.
+## Drop characters from a string while a predicate is true.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ String.drop_while("aaabbc", fn(c) => c == 'a')
+## ➢ String.drop_while (fn c => c == 'a') "aaabbc"
 ## "bbc" : String
 ## ```
-let drop_while(str : String, predicate : (Char -> Bool)) -> String =
-    todo("not implemented")
+let drop_while (predicate : Char -> Bool) (str : String) : String =
+    todo "not implemented"
 
-## Determine if a string contains the given pattern.
-## Returns True if the pattern is found anywhere within the string.
+## Check if a string contains a given pattern.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ String.contains?("hello world", Pattern("world"))
-## True : Bool
-##
-## ➢ String.contains?("hello world", Pattern("moon"))
-## False : Bool
+## ➢ String.contains? "world" "hello world"
+## true : Bool
 ## ```
-let contains?(str : String, pattern : Pattern) -> Bool =
-    todo("not implemented")
+let contains? (pattern : Pattern) (str : String) : Bool =
+    todo "not implemented"
 
 ## Break a string into words, splitting on chunks of whitespace.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ String.words("hello world")
-## ["hello", "world"] : List(String)
+## ➢ String.words "hello world"
+## ["hello", "world"] : List String
 ##
-## ➢ String.words("  multiple   spaces   ")
-## ["multiple", "spaces"] : List(String)
+## ➢ String.words "  multiple   spaces   "
+## ["multiple", "spaces"] : List String
 ## ```
-let words(str : String) -> List(String) =
-    todo("not implemented")
+let words (str : String) : List String =
+    todo "not implemented"
 
 ## Break a string into lines, splitting on newlines.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ String.lines("hello\nworld")
-## ["hello", "world"] : List(String)
+## ➢ String.lines "hello\nworld"
+## ["hello", "world"] : List String
 ##
-## ➢ String.lines("multiple\n\nblank\nlines")
-## ["multiple", "", "blank", "lines"] : List(String)
+## ➢ String.lines "multiple\n\nblank\nlines"
+## ["multiple", "", "blank", "lines"] : List String
 ## ```
-let lines(str : String) -> List(String) =
-    todo("not implemented")
+let lines (str : String) : List String =
+    todo "not implemented"
 
 ## Find the first occurrence of a pattern in a string.
-## Returns the index of the first character where the pattern is found, or None if not present.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ String.index_of("hello world", Pattern("world"))
-## Some(6) : Maybe(Int)
+## ➢ String.index_of (Pattern "world") "hello world"
+## Some 6 : Maybe Int
 ##
-## ➢ String.index_of("hello world", Pattern("moon"))
-## None : Maybe(Int)
+## ➢ String.index_of (Pattern "moon") "hello world"
+## None : Maybe Int
 ## ```
-let index_of(str : String, pattern : Pattern) -> Maybe(Int) =
-    todo("not implemented")
+let index_of (pattern : Pattern) (str : String) : Maybe Int =
+    let (Pattern p) = pattern
+    string_index_of p str
 
 ## Find the last occurrence of a pattern in a string.
-## Returns the index of the first character of the last match, or None if not present.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ String.last_index_of("hello hello world", Pattern("hello"))
-## Some(6) : Maybe(Int)
+## ➢ String.last_index_of (Pattern "hello") "hello hello world"
+## Some 6 : Maybe Int
 ##
-## ➢ String.last_index_of("hello world", Pattern("moon"))
-## None : Maybe(Int)
+## ➢ String.last_index_of (Pattern "moon") "hello world"
+## None : Maybe Int
 ## ```
-let last_index_of(str : String, pattern : Pattern) -> Maybe(Int) =
-    todo("not implemented")
+let last_index_of (pattern : Pattern) (str : String) : Maybe Int =
+    let (Pattern p) = pattern
+    string_last_index_of p str
 
 ## Split a string using a given pattern.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ String.split_on("foo,bar", Pattern(","))
-## ["foo", "bar"] : List(String)
+## ➢ String.split_on (Pattern ",") "foo,bar"
+## ["foo", "bar"] : List String
 ## ```
-let split_on(str : String, pattern : Pattern) -> List(String) =
-    todo("not implemented")
+let split_on (pattern : Pattern) (str : String) : List String =
+    let (Pattern p) = pattern
+    string_split p str
 
 ## Split a string using a given pattern.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ String.split_at("foobar", 3)
+## ➢ String.split_at 3 "foobar"
 ## ("foo", "bar") : (String, String)
 ## ```
-let split_at(str : String, n : Int) -> (String, String) =
-    todo("not implemented")
+let split_at (n : Int) (str : String) : (String, String) =
+    todo "not implemented"
 
 ## Take a substring given a start and end index.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ String.slice("abcd", 1, 3)
+## ➢ String.slice 1 3 "abcd"
 ## "bc" : String
 ## ```
-let slice(str : String, start : Int, end : Int) -> String =
-    string_slice(str, start, end)
+let slice (start : Int) (end : Int) (str : String) : String =
+    string_slice start end str
 
 ## Convert a string to all lower case.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ String.to_lower("FOOBAR")
+## ➢ String.to_lower "FOOBAR"
 ## "foobar" : String
 ## ```
-let to_lower(str : String) -> String =
-    string_to_lower(str)
+let to_lower (str : String) : String =
+    string_to_lower str
 
 ## Convert a string to all upper case.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ String.to_upper("foobar")
+## ➢ String.to_upper "foobar"
 ## "FOOBAR" : String
 ## ```
-let to_upper(str : String) -> String =
-    string_to_upper(str)
+let to_upper (str : String) : String =
+    string_to_upper str
 
 ## Reverse a string.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ String.reverse("foobar")
+## ➢ String.reverse "foobar"
 ## "raboof" : String
 ## ```
-let reverse(str : String) -> String =
-    string_reverse(str)
+let reverse (str : String) : String =
+    string_reverse str
 
 ## Repeat a string *n* times.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ String.repeat("ha", 3)
+## ➢ String.repeat 3 "ha"
 ## "hahaha" : String
 ## ```
-let repeat(str : String, count : Int) -> String =
-    todo("not implemented")
+let repeat (n : Int) (str : String) : String =
+    string_repeat n str
 
 ## Test whether a string is empty.
-## Returns True if the string contains no characters.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ String.empty?("")
+## ➢ String.empty? ""
 ## True : Bool
 ##
-## ➢ String.empty?("hello")
+## ➢ String.empty? "hello"
 ## False : Bool
 ## ```
 let empty?(str : String) -> Bool =
-    todo("not implemented")
+    str == ""
 
-## Returns `True` if string ends with the given pattern.
+## Check if a string starts with a given prefix.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ String.ends_with?("abc", "c")
+## ➢ String.starts_with? "a" "abc"
 ## True : Bool
 ## ```
-let ends_with?(str : String, pattern : Pattern) =
-    string_ends_with(str, pattern)
+let starts_with? (prefix : String) (str : String) : Bool =
+    string_starts_with prefix str
 
-## Returns `True` if string starts with the given pattern.
+## Check if a string ends with a given suffix.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ String.starts_with?("abc", "a")
+## ➢ String.ends_with? "c" "abc"
 ## True : Bool
 ## ```
-let starts_with?(str : String, pattern : Pattern) -> Bool
-    string_starts_with(str, pattern)
+let ends_with? (suffix : String) (str : String) : Bool =
+    string_ends_with suffix str
 
 ## Replace all occurrences of some pattern.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ String.replace "foo-bar-baz" (Pattern "-") (Pattern "_")
+## ➢ String.replace (Pattern "-") (Pattern "_") "foo-bar-baz"
 ## "foo_bar_baz" : String
 ## ```
-let replace(str: String, pattern1 : String, pattern2 : String) -> String =
-    todo("not implemented")
+let replace (old : String) (new : String) (str : String) : String =
+    string_replace old new str
 
 ## Remove whitespace from both sides of a string.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ String.trim("  foo  ")
+## ➢ String.trim "  foo  "
 ## "foo" : String
 ## ```
-let trim(str : String) -> String =
-    todo("not implemented")
+let trim (str : String) : String =
+    string_trim str
 
 ## Remove whitespace from the left of a string.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ String.trim_left("  foo")
+## ➢ String.trim_left "  foo"
 ## "foo" : String
 ## ```
-let trim_left(str : String) -> String =
-    todo("not implemented")
+let trim_left (str : String) : String =
+    todo "not implemented"
 
 ## Remove whitespace from the right of a string.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ String.trim_right("foo  ")
+## ➢ String.trim_right "foo  "
 ## "foo" : String
 ## ```
-let trim_right(str : String) -> String =
-    todo("not implemented")
+let trim_right (str : String) : String =
+    todo "not implemented"
 
 ## Pad a string on both sides until it has a given length.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ String.pad("foobar", 10, '_')
+## ➢ String.pad 10 '_' "foobar"
 ## "__foobar__" : String
 ## ```
-let pad(str : String, n : Int, char : Char) -> String =
-    todo("not implemented")
+let pad (length : Int) (char : Char) (str : String) : String =
+    todo "not implemented"
 
 ## Pad a string from the left until it has a given length.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ String.pad_left("foo", 6, Pattern(" "))
+## ➢ String.pad_left 6 (Pattern " ") "foo"
 ## "   foo" : String
 ## ```
-let pad_left(str : String, count : Int, pattern : Pattern) -> String =
-    todo("not implemented")
+let pad_left (length : Int) (char : Char) (str : String) : String =
+    todo "not implemented"
 
 ## Pad a string from the right until it has a given length.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ String.pad_right("foo", 6, Pattern(" "))
+## ➢ String.pad_right 6 (Pattern " ") "foo"
 ## "foo   " : String
 ## ```
-let pad_right(str : String, count : Int, pattern : Pattern) -> String =
-    todo("not implemented")
+let pad_right (length : Int) (char : Char) (str : String) : String =
+    todo "not implemented"
 
-## Returns `True` if string starts with the given pattern.
+## Find all indexes of a pattern in a string.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ String.indexes_of("Mississippi", "i")
-## [1, 4, 7, 10] : List(Int)
+## ➢ String.indexes_of "ana" "banana"
+## [1, 3] : List Int
 ## ```
-let indexes_of(str: String, substr : String) -> List(Int) =
-    todo("not implemented")
+let indexes_of (pattern : Pattern) (str : String) : List Int =
+    todo "not implemented"
 
-## Convert a string to an integer.
-## Returns `Some(value)` if the string contains a valid integer, or `None` otherwise.
+## Convert a string to an integer, if possible.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ String.to_int("42")
-## Some(42) : Maybe(Int)
-##
-## ➢ String.to_int("not_a_number")
-## None : Maybe(Int)
+## ➢ String.to_int "42"
+## Some 42 : Maybe Int
 ## ```
-let to_int(str : String) -> Maybe(Int) =
-    todo("not implemented")
+let to_int (str : String) : Maybe Int =
+    todo "not implemented"
 
-## Convert a string to a floating-point number.
-## Returns `Some(value)` if the string contains a valid number, or `None` otherwise.
+## Convert a string to a floating-point number, if possible.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ String.to_float("3.14")
-## Some(3.14) : Maybe(Float)
-##
-## ➢ String.to_float("invalid")
-## None : Maybe(Float)
+## ➢ String.to_float "3.14"
+## Some 3.14 : Maybe Float
 ## ```
-let to_float(str : String) -> Maybe(Float) =
-    todo("not implemented")
+let to_float (str : String) : Maybe Float =
+    todo "not implemented"
 
-## Convert a single character to a string.
-## Returns a new string containing only the given character.
+## Convert a character to a string.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ String.from_char('a')
-## "a" : String
-##
-## ➢ String.from_char('🐱')
-## "🐱" : String
+## ➢ String.from_char 'A'
+## "A" : String
 ## ```
-let from_char(char : Char) -> String =
-    todo("not implemented")
+let from_char (char : Char) : String =
+    todo "not implemented"
 
-## Transform every character in a string using the provided function.
-## Returns a new string with each character replaced by the result of applying the function.
+## Apply a function to each character in a string, producing a new string.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ String.map("hello", fn(c) => if c == 'e' then 'a' else c)
-## "hallo" : String
+## ➢ String.map Char.to_upper "hello"
+## "HELLO" : String
 ## ```
-let map(str : String, f : (Char -> Char)) -> String =
-    todo("not implemented")
+let map (f : Char -> Char) (str : String) : String =
+    fold_left (fn acc c => acc <> from_char (f c)) "" str
 
 ## Keep only the characters that pass the predicate test.
-## Returns a new string containing just the characters for which the predicate returns `True`.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ String.keep("hello world", fn(c) => c != ' ')
+## ➢ String.keep (fn c => c != ' ') "hello world"
 ## "helloworld" : String
 ## ```
-let keep(str : String, predicate : (Char -> Bool)) -> String =
-    todo("not implemented")
+let keep (predicate : Char -> Bool) (str : String) : String =
+    fold_left (fn acc c => if predicate c then acc <> from_char c else acc) "" str
 
-## Remove all characters that pass the predicate test.
-## Returns a new string excluding the characters for which the predicate returns `True`.
+## Remove characters that match a predicate.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ String.reject("hello world", fn(c) => c == 'l')
+## ➢ String.reject (fn c => c == 'l') "hello world"
 ## "heo word" : String
 ## ```
-let reject(str : String, predicate : (Char -> Bool)) -> String =
-    todo("not implemented")
+let reject (predicate : Char -> Bool) (str : String) : String =
+    todo "not implemented"
 
-## Reduce a string from the left, accumulating a value by applying a function to each character.
-## The function takes the accumulated value and current character, returning a new accumulated value.
+## Fold over a string from left to right.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ String.fold_left("abc", 0, fn(acc, c) => acc + Char.to_code(c))
-## 294 : Int  # Sum of character codes for 'a', 'b', and 'c'
+## ➢ String.fold_left (fn acc c => acc + Char.to_int c) 0 "abc"
+## 294 : Int
 ## ```
-let fold_left(str : String, f : (Char, b -> b), init : b) -> b =
-    todo("not implemented")
+let fold_left (f : a -> Char -> a) (init : a) (str : String) : a =
+    todo "not implemented"
 
-## Reduce a string from the right, accumulating a value by applying a function to each character.
-## The function takes the current character and accumulated value, returning a new accumulated value.
+## Fold over a string from right to left.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ String.fold_right("abc", "", fn(c, acc) => String.append(acc, String.from_char(c)))
-## "cba" : String  # Characters in reverse order
+## ➢ String.fold_right (fn c acc => from_char c <> acc) "" "abc"
+## "cba" : String
 ## ```
-let fold_right(str : String, f : (Char, b -> b), init : b) -> b =
-    todo("not implemented")
+let fold_right (f : Char -> a -> a) (init : a) (str : String) : a =
+    todo "not implemented"
 
-## Determine whether any character in the string satisfies the predicate.
-## Returns `True` if at least one character passes the test.
+## Check if any character in a string matches a predicate.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ String.any?("hello", fn(c) => c == 'x')
-## False : Bool
-##
-## ➢ String.any?("hello", fn(c) => c == 'e')
-## True : Bool
+## ➢ String.any? (fn c => c == 'a') "hello"
+## false : Bool
 ## ```
-let any?(str : String, pred : (Char -> Bool)) -> Bool =
-    todo("not implemented")
+let any? (predicate : Char -> Bool) (str : String) : Bool =
+    fold_left (fn acc c => acc || predicate c) False str
 
-## Determine whether all characters in the string satisfy the predicate.
-## Returns `True` only if every character passes the test.
+## Check if all characters in a string match a predicate.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ String.all?("12345", fn(c) => Char.is_digit(c))
-## True : Bool
-##
-## ➢ String.all?("123a5", fn(c) => Char.is_digit(c))
-## False : Bool
+## ➢ String.all? (fn c => c == 'a') "aaaa"
+## true : Bool
 ## ```
-let all?(str : String, pred : (Char -> Bool)) -> Bool =
-    todo("not implemented")
+let all? (predicate : Char -> Bool) (str : String) : Bool =
+    fold_left (fn acc c => acc && predicate c) True str
 
-## Get character at the given position.
-## Returns `Some(char)` if position is valid, or `None` if out of bounds.
+## Get the character at a given index in a string.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ String.at("hello", 1)
-## Some('e') : Maybe(Char)
-##
-## ➢ String.at("hello", 10)
-## None : Maybe(Char)
+## ➢ String.at 1 "hello"
+## Some 'e' : Maybe Char
 ## ```
-let at(str : String, position : Int) -> Maybe(Char) =
-    string_at(str, position)
+let at (index : Int) (str : String) : Maybe Char =
+    string_at index str
 
-## Determines if a string exactly matches the given pattern.
-## Returns `True` only for a complete match.
+## Check if a string matches a given pattern.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ String.match?("hello", Pattern("hello"))
-## True : Bool
-##
-## ➢ String.match?("hello world", Pattern("hello"))
-## False : Bool
+## ➢ String.match? "[0-9]+" "123"
+## true : Bool
 ## ```
-let match?(str : String, pattern : Pattern) -> Bool =
-    todo("not implemented")
+let match? (pattern : Pattern) (str : String) : Bool =
+    todo "not implemented"
 
-foreign string_size(_ : String) -> Int =
+foreign string_size : String -> Int =
     "zig_string_size"
 
-foreign string_append(_ : String, _ : String) -> String =
+foreign string_append : String -> String -> String =
     "zig_string_append"
 
-foreign string_concat(_ : List(String)) -> String =
+foreign string_concat : String -> String -> String =
     "zig_string_concat"
 
-foreign string_slice(_ : String, _ : Int, _ : Int) -> String =
-    "zig_string_slice"
+foreign string_join : String -> List String -> String =
+    "zig_string_concat"
 
-foreign string_to_lower(_ : String) -> String =
-    "zig_string_to_lower"
+foreign string_substr : String -> Int -> Int -> String =
+    "zig_string_substr"
 
-foreign string_to_upper(_ : String) -> String =
+foreign string_index_of : String -> String -> Maybe Int =
+    "zig_string_index_of"
+
+foreign string_last_index_of : String -> String -> Maybe Int =
+    "zig_string_last_index_of"
+
+foreign string_split : String -> String -> List String =
+    "zig_string_split"
+
+foreign string_to_upper : String -> String =
     "zig_string_to_upper"
 
-foreign string_at(_ : String, _ : Int) -> Int =
-    "zig_string_at"
+foreign string_to_lower : String -> String =
+    "zig_string_to_lower"
 
-foreign string_empty(_ : String) -> Bool =
-    "zig_string_empty"
-
-foreign string_reverse(_ : String) -> String =
+foreign string_reverse : String -> String =
     "zig_string_reverse"
 
-foreign string_starts_with(_ : String, _ : String) -> Bool =
+foreign string_repeat : Int -> String -> String =
+    "zig_string_repeat"
+
+foreign string_starts_with : String -> String -> Bool =
     "zig_string_starts_with"
 
-foreign string_ends_with(_ : String, _ : String) -> Bool =
+foreign string_ends_with : String -> String -> Bool =
     "zig_string_ends_with"
+
+foreign string_replace : String -> String -> String -> String =
+    "zig_string_replace"
+
+foreign string_trim : String -> String =
+    "zig_string_trim"

--- a/stdlib/tree_map.mn
+++ b/stdlib/tree_map.mn
@@ -1,3 +1,5 @@
+## A map from keys to values, based on a balanced binary tree.
+## Keys must be comparable.
 module TreeMap exposing
     ( TreeMap
     , empty
@@ -22,63 +24,58 @@ module TreeMap exposing
     , partition
     )
 
-## A map from keys to values, based on a balanced binary tree.
-## Keys must be comparable.
-##
-## @since 0.1.0
-type TreeMap(k, v) =
-    TreeMap(k, v)
+type TreeMap k v =
+    TreeMap
 
 ## Create an empty tree map.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ TreeMap.empty()
-## {} : TreeMap(k, v)
+## ➢ TreeMap.empty
+## {} : TreeMap k v
 ## ```
-let empty() -> TreeMap(k, v) =
-    tree_map_empty()
+let empty : TreeMap k v =
+    tree_map_empty
 
 ## Determine if a tree map is empty.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ TreeMap.empty?(TreeMap.empty())
+## ➢ TreeMap.empty? TreeMap.empty
 ## True : Bool
 ##
-## ➢ TreeMap.empty?(TreeMap.singleton(1, "one"))
+## ➢ TreeMap.empty? (TreeMap.singleton 1 "one")
 ## False : Bool
 ## ```
-let empty?(map : TreeMap(k, v)) -> Bool =
-    tree_map_is_empty(map)
+let empty? (map : TreeMap k v) : Bool =
+    tree_map_is_empty map
 
 ## Create a tree map with a single key-value pair.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ TreeMap.singleton(1, "one")
-## {1: "one"} : TreeMap(Int, String)
+## ➢ TreeMap.singleton 1 "one"
+## {1: "one"} : TreeMap Int String
 ## ```
-let singleton(key : comparable, value : v) -> TreeMap(comparable, v) =
-    tree_map_singleton(key, value)
+let singleton (key : comparable) (value : v) : TreeMap comparable v =
+    tree_map_singleton key value
 
 ## Get the value associated with a key.
-## Returns `None` if the key is not found.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ TreeMap.get(TreeMap.singleton(1, "one"), 1)
-## Some("one") : Maybe(String)
+## ➢ TreeMap.get 1 (TreeMap.singleton 1 "one")
+## Some "one" : Maybe String
 ##
-## ➢ TreeMap.get(TreeMap.singleton(1, "one"), 2)
-## None : Maybe(String)
+## ➢ TreeMap.get 2 (TreeMap.singleton 1 "one")
+## None : Maybe String
 ## ```
-let get(map : TreeMap(comparable, v), key : comparable) -> Maybe(v) =
-    tree_map_get(map, key)
+let get (key : comparable) (map : TreeMap comparable v) : Maybe v =
+    tree_map_get key map
 
 ## Insert a key-value pair into a tree map.
 ## If the key already exists, the value is updated.
@@ -86,14 +83,14 @@ let get(map : TreeMap(comparable, v), key : comparable) -> Maybe(v) =
 ## @since 0.1.0
 ##
 ## ```
-## ➢ TreeMap.insert(TreeMap.singleton(1, "one"), 2, "two")
-## {1: "one", 2: "two"} : TreeMap(Int, String)
+## ➢ TreeMap.insert 2 "two" (TreeMap.singleton 1 "one")
+## {1: "one", 2: "two"} : TreeMap Int String
 ##
-## ➢ TreeMap.insert(TreeMap.singleton(1, "one"), 1, "ONE")
-## {1: "ONE"} : TreeMap(Int, String)
+## ➢ TreeMap.insert 1 "ONE" (TreeMap.singleton 1 "one")
+## {1: "ONE"} : TreeMap Int String
 ## ```
-let insert(map : TreeMap(comparable, v), key : comparable, value : v) -> TreeMap(comparable, v) =
-    tree_map_insert(map, key, value)
+let insert (key : comparable) (value : v) (map : TreeMap comparable v) : TreeMap comparable v =
+    tree_map_insert key value map
 
 ## Remove a key-value pair from a tree map.
 ## If the key is not found, no changes are made.
@@ -101,33 +98,33 @@ let insert(map : TreeMap(comparable, v), key : comparable, value : v) -> TreeMap
 ## @since 0.1.0
 ##
 ## ```
-## ➢ TreeMap.remove(TreeMap.from_list([(1, "one"), (2, "two")]), 1)
-## {2: "two"} : TreeMap(Int, String)
+## ➢ TreeMap.remove 1 (TreeMap.from_list [(1, "one"), (2, "two")])
+## {2: "two"} : TreeMap Int String
 ## ```
-let remove(map : TreeMap(comparable, v), key : comparable) -> TreeMap(comparable, v) =
-    tree_map_remove(map, key)
+let remove (key : comparable) (map : TreeMap comparable v) : TreeMap comparable v =
+    tree_map_remove key map
 
 ## Determine the number of key-value pairs in a tree map.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ TreeMap.size(TreeMap.from_list([(1, "one"), (2, "two")]))
+## ➢ TreeMap.size (TreeMap.from_list [(1, "one"), (2, "two")])
 ## 2 : Int
 ## ```
-let size(map : TreeMap(k, v)) -> Int =
-    tree_map_size(map)
+let size (map : TreeMap k v) : Int =
+    tree_map_size map
 
 ## Convert a tree map into a list of key-value pairs, sorted by key.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ TreeMap.to_list(TreeMap.from_list([(2, "two"), (1, "one")]))
-## [(1, "one"), (2, "two")] : List((Int, String))
+## ➢ TreeMap.to_list (TreeMap.from_list [(2, "two"), (1, "one")])
+## [(1, "one"), (2, "two")] : List (Int, String)
 ## ```
-let to_list(map : TreeMap(k, v)) -> List((k, v)) =
-    tree_map_to_list(map)
+let to_list (map : TreeMap k v) : List (k, v) =
+    tree_map_to_list map
 
 ## Convert a list of key-value pairs into a tree map.
 ## If there are duplicate keys, later values overwrite earlier ones.
@@ -135,44 +132,45 @@ let to_list(map : TreeMap(k, v)) -> List((k, v)) =
 ## @since 0.1.0
 ##
 ## ```
-## ➢ TreeMap.from_list([(1, "one"), (2, "two"), (1, "ONE")])
-## {1: "ONE", 2: "two"} : TreeMap(Int, String)
+## ➢ TreeMap.from_list [(1, "one"), (2, "two"), (1, "ONE")]
+## {1: "ONE", 2: "two"} : TreeMap Int String
 ## ```
-let from_list(list : List((comparable, v))) -> TreeMap(comparable, v) =
-    tree_map_from_list(list)
+let from_list (list : List (comparable, v)) : TreeMap comparable v =
+    tree_map_from_list list
 
 ## Get a list of all keys in a tree map, sorted.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ TreeMap.keys(TreeMap.from_list([(1, "one"), (2, "two")]))
-## [1, 2] : List(Int)
+## ➢ TreeMap.keys (TreeMap.from_list [(1, "one"), (2, "two")])
+## [1, 2] : List Int
 ## ```
-let keys(map : TreeMap(k, v)) -> List(k) =
-    tree_map_keys(map)
+let keys (map : TreeMap k v) : List k =
+    tree_map_keys map
+
 
 ## Get a list of all values in a tree map, in key order.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ TreeMap.values(TreeMap.from_list([(1, "one"), (2, "two")]))
-## ["one", "two"] : List(String)
+## ➢ TreeMap.values (TreeMap.from_list [(1, "one"), (2, "two")])
+## ["one", "two"] : List String
 ## ```
-let values(map : TreeMap(k, v)) -> List(v) =
-    tree_map_values(map)
+let values (map : TreeMap k v) : List v =
+    tree_map_values map
 
 ## Combine two tree maps, favoring values from the second map when keys overlap.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ TreeMap.union(TreeMap.from_list([(1, "one"), (2, "two")]), TreeMap.from_list([(2, "TWO"), (3, "three")]))
-## {1: "one", 2: "TWO", 3: "three"} : TreeMap(Int, String)
+## ➢ TreeMap.union (TreeMap.from_list [(1, "one"), (2, "two")]) (TreeMap.from_list [(2, "TWO"), (3, "three")])
+## {1: "one", 2: "TWO", 3: "three"} : TreeMap Int String
 ## ```
-let union(map1 : TreeMap(comparable, v), map2 : TreeMap(comparable, v)) -> TreeMap(comparable, v) =
-    tree_map_union(map1, map2)
+let union (map1 : TreeMap comparable v) (map2 : TreeMap comparable v) : TreeMap comparable v =
+    tree_map_union map1 map2
 
 ## Keep only key-value pairs where the key exists in both maps.
 ## Values are taken from the first map.
@@ -180,77 +178,77 @@ let union(map1 : TreeMap(comparable, v), map2 : TreeMap(comparable, v)) -> TreeM
 ## @since 0.1.0
 ##
 ## ```
-## ➢ TreeMap.intersect(TreeMap.from_list([(1, "one"), (2, "two")]), TreeMap.from_list([(2, "TWO"), (3, "three")]))
-## {2: "two"} : TreeMap(Int, String)
+## ➢ TreeMap.intersect (TreeMap.from_list [(1, "one"), (2, "two")]) (TreeMap.from_list [(2, "TWO"), (3, "three")])
+## {2: "two"} : TreeMap Int String
 ## ```
-let intersect(map1 : TreeMap(comparable, v), map2 : TreeMap(comparable, v)) -> TreeMap(comparable, v) =
-    tree_map_intersect(map1, map2)
+let intersect (map1 : TreeMap comparable v) (map2 : TreeMap comparable v) : TreeMap comparable v =
+    tree_map_intersect map1 map2
 
 ## Keep only key-value pairs where the key exists in the first map but not the second.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ TreeMap.diff(TreeMap.from_list([(1, "one"), (2, "two")]), TreeMap.from_list([(2, "TWO"), (3, "three")]))
-## {1: "one"} : TreeMap(Int, String)
+## ➢ TreeMap.diff (TreeMap.from_list [(1, "one"), (2, "two")]) (TreeMap.from_list [(2, "TWO"), (3, "three")])
+## {1: "one"} : TreeMap Int String
 ## ```
-let diff(map1 : TreeMap(comparable, v), map2 : TreeMap(comparable, v)) -> TreeMap(comparable, v) =
-    tree_map_diff(map1, map2)
+let diff (map1 : TreeMap comparable v) (map2 : TreeMap comparable v) : TreeMap comparable v =
+    tree_map_diff map1 map2
 
 ## Fold over the key-value pairs in a tree map, in key order from lowest to highest.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ TreeMap.fold_left(TreeMap.from_list([(1, "one"), (2, "two")]), fn(k, v, acc) => acc ++ v, "")
+## ➢ TreeMap.fold_left (fn k v acc => acc ++ v) "" (TreeMap.from_list [(1, "one"), (2, "two")])
 ## "onetwo" : String
 ## ```
-let fold_left(map : TreeMap(k, v), f : (k, v, acc -> acc), init : acc) -> acc =
-    tree_map_fold_left(map, f, init)
+let fold_left (f : k -> v -> acc -> acc) (init : acc) (map : TreeMap k v) : acc =
+    tree_map_fold_left f init map
 
 ## Fold over the key-value pairs in a tree map, in key order from highest to lowest.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ TreeMap.fold_right(TreeMap.from_list([(1, "one"), (2, "two")]), fn(k, v, acc) => acc ++ v, "")
+## ➢ TreeMap.fold_right (fn k v acc => acc ++ v) "" (TreeMap.from_list [(1, "one"), (2, "two")])
 ## "twoone" : String
 ## ```
-let fold_right(map : TreeMap(k, v), f : (k, v, acc -> acc), init : acc) -> acc =
-    tree_map_fold_right(map, f, init)
+let fold_right (f : k -> v -> acc -> acc) (init : acc) (map : TreeMap k v) : acc =
+    tree_map_fold_right f init map
 
 ## Transform values in a tree map.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ TreeMap.map(TreeMap.from_list([(1, "one"), (2, "two")]), fn(k, v) => String.to_upper(v))
-## {1: "ONE", 2: "TWO"} : TreeMap(Int, String)
+## ➢ TreeMap.map (fn k v => String.to_upper v) (TreeMap.from_list [(1, "one"), (2, "two")])
+## {1: "ONE", 2: "TWO"} : TreeMap Int String
 ## ```
-let map(map : TreeMap(k, v), f : (k, v -> v2)) -> TreeMap(k, v2) =
-    tree_map_map(map, f)
+let map (f : k -> v -> v2) (map : TreeMap k v) : TreeMap k v2 =
+    tree_map_map f map
 
 ## Keep only key-value pairs that satisfy the given predicate.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ TreeMap.keep(TreeMap.from_list([(1, "one"), (2, "two")]), fn(k, v) => k % 2 == 0)
-## {2: "two"} : TreeMap(Int, String)
+## ➢ TreeMap.keep (fn k v => mod k 2 == 0) (TreeMap.from_list [(1, "one"), (2, "two")])
+## {2: "two"} : TreeMap Int String
 ## ```
-let keep(map : TreeMap(comparable, v), pred : (comparable, v -> Bool)) -> TreeMap(comparable, v) =
-    tree_map_keep(map, pred)
+let keep (pred : comparable -> v -> Bool) (map : TreeMap comparable v) : TreeMap comparable v =
+    tree_map_keep map pred
 
 ## Remove key-value pairs that satisfy the given predicate.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ TreeMap.reject(TreeMap.from_list([(1, "one"), (2, "two")]), fn(k, v) => k % 2 == 0)
-## {1: "one"} : TreeMap(Int, String)
+## ➢ TreeMap.reject (fn k v => mod k 2 == 0) (TreeMap.from_list [(1, "one"), (2, "two")])
+## {1: "one"} : TreeMap Int String
 ## ```
-let reject(map : TreeMap(comparable, v), pred : (comparable, v -> Bool)) -> TreeMap(comparable, v) =
-    tree_map_reject(map, pred)
+let reject (pred : comparable -> v -> Bool) (map : TreeMap comparable v) : TreeMap comparable v =
+    tree_map_reject pred map
 
 ## Create two new maps. The first contains all key-value pairs that passed the
 ## given test, and the second contains all key-value pairs that did not.
@@ -258,68 +256,68 @@ let reject(map : TreeMap(comparable, v), pred : (comparable, v -> Bool)) -> Tree
 ## @since 0.1.0
 ##
 ## ```
-## ➢ TreeMap.partition(TreeMap.from_list([(1, "one"), (2, "two")]), fn(k, v) => k % 2 == 0)
-## ({2: "two"}, {1: "one"}) : (TreeMap(Int, String), TreeMap(Int, String))
+## ➢ TreeMap.partition (fn k v => mod k 2 == 0) (TreeMap.from_list [(1, "one"), (2, "two")])
+## ({2: "two"}, {1: "one"}) : (TreeMap Int String, TreeMap Int String)
 ## ```
-let partition(map : TreeMap(comparable, v), pred : (comparable, v -> Bool)) -> (TreeMap(comparable, v), TreeMap(comparable, v)) =
-    tree_map_partition(map, pred)
+let partition (pred : comparable -> v -> Bool) (map : TreeMap comparable v) : (TreeMap comparable v, TreeMap comparable v) =
+    tree_map_partition pred map
 
-foreign tree_map_empty() -> TreeMap(k, v) =
+foreign tree_map_empty : TreeMap k v =
     "zig_tree_map_empty"
 
-foreign tree_map_is_empty(_ : TreeMap(k, v)) -> Bool =
+foreign tree_map_is_empty : TreeMap k v -> Bool =
     "zig_tree_map_is_empty"
 
-foreign tree_map_singleton(_ : comparable, _ : v) -> TreeMap(comparable, v) =
+foreign tree_map_singleton : comparable -> v -> TreeMap comparable v =
     "zig_tree_map_singleton"
 
-foreign tree_map_get(_ : TreeMap(comparable, v), _ : comparable) -> Maybe(v) =
+foreign tree_map_get : TreeMap comparable v -> comparable -> Maybe v =
     "zig_tree_map_get"
 
-foreign tree_map_insert(_ : TreeMap(comparable, v), _ : comparable, _ : v) -> TreeMap(comparable, v) =
+foreign tree_map_insert : TreeMap comparable v -> comparable -> v -> TreeMap comparable v =
     "zig_tree_map_insert"
 
-foreign tree_map_remove(_ : TreeMap(comparable, v), _ : comparable) -> TreeMap(comparable, v) =
+foreign tree_map_remove : TreeMap comparable v -> comparable -> TreeMap comparable v =
     "zig_tree_map_remove"
 
-foreign tree_map_size(_ : TreeMap(k, v)) -> Int =
+foreign tree_map_size : TreeMap k v -> Int =
     "zig_tree_map_size"
 
-foreign tree_map_to_list(_ : TreeMap(k, v)) -> List((k, v)) =
+foreign tree_map_to_list : TreeMap k v -> List (k, v) =
     "zig_tree_map_to_list"
 
-foreign tree_map_from_list(_ : List((comparable, v))) -> TreeMap(comparable, v) =
+foreign tree_map_from_list : List (comparable, v) -> TreeMap comparable v =
     "zig_tree_map_from_list"
 
-foreign tree_map_keys(_ : TreeMap(k, v)) -> List(k) =
+foreign tree_map_keys : TreeMap k v -> List k =
     "zig_tree_map_keys"
 
-foreign tree_map_values(_ : TreeMap(k, v)) -> List(v) =
+foreign tree_map_values : TreeMap k v -> List v =
     "zig_tree_map_values"
 
-foreign tree_map_union(_ : TreeMap(comparable, v), _ : TreeMap(comparable, v)) -> TreeMap(comparable, v) =
+foreign tree_map_union : TreeMap comparable v -> TreeMap comparable v -> TreeMap comparable v =
     "zig_tree_map_union"
 
-foreign tree_map_intersect(_ : TreeMap(comparable, v), _ : TreeMap(comparable, v)) -> TreeMap(comparable, v) =
+foreign tree_map_intersect : TreeMap comparable v -> TreeMap comparable v -> TreeMap comparable v =
     "zig_tree_map_intersect"
 
-foreign tree_map_diff(_ : TreeMap(comparable, v), _ : TreeMap(comparable, v)) -> TreeMap(comparable, v) =
+foreign tree_map_diff : TreeMap comparable v -> TreeMap comparable v -> TreeMap comparable v =
     "zig_tree_map_diff"
 
-foreign tree_map_fold_left(_ : TreeMap(k, v), _ : (k, v, acc -> acc), _ : acc) -> acc =
+foreign tree_map_fold_left : TreeMap k v -> (k -> v -> acc -> acc) -> acc -> acc =
     "zig_tree_map_fold_left"
 
-foreign tree_map_fold_right(_ : TreeMap(k, v), _ : (k, v, acc -> acc), _ : acc) -> acc =
+foreign tree_map_fold_right : TreeMap k v -> (k -> v -> acc -> acc) -> acc -> acc =
     "zig_tree_map_fold_right"
 
-foreign tree_map_map(_ : TreeMap(k, v), _ : (k, v -> v2)) -> TreeMap(k, v2) =
+foreign tree_map_map : TreeMap k v -> (k -> v -> v2) -> TreeMap k v2 =
     "zig_tree_map_map"
 
-foreign tree_map_keep(_ : TreeMap(comparable, v), _ : (comparable, v -> Bool)) -> TreeMap(comparable, v) =
+foreign tree_map_keep : TreeMap comparable v -> (comparable -> v -> Bool) -> TreeMap comparable v =
     "zig_tree_map_keep"
 
-foreign tree_map_reject(_ : TreeMap(comparable, v), _ : (comparable, v -> Bool)) -> TreeMap(comparable, v) =
+foreign tree_map_reject : TreeMap comparable v -> (comparable -> v -> Bool) -> TreeMap comparable v =
     "zig_tree_map_reject"
 
-foreign tree_map_partition(_ : TreeMap(comparable, v), _ : (comparable, v -> Bool)) -> (TreeMap(comparable, v), TreeMap(comparable, v)) =
+foreign tree_map_partition : TreeMap comparable v -> (comparable -> v -> Bool) -> (TreeMap comparable v, TreeMap comparable v) =
     "zig_tree_map_partition"

--- a/stdlib/tuple.mn
+++ b/stdlib/tuple.mn
@@ -12,10 +12,10 @@ module Tuple exposing
 ## @since 0.1.0
 ##
 ## ```
-## ➢ Tuple.pair(1, "a")
+## ➢ Tuple.pair 1 "a"
 ## (1, "a") : (Int, String)
 ## ```
-let pair(x : a, y : b) -> (a, b) =
+let pair (x : a) (y : b) : (a, b) =
     (x, y)
 
 ## Gets the first value from a tuple.
@@ -23,10 +23,10 @@ let pair(x : a, y : b) -> (a, b) =
 ## @since 0.1.0
 ##
 ## ```
-## ➢ Tuple.fst((1, "a"))
+## ➢ Tuple.fst (1, "a")
 ## 1 : Int
 ## ```
-let fst(x : a, _ : b) -> a =
+let fst (x : a) (_ : b) : a =
     x
 
 ## Gets the second value from a tuple.
@@ -34,10 +34,10 @@ let fst(x : a, _ : b) -> a =
 ## @since 0.1.0
 ##
 ## ```
-## ➢ Tuple.snd((1, "a"))
+## ➢ Tuple.snd (1, "a")
 ## "a" : String
 ## ```
-let snd(_ : a, y: b) -> b =
+let snd (_ : a) (y : b) : b =
     y
 
 ## Applies functions to both elements of a tuple.
@@ -45,33 +45,33 @@ let snd(_ : a, y: b) -> b =
 ## @since 0.1.0
 ##
 ## ```
-## ➢ Tuple.map_both((1, "a"), String.from_int, String.to_upper)
+## ➢ Tuple.map_both String.from_int String.to_upper (1, "a")
 ## ("1", "A") : (String, String)
 ## ```
-let map_both(pair : (a, b), f : (a -> x), g : (b -> y)) -> (x, y) =
+let map_both (f : a -> x) (g : b -> y) (pair : (a, b)) : (x, y) =
     match pair on
-    | (x, y) => (f(x), g(y))
+    | (x, y) => (f x, g y)
 
 ## Applies a function to the first element of a tuple.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ Tuple.map_first((1, "a"), String.from_int)
+## ➢ Tuple.map_first String.from_int (1, "a")
 ## ("1", "a") : (String, String)
 ## ```
-let map_first(pair : (a, b), f : (a -> x)) -> (x, b) =
+let map_first (f : a -> x) (pair : (a, b)) : (x, b) =
     match pair on
-    | (x, y) => (f(x), y)
+    | (x, y) => (f x, y)
 
 ## Applies a function to the second element of a tuple.
 ##
 ## @since 0.1.0
 ##
 ## ```
-## ➢ Tuple.map_second((1, "a"), String.to_upper)
+## ➢ Tuple.map_second String.to_upper (1, "a")
 ## (1, "A") : (Int, String)
 ## ```
-let map_second(pair : (a, b), f : (b -> y)) -> (a, y) =
+let map_second (f : b -> y) (pair : (a, b)) : (a, y) =
     match pair on
-    | (x, y) => (x, f(y))
+    | (x, y) => (x, f y)

--- a/stdlib/unit.mn
+++ b/stdlib/unit.mn
@@ -8,8 +8,8 @@ type Unit =
 ## @since 0.1.0
 ##
 ## ```
-## ➢ ignore(42)
+## ➢ ignore 42
 ## Unit : Unit
 ## ```
-let ignore(_ : a) -> Unit =
+let ignore (_ : a) : Unit =
     Unit

--- a/stdlib/validation.mn
+++ b/stdlib/validation.mn
@@ -1,5 +1,5 @@
 module Validation exposing (Validation(..))
 
 ## Result type that accumulates errors
-type Validation(e, a) =
-    Validation(e, a)
+type Validation e a =
+    Validation e a


### PR DESCRIPTION
## Old

I've decided to revert back to curried functions but use the Ocaml like fn decl w/ types syntax to solve 2 problems: 
1) func types being treated as tuples 
```
let map2(
    ma : Maybe(a),
    mb : Maybe(b)
    f : ((a, b) -> value), <- here
) -> Maybe(value) = ...
```

2) FFI with unused params (awkward). Would have required a linter rule to ignore unused params.
```
foreign bitwise_and(_ : Int, _ : Int) -> Int =
    "zig_bitwise_and"
```

3) Parens everywhere has always been and will always be painful 😂

## New

```
let satisfy? (ma : Maybe a) (predicate : a -> Bool) : Bool =
    match ma on
    | None => False
    | Some a => predicate a
    
foreign bitwise_and : Int -> Int -> Int =
    "zig_bitwise_and"
```

Solves both problems but adds a little more complexity to the parser (acceptable). 
